### PR TITLE
Parametrize Manager/Subordinate-only chimneys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## Unreleased
 
+### Added
+
+- Added Chimney Parameters `EnMgrPort` and `EnSbrPort` to properly parametrize Manager resp. Subordinate-only instances of a chimney
+
 ## [0.2.1] - 2023-10-13
 
 ### Changed

--- a/src/floo_axi_chimney.sv
+++ b/src/floo_axi_chimney.sv
@@ -531,8 +531,10 @@ module floo_axi_chimney
   assign axi_valid_in[AxiAw] = floo_req_in_valid && (unpack_req_generic.hdr.axi_ch == AxiAw);
   assign axi_valid_in[AxiW]  = floo_req_in_valid && (unpack_req_generic.hdr.axi_ch == AxiW);
   assign axi_valid_in[AxiAr] = floo_req_in_valid && (unpack_req_generic.hdr.axi_ch == AxiAr);
-  assign axi_valid_in[AxiB]  = EnSbrPort && floo_rsp_in_valid && (unpack_rsp_generic.hdr.axi_ch == AxiB);
-  assign axi_valid_in[AxiR]  = EnSbrPort && floo_rsp_in_valid && (unpack_rsp_generic.hdr.axi_ch == AxiR);
+  assign axi_valid_in[AxiB]  = EnSbrPort && floo_rsp_in_valid &&
+                               (unpack_rsp_generic.hdr.axi_ch == AxiB);
+  assign axi_valid_in[AxiR]  = EnSbrPort && floo_rsp_in_valid &&
+                               (unpack_rsp_generic.hdr.axi_ch == AxiR);
 
   assign axi_ready_out[AxiAw] = axi_meta_buf_rsp_out.aw_ready;
   assign axi_ready_out[AxiW]  = axi_meta_buf_rsp_out.w_ready;
@@ -645,11 +647,16 @@ module floo_axi_chimney
   `ASSERT_INIT(NoSbrPortRobType, EnSbrPort || (RoBType == NoRoB))
 
   // Network Interface cannot accept any B and R responses if `EnSbrPort` is not set
-  `ASSERT(NoSbrPortBResponse, EnSbrPort || !(floo_rsp_in_valid && (unpack_rsp_generic.hdr.axi_ch == AxiB)))
-  `ASSERT(NoSbrPortRResponse, EnSbrPort || !(floo_rsp_in_valid && (unpack_rsp_generic.hdr.axi_ch == AxiR)))
+  `ASSERT(NoSbrPortBResponse, EnSbrPort || !(floo_rsp_in_valid &&
+                                             (unpack_rsp_generic.hdr.axi_ch == AxiB)))
+  `ASSERT(NoSbrPortRResponse, EnSbrPort || !(floo_rsp_in_valid &&
+                                             (unpack_rsp_generic.hdr.axi_ch == AxiR)))
   // Network Interface cannot accept any AW, AR and W requests if `EnMgrPort` is not set
-  `ASSERT(NoMgrPortAwRequest, EnMgrPort || !(floo_req_in_valid && (unpack_req_generic.hdr.axi_ch == AxiAw)))
-  `ASSERT(NoMgrPortArRequest, EnMgrPort || !(floo_req_in_valid && (unpack_req_generic.hdr.axi_ch == AxiAr)))
-  `ASSERT(NoMgrPortWRequest,  EnMgrPort || !(floo_req_in_valid && (unpack_req_generic.hdr.axi_ch == AxiW)))
+  `ASSERT(NoMgrPortAwRequest, EnMgrPort || !(floo_req_in_valid &&
+                                             (unpack_req_generic.hdr.axi_ch == AxiAw)))
+  `ASSERT(NoMgrPortArRequest, EnMgrPort || !(floo_req_in_valid &&
+                                             (unpack_req_generic.hdr.axi_ch == AxiAr)))
+  `ASSERT(NoMgrPortWRequest,  EnMgrPort || !(floo_req_in_valid &&
+                                             (unpack_req_generic.hdr.axi_ch == AxiW)))
 
 endmodule

--- a/src/floo_axi_chimney.sv
+++ b/src/floo_axi_chimney.sv
@@ -155,7 +155,7 @@ module floo_axi_chimney
         .rst_ni,
         .data_i     ( axi_in_req_i.aw         ),
         .valid_i    ( axi_in_req_i.aw_valid   ),
-        .ready_o    ( axi_in_rsp_o.aw_ready   ),
+        .ready_o    ( axi_rsp_out.aw_ready    ),
         .data_o     ( axi_aw_queue            ),
         .valid_o    ( axi_aw_queue_valid_out  ),
         .ready_i    ( axi_aw_queue_ready_in   )
@@ -168,7 +168,7 @@ module floo_axi_chimney
         .rst_ni,
         .data_i     ( axi_in_req_i.ar         ),
         .valid_i    ( axi_in_req_i.ar_valid   ),
-        .ready_o    ( axi_in_rsp_o.ar_ready   ),
+        .ready_o    ( axi_rsp_out.ar_ready    ),
         .data_o     ( axi_ar_queue            ),
         .valid_o    ( axi_ar_queue_valid_out  ),
         .ready_i    ( axi_ar_queue_ready_in   )

--- a/src/floo_narrow_wide_chimney.sv
+++ b/src/floo_narrow_wide_chimney.sv
@@ -1175,16 +1175,26 @@ module floo_narrow_wide_chimney
                            !floo_wide_o.ready |=> floo_wide_i.valid)
 
   // Network Interface cannot accept any B and R responses if `En*SbrPort` are not set
-  `ASSERT(NoNarrowSbrPortBResponse, EnNarrowSbrPort || !(floo_rsp_in_valid && (floo_rsp_unpack_generic.hdr.axi_ch == NarrowB)))
-  `ASSERT(NoNarrowSbrPortRResponse, EnNarrowSbrPort || !(floo_rsp_in_valid && (floo_rsp_unpack_generic.hdr.axi_ch == NarrowR)))
-  `ASSERT(NoWideSbrPortBResponse, EnWideSbrPort || !(floo_rsp_in_valid && (floo_rsp_unpack_generic.hdr.axi_ch == WideB)))
-  `ASSERT(NoWideSbrPortRResponse, EnWideSbrPort || !(floo_wide_in_valid && (floo_wide_unpack_generic.hdr.axi_ch == WideR)))
+  `ASSERT(NoNarrowSbrPortBResponse, EnNarrowSbrPort || !(floo_rsp_in_valid &&
+                           (floo_rsp_unpack_generic.hdr.axi_ch == NarrowB)))
+  `ASSERT(NoNarrowSbrPortRResponse, EnNarrowSbrPort || !(floo_rsp_in_valid &&
+                           (floo_rsp_unpack_generic.hdr.axi_ch == NarrowR)))
+  `ASSERT(NoWideSbrPortBResponse, EnWideSbrPort || !(floo_rsp_in_valid &&
+                           (floo_rsp_unpack_generic.hdr.axi_ch == WideB)))
+  `ASSERT(NoWideSbrPortRResponse, EnWideSbrPort || !(floo_wide_in_valid &&
+                           (floo_wide_unpack_generic.hdr.axi_ch == WideR)))
   // Network Interface cannot accept any AW, AR and W requests if `En*MgrPort` is not set
-  `ASSERT(NoNarrowMgrPortAwRequest, EnNarrowMgrPort || !(floo_req_in_valid && (floo_req_unpack_generic.hdr.axi_ch == NarrowAw)))
-  `ASSERT(NoNarrowMgrPortArRequest, EnNarrowMgrPort || !(floo_req_in_valid && (floo_req_unpack_generic.hdr.axi_ch == NarrowAr)))
-  `ASSERT(NoNarrowMgrPortWRequest,  EnNarrowMgrPort || !(floo_req_in_valid && (floo_req_unpack_generic.hdr.axi_ch == NarrowW)))
-  `ASSERT(NoWideMgrPortAwRequest, EnWideMgrPort || !(floo_req_in_valid && (floo_req_unpack_generic.hdr.axi_ch == WideAw)))
-  `ASSERT(NoWideMgrPortArRequest, EnWideMgrPort || !(floo_req_in_valid && (floo_req_unpack_generic.hdr.axi_ch == WideAr)))
-  `ASSERT(NoWideMgrPortWRequest,  EnWideMgrPort || !(floo_wide_in_valid && (floo_wide_unpack_generic.hdr.axi_ch == WideW)))
+  `ASSERT(NoNarrowMgrPortAwRequest, EnNarrowMgrPort || !(floo_req_in_valid &&
+                           (floo_req_unpack_generic.hdr.axi_ch == NarrowAw)))
+  `ASSERT(NoNarrowMgrPortArRequest, EnNarrowMgrPort || !(floo_req_in_valid &&
+                           (floo_req_unpack_generic.hdr.axi_ch == NarrowAr)))
+  `ASSERT(NoNarrowMgrPortWRequest,  EnNarrowMgrPort || !(floo_req_in_valid &&
+                           (floo_req_unpack_generic.hdr.axi_ch == NarrowW)))
+  `ASSERT(NoWideMgrPortAwRequest, EnWideMgrPort || !(floo_req_in_valid &&
+                           (floo_req_unpack_generic.hdr.axi_ch == WideAw)))
+  `ASSERT(NoWideMgrPortArRequest, EnWideMgrPort || !(floo_req_in_valid &&
+                           (floo_req_unpack_generic.hdr.axi_ch == WideAr)))
+  `ASSERT(NoWideMgrPortWRequest,  EnWideMgrPort || !(floo_wide_in_valid &&
+                           (floo_wide_unpack_generic.hdr.axi_ch == WideW)))
 
 endmodule

--- a/src/floo_narrow_wide_chimney.sv
+++ b/src/floo_narrow_wide_chimney.sv
@@ -212,7 +212,7 @@ module floo_narrow_wide_chimney
         .rst_ni,
         .data_i   ( axi_narrow_in_req_i.aw        ),
         .valid_i  ( axi_narrow_in_req_i.aw_valid  ),
-        .ready_o  ( axi_narrow_in_rsp_o.aw_ready  ),
+        .ready_o  ( axi_narrow_rsp_out.aw_ready   ),
         .data_o   ( axi_narrow_aw_queue           ),
         .valid_o  ( axi_narrow_aw_queue_valid_out ),
         .ready_i  ( axi_narrow_aw_queue_ready_in  )
@@ -225,7 +225,7 @@ module floo_narrow_wide_chimney
         .rst_ni,
         .data_i   ( axi_narrow_in_req_i.ar        ),
         .valid_i  ( axi_narrow_in_req_i.ar_valid  ),
-        .ready_o  ( axi_narrow_in_rsp_o.ar_ready  ),
+        .ready_o  ( axi_narrow_rsp_out.ar_ready   ),
         .data_o   ( axi_narrow_ar_queue           ),
         .valid_o  ( axi_narrow_ar_queue_valid_out ),
         .ready_i  ( axi_narrow_ar_queue_ready_in  )
@@ -234,10 +234,10 @@ module floo_narrow_wide_chimney
     end else begin : gen_ax_no_cuts
       assign axi_narrow_aw_queue = axi_narrow_in_req_i.aw;
       assign axi_narrow_aw_queue_valid_out = axi_narrow_in_req_i.aw_valid;
-      assign axi_narrow_in_rsp_o.aw_ready = axi_narrow_aw_queue_ready_in;
+      assign axi_narrow_rsp_out.aw_ready = axi_narrow_aw_queue_ready_in;
       assign axi_narrow_ar_queue = axi_narrow_in_req_i.ar;
       assign axi_narrow_ar_queue_valid_out = axi_narrow_in_req_i.ar_valid;
-      assign axi_narrow_in_rsp_o.ar_ready = axi_narrow_ar_queue_ready_in;
+      assign axi_narrow_rsp_out.ar_ready = axi_narrow_ar_queue_ready_in;
     end
 
   end else begin : gen_narrow_err_slv_port
@@ -273,7 +273,7 @@ module floo_narrow_wide_chimney
         .rst_ni,
         .data_i   ( axi_wide_in_req_i.aw        ),
         .valid_i  ( axi_wide_in_req_i.aw_valid  ),
-        .ready_o  ( axi_wide_in_rsp_o.aw_ready  ),
+        .ready_o  ( axi_wide_rsp_out.aw_ready   ),
         .data_o   ( axi_wide_aw_queue           ),
         .valid_o  ( axi_wide_aw_queue_valid_out ),
         .ready_i  ( axi_wide_aw_queue_ready_in  )
@@ -286,7 +286,7 @@ module floo_narrow_wide_chimney
         .rst_ni,
         .data_i   ( axi_wide_in_req_i.ar        ),
         .valid_i  ( axi_wide_in_req_i.ar_valid  ),
-        .ready_o  ( axi_wide_in_rsp_o.ar_ready  ),
+        .ready_o  ( axi_wide_rsp_out.ar_ready   ),
         .data_o   ( axi_wide_ar_queue           ),
         .valid_o  ( axi_wide_ar_queue_valid_out ),
         .ready_i  ( axi_wide_ar_queue_ready_in  )
@@ -294,10 +294,10 @@ module floo_narrow_wide_chimney
     end else begin : gen_ax_no_cuts
       assign axi_wide_aw_queue = axi_wide_in_req_i.aw;
       assign axi_wide_aw_queue_valid_out = axi_wide_in_req_i.aw_valid;
-      assign axi_wide_in_rsp_o.aw_ready = axi_wide_aw_queue_ready_in;
+      assign axi_wide_rsp_out.aw_ready = axi_wide_aw_queue_ready_in;
       assign axi_wide_ar_queue = axi_wide_in_req_i.ar;
       assign axi_wide_ar_queue_valid_out = axi_wide_in_req_i.ar_valid;
-      assign axi_wide_in_rsp_o.ar_ready = axi_wide_ar_queue_ready_in;
+      assign axi_wide_rsp_out.ar_ready = axi_wide_ar_queue_ready_in;
     end
   end else begin : gen_wide_err_slv_port
     axi_err_slv #(


### PR DESCRIPTION
Added Chimney Parameters `EnMgrPort` and `EnSbrPort` to properly parametrize Manager resp. Subordinate-only instances of a chimney.

A couple of assertions were added to check that no packets arrive at a network interface that cannot be handled