### PR TITLE
chimney: Fix ordering of `AW` and `W` beats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+
+- Wormhole routing for bursts was removed for some channels in the chimney since it is generally not necessary if the header information is sent in parallel to the payload.
+
+### Fixed
+
+- Write ordering in the narrow-wide version was incorrect. Sending `AW` and `W` beats over different channels would have allowed to arrive them out of order, if multiple managers are sending write requests to the same subordinate, which could result in interleaving of the data. This is now fixed by sending `AW` and `W` beats over the same wide channel. The `AW` and `W` beats are coupled together and wormhole routing prevents interleaving of the data.
+
 ## [0.3.0] - 2024-01-09
 
 ### Added

--- a/floogen/model/link.py
+++ b/floogen/model/link.py
@@ -148,9 +148,9 @@ class NarrowWideLink(Link):
     """Link class to describe a NarrowWidelink."""
 
     channel_mapping: ClassVar[Dict] = {
-        "req": {"narrow": ["aw", "w", "ar"], "wide": ["aw", "ar"]},
+        "req": {"narrow": ["aw", "w", "ar"], "wide": ["ar"]},
         "rsp": {"narrow": ["b", "r"], "wide": ["b"]},
-        "wide": {"wide": ["w", "r"]},
+        "wide": {"wide": ["aw", "w", "r"]},
     }
 
     req_type: ClassVar[str] = "floo_req_t"

--- a/hw/floo_axi_chimney.sv
+++ b/hw/floo_axi_chimney.sv
@@ -283,7 +283,7 @@ module floo_axi_chimney
     .rsp_i          ( axi_b_rob_in                  ),
     .rsp_rob_req_i  ( floo_rsp_in.axi_b.hdr.rob_req ),
     .rsp_rob_idx_i  ( floo_rsp_in.axi_b.hdr.rob_idx ),
-    .rsp_last_i     ( floo_rsp_in.axi_b.hdr.last    ),
+    .rsp_last_i     ( 1'b1                          ),
     .rsp_valid_o    ( b_rob_valid_out               ),
     .rsp_ready_i    ( b_rob_ready_in                ),
     .rsp_o          ( axi_b_rob_out                 )
@@ -329,7 +329,7 @@ module floo_axi_chimney
     .rsp_i          ( axi_r_rob_in                  ),
     .rsp_rob_req_i  ( floo_rsp_in.axi_r.hdr.rob_req ),
     .rsp_rob_idx_i  ( floo_rsp_in.axi_r.hdr.rob_idx ),
-    .rsp_last_i     ( floo_rsp_in.axi_r.hdr.last    ),
+    .rsp_last_i     ( floo_rsp_in.axi_r.r.last      ),
     .rsp_valid_o    ( r_rob_valid_out               ),
     .rsp_ready_i    ( r_rob_ready_in                ),
     .rsp_o          ( axi_r_rob_out                 )

--- a/hw/floo_axi_chimney.sv
+++ b/hw/floo_axi_chimney.sv
@@ -386,7 +386,7 @@ module floo_axi_chimney
     floo_axi_aw.hdr.rob_idx = aw_rob_idx_out;
     floo_axi_aw.hdr.dst_id  = dst_id[AxiAw];
     floo_axi_aw.hdr.src_id  = id_i;
-    floo_axi_aw.hdr.last    = 1'b1;
+    floo_axi_aw.hdr.last    = 1'b0;
     floo_axi_aw.hdr.axi_ch  = AxiAw;
     floo_axi_aw.hdr.atop    = axi_aw_queue.atop != axi_pkg::ATOP_NONE;
     floo_axi_aw.aw          = axi_aw_queue;
@@ -433,7 +433,7 @@ module floo_axi_chimney
     floo_axi_r.hdr.rob_idx  = ar_out_data_out.rob_idx;
     floo_axi_r.hdr.dst_id   = ar_out_data_out.src_id;
     floo_axi_r.hdr.src_id   = id_i;
-    floo_axi_r.hdr.last     = axi_out_rsp_i.r.last;
+    floo_axi_r.hdr.last     = 1'b1; // There is no reason to do wormhole routing for R bursts
     floo_axi_r.hdr.axi_ch   = AxiR;
     floo_axi_r.hdr.atop     = ar_out_data_out.atop;
     floo_axi_r.r            = axi_meta_buf_rsp_out.r;

--- a/hw/floo_axi_chimney.sv
+++ b/hw/floo_axi_chimney.sv
@@ -470,40 +470,32 @@ module floo_axi_chimney
   // FLIT ARBITRATION  //
   ///////////////////////
 
-  rr_arb_tree #(
-    .NumIn      ( 3                       ),
-    .AxiVldRdy  ( 1'b1                    ),
-    .DataType   ( floo_req_generic_flit_t )
+  floo_wormhole_arbiter #(
+    .NumRoutes  ( 3                       ),
+    .flit_t     ( floo_req_generic_flit_t )
   ) i_req_wormhole_arbiter (
-    .clk_i,
-    .rst_ni,
-    .flush_i  ( 1'b0                  ),
-    .rr_i     ( '0                    ),
-    .req_i    ( floo_req_arb_req_in   ),
-    .gnt_o    ( floo_req_arb_gnt_out  ),
+    .clk_i    ( clk_i                 ),
+    .rst_ni   ( rst_ni                ),
+    .valid_i  ( floo_req_arb_req_in   ),
     .data_i   ( floo_req_arb_in       ),
-    .req_o    ( floo_req_o.valid      ),
-    .gnt_i    ( floo_req_i.ready      ),
+    .ready_o  ( floo_req_arb_gnt_out  ),
     .data_o   ( floo_req_o.req        ),
-    .idx_o    (                       )
+    .ready_i  ( floo_req_i.ready      ),
+    .valid_o  ( floo_req_o.valid      )
   );
 
-  rr_arb_tree #(
-    .NumIn      ( 2                       ),
-    .AxiVldRdy  ( 1'b1                    ),
-    .DataType   ( floo_rsp_generic_flit_t )
+  floo_wormhole_arbiter #(
+    .NumRoutes  ( 2                       ),
+    .flit_t     ( floo_rsp_generic_flit_t )
   ) i_rsp_wormhole_arbiter (
-    .clk_i,
-    .rst_ni,
-    .flush_i  ( 1'b0                  ),
-    .rr_i     ( '0                    ),
-    .req_i    ( floo_rsp_arb_req_in   ),
-    .gnt_o    ( floo_rsp_arb_gnt_out  ),
+    .clk_i    ( clk_i                 ),
+    .rst_ni   ( rst_ni                ),
+    .valid_i  ( floo_rsp_arb_req_in   ),
     .data_i   ( floo_rsp_arb_in       ),
-    .req_o    ( floo_rsp_o.valid      ),
-    .gnt_i    ( floo_rsp_i.ready      ),
+    .ready_o  ( floo_rsp_arb_gnt_out  ),
     .data_o   ( floo_rsp_o.rsp        ),
-    .idx_o    (                       )
+    .ready_i  ( floo_rsp_i.ready      ),
+    .valid_o  ( floo_rsp_o.valid      )
   );
 
   ////////////////////

--- a/hw/floo_axi_chimney.sv
+++ b/hw/floo_axi_chimney.sv
@@ -470,32 +470,40 @@ module floo_axi_chimney
   // FLIT ARBITRATION  //
   ///////////////////////
 
-  floo_wormhole_arbiter #(
-    .NumRoutes  ( 3                       ),
-    .flit_t     ( floo_req_generic_flit_t )
+  rr_arb_tree #(
+    .NumIn      ( 3                       ),
+    .AxiVldRdy  ( 1'b1                    ),
+    .DataType   ( floo_req_generic_flit_t )
   ) i_req_wormhole_arbiter (
-    .clk_i    ( clk_i                 ),
-    .rst_ni   ( rst_ni                ),
-    .valid_i  ( floo_req_arb_req_in   ),
+    .clk_i,
+    .rst_ni,
+    .flush_i  ( 1'b0                  ),
+    .rr_i     ( '0                    ),
+    .req_i    ( floo_req_arb_req_in   ),
+    .gnt_o    ( floo_req_arb_gnt_out  ),
     .data_i   ( floo_req_arb_in       ),
-    .ready_o  ( floo_req_arb_gnt_out  ),
+    .req_o    ( floo_req_o.valid      ),
+    .gnt_i    ( floo_req_i.ready      ),
     .data_o   ( floo_req_o.req        ),
-    .ready_i  ( floo_req_i.ready      ),
-    .valid_o  ( floo_req_o.valid      )
+    .idx_o    (                       )
   );
 
-  floo_wormhole_arbiter #(
-    .NumRoutes  ( 2                       ),
-    .flit_t     ( floo_rsp_generic_flit_t )
+  rr_arb_tree #(
+    .NumIn      ( 2                       ),
+    .AxiVldRdy  ( 1'b1                    ),
+    .DataType   ( floo_rsp_generic_flit_t )
   ) i_rsp_wormhole_arbiter (
-    .clk_i    ( clk_i                 ),
-    .rst_ni   ( rst_ni                ),
-    .valid_i  ( floo_rsp_arb_req_in   ),
+    .clk_i,
+    .rst_ni,
+    .flush_i  ( 1'b0                  ),
+    .rr_i     ( '0                    ),
+    .req_i    ( floo_rsp_arb_req_in   ),
+    .gnt_o    ( floo_rsp_arb_gnt_out  ),
     .data_i   ( floo_rsp_arb_in       ),
-    .ready_o  ( floo_rsp_arb_gnt_out  ),
+    .req_o    ( floo_rsp_o.valid      ),
+    .gnt_i    ( floo_rsp_i.ready      ),
     .data_o   ( floo_rsp_o.rsp        ),
-    .ready_i  ( floo_rsp_i.ready      ),
-    .valid_o  ( floo_rsp_o.valid      )
+    .idx_o    (                       )
   );
 
   ////////////////////

--- a/hw/floo_narrow_wide_chimney.sv
+++ b/hw/floo_narrow_wide_chimney.sv
@@ -502,7 +502,7 @@ module floo_narrow_wide_chimney
   rob_idx_t narrow_r_rob_rob_idx;
   assign narrow_r_rob_rob_req = floo_rsp_in.narrow_r.hdr.rob_req;
   assign narrow_r_rob_rob_idx = floo_rsp_in.narrow_r.hdr.rob_idx;
-  assign narrow_r_rob_last = floo_rsp_in.narrow_r.hdr.last;
+  assign narrow_r_rob_last = floo_rsp_in.narrow_r.r.last;
 
   floo_rob_wrapper #(
     .RoBType            ( NarrowRoBType           ),
@@ -546,7 +546,7 @@ module floo_narrow_wide_chimney
   rob_idx_t wide_r_rob_rob_idx;
   assign wide_r_rob_rob_req = floo_wide_in.wide_r.hdr.rob_req;
   assign wide_r_rob_rob_idx = floo_wide_in.wide_r.hdr.rob_idx;
-  assign wide_r_rob_last = floo_wide_in.wide_r.hdr.last;
+  assign wide_r_rob_last = floo_wide_in.wide_r.r.last;
 
   floo_rob_wrapper #(
     .RoBType            ( WideRoBType           ),

--- a/hw/floo_narrow_wide_chimney.sv
+++ b/hw/floo_narrow_wide_chimney.sv
@@ -916,8 +916,6 @@ module floo_narrow_wide_chimney
                                   (floo_req_unpack_generic.hdr.axi_ch  == NarrowW);
   assign axi_valid_in[NarrowAr] = floo_req_in_valid &&
                                   (floo_req_unpack_generic.hdr.axi_ch == NarrowAr);
-  assign axi_valid_in[WideAw]   = floo_req_in_valid &&
-                                  (floo_req_unpack_generic.hdr.axi_ch == WideAw);
   assign axi_valid_in[WideAr]   = floo_req_in_valid &&
                                   (floo_req_unpack_generic.hdr.axi_ch == WideAr);
   assign axi_valid_in[NarrowB]  = EnNarrowSbrPort && floo_rsp_in_valid &&
@@ -926,6 +924,8 @@ module floo_narrow_wide_chimney
                                   (floo_rsp_unpack_generic.hdr.axi_ch  == NarrowR);
   assign axi_valid_in[WideB]    = EnWideSbrPort && floo_rsp_in_valid &&
                                   (floo_rsp_unpack_generic.hdr.axi_ch  == WideB);
+  assign axi_valid_in[WideAw]   = floo_wide_in_valid &&
+                                  (floo_wide_unpack_generic.hdr.axi_ch == WideAw);
   assign axi_valid_in[WideW]    = floo_wide_in_valid &&
                                   (floo_wide_unpack_generic.hdr.axi_ch  == WideW);
   assign axi_valid_in[WideR]    = EnWideSbrPort && floo_wide_in_valid &&

--- a/hw/floo_narrow_wide_chimney.sv
+++ b/hw/floo_narrow_wide_chimney.sv
@@ -783,43 +783,47 @@ module floo_narrow_wide_chimney
   `FF(narrow_aw_w_sel_q, narrow_aw_w_sel_d, SelAw)
   `FF(wide_aw_w_sel_q, wide_aw_w_sel_d, SelAw)
 
-  assign floo_req_arb_req_in[NarrowAw]  = (narrow_aw_w_sel_q == SelAw) &&
+  assign floo_req_arb_req_in[NarrowW]  = (narrow_aw_w_sel_q == SelAw) &&
                                           (narrow_aw_rob_valid_out ||
                                           ((axi_narrow_aw_queue.atop != axi_pkg::ATOP_NONE) &&
-                                          axi_narrow_aw_queue_valid_out));
-  assign floo_req_arb_req_in[NarrowW]   = (narrow_aw_w_sel_q == SelW) &&
+                                          axi_narrow_aw_queue_valid_out)) ||
+                                          (narrow_aw_w_sel_q == SelW) &&
                                           axi_narrow_req_in.w_valid;
+  assign floo_req_arb_req_in[NarrowAw] = 1'b0; // AW and W need to be sent together
   assign floo_req_arb_req_in[NarrowAr]  = narrow_ar_rob_valid_out;
   assign floo_req_arb_req_in[WideAr]    = wide_ar_rob_valid_out;
   assign floo_rsp_arb_req_in[NarrowB]   = axi_narrow_meta_buf_rsp_out.b_valid;
   assign floo_rsp_arb_req_in[NarrowR]   = axi_narrow_meta_buf_rsp_out.r_valid;
   assign floo_rsp_arb_req_in[WideB]     = axi_wide_meta_buf_rsp_out.b_valid;
-  assign floo_wide_arb_req_in[WideAw]   = (wide_aw_w_sel_q == SelAw) &&
-                                          wide_aw_rob_valid_out;
-  assign floo_wide_arb_req_in[WideW]    = (wide_aw_w_sel_q == SelW) &&
+  assign floo_wide_arb_req_in[WideW]    = (wide_aw_w_sel_q == SelAw) &&
+                                          wide_aw_rob_valid_out ||
+                                          (wide_aw_w_sel_q == SelW) &&
                                           axi_wide_req_in.w_valid;
+  assign floo_wide_arb_req_in[WideAw]   = 1'b0; // AW and W need to be sent together
   assign floo_wide_arb_req_in[WideR]    = axi_wide_meta_buf_rsp_out.r_valid;
 
-  assign narrow_aw_rob_ready_in     = floo_req_arb_gnt_out[NarrowAw] &&
+  assign narrow_aw_rob_ready_in     = floo_req_arb_gnt_out[NarrowW] &&
                                       (narrow_aw_w_sel_q == SelAw);
   assign axi_narrow_rsp_out.w_ready = floo_req_arb_gnt_out[NarrowW] &&
                                       (narrow_aw_w_sel_q == SelW);
   assign narrow_ar_rob_ready_in     = floo_req_arb_gnt_out[NarrowAr];
-  assign wide_aw_rob_ready_in       = floo_wide_arb_gnt_out[WideAw] &&
+  assign wide_aw_rob_ready_in       = floo_wide_arb_gnt_out[WideW] &&
                                       (wide_aw_w_sel_q == SelAw);
   assign axi_wide_rsp_out.w_ready   = floo_wide_arb_gnt_out[WideW] &&
                                       (wide_aw_w_sel_q == SelW);
   assign wide_ar_rob_ready_in       = floo_req_arb_gnt_out[WideAr];
 
-  assign floo_req_arb_in[NarrowAw].narrow_aw  = floo_narrow_aw;
-  assign floo_req_arb_in[NarrowW].narrow_w    = floo_narrow_w;
+  assign floo_req_arb_in[NarrowAw]            = '0;
+  assign floo_req_arb_in[NarrowW]             = (narrow_aw_w_sel_q == SelAw)?
+                                                floo_narrow_aw : floo_narrow_w;
   assign floo_req_arb_in[NarrowAr].narrow_ar  = floo_narrow_ar;
   assign floo_req_arb_in[WideAr].wide_ar      = floo_wide_ar;
   assign floo_rsp_arb_in[NarrowB].narrow_b    = floo_narrow_b;
   assign floo_rsp_arb_in[NarrowR].narrow_r    = floo_narrow_r;
   assign floo_rsp_arb_in[WideB].wide_b        = floo_wide_b;
-  assign floo_wide_arb_in[WideAw].wide_aw     = floo_wide_aw;
-  assign floo_wide_arb_in[WideW].wide_w       = floo_wide_w;
+  assign floo_wide_arb_in[WideAw]             = '0;
+  assign floo_wide_arb_in[WideW]              = (wide_aw_w_sel_q == SelAw)?
+                                                floo_wide_aw : floo_wide_w;
   assign floo_wide_arb_in[WideR].wide_r       = floo_wide_r;
 
   ///////////////////////

--- a/hw/floo_narrow_wide_chimney.sv
+++ b/hw/floo_narrow_wide_chimney.sv
@@ -651,7 +651,7 @@ module floo_narrow_wide_chimney
     floo_narrow_aw.hdr.rob_idx  = rob_idx_t'(narrow_aw_rob_idx_out);
     floo_narrow_aw.hdr.dst_id   = dst_id[NarrowAw];
     floo_narrow_aw.hdr.src_id   = id_i;
-    floo_narrow_aw.hdr.last     = 1'b1;
+    floo_narrow_aw.hdr.last     = 1'b0;  // AW and W need to be sent together
     floo_narrow_aw.hdr.axi_ch   = NarrowAw;
     floo_narrow_aw.hdr.atop     = axi_narrow_aw_queue.atop != axi_pkg::ATOP_NONE;
     floo_narrow_aw.aw           = axi_narrow_aw_queue;
@@ -699,7 +699,7 @@ module floo_narrow_wide_chimney
     floo_narrow_r.hdr.dst_id  = narrow_ar_out_data_out.src_id;
     floo_narrow_r.hdr.src_id  = id_i;
     floo_narrow_r.hdr.axi_ch  = NarrowR;
-    floo_narrow_r.hdr.last    = axi_narrow_out_rsp_i.r.last;
+    floo_narrow_r.hdr.last    = 1'b1; // There is no reason to do wormhole routing for R bursts
     floo_narrow_r.hdr.atop    = narrow_ar_out_data_out.atop;
     floo_narrow_r.r           = axi_narrow_meta_buf_rsp_out.r;
     floo_narrow_r.r.id        = narrow_ar_out_data_out.id;
@@ -711,7 +711,7 @@ module floo_narrow_wide_chimney
     floo_wide_aw.hdr.rob_idx  = rob_idx_t'(wide_aw_rob_idx_out);
     floo_wide_aw.hdr.dst_id   = dst_id[WideAw];
     floo_wide_aw.hdr.src_id   = id_i;
-    floo_wide_aw.hdr.last     = 1'b1;
+    floo_wide_aw.hdr.last     = 1'b0;  // AW and W need to be sent together
     floo_wide_aw.hdr.axi_ch   = WideAw;
     floo_wide_aw.aw           = axi_wide_aw_queue;
   end
@@ -757,7 +757,7 @@ module floo_narrow_wide_chimney
     floo_wide_r.hdr.dst_id  = wide_ar_out_data_out.src_id;
     floo_wide_r.hdr.src_id  = id_i;
     floo_wide_r.hdr.axi_ch  = WideR;
-    floo_wide_r.hdr.last    = axi_wide_out_rsp_i.r.last;
+    floo_wide_r.hdr.last    = 1'b1; // There is no reason to do wormhole routing for R bursts
     floo_wide_r.r           = axi_wide_meta_buf_rsp_out.r;
     floo_wide_r.r.id        = wide_ar_out_data_out.id;
   end

--- a/hw/floo_narrow_wide_chimney.sv
+++ b/hw/floo_narrow_wide_chimney.sv
@@ -96,10 +96,10 @@ module floo_narrow_wide_chimney
 
   floo_req_chan_t [WideAr:NarrowAw] floo_req_arb_in;
   floo_rsp_chan_t [WideB:NarrowB] floo_rsp_arb_in;
-  floo_wide_chan_t [WideR:WideW] floo_wide_arb_in;
+  floo_wide_chan_t [WideR:WideAw] floo_wide_arb_in;
   logic  [WideAr:NarrowAw] floo_req_arb_req_in, floo_req_arb_gnt_out;
   logic  [WideB:NarrowB]   floo_rsp_arb_req_in, floo_rsp_arb_gnt_out;
-  logic  [WideR:WideW]     floo_wide_arb_req_in, floo_wide_arb_gnt_out;
+  logic  [WideR:WideAw]    floo_wide_arb_req_in, floo_wide_arb_gnt_out;
 
   // flit queue
   floo_req_chan_t floo_req_in;
@@ -790,12 +790,12 @@ module floo_narrow_wide_chimney
   assign floo_req_arb_req_in[NarrowW]   = (narrow_aw_w_sel_q == SelW) &&
                                           axi_narrow_req_in.w_valid;
   assign floo_req_arb_req_in[NarrowAr]  = narrow_ar_rob_valid_out;
-  assign floo_req_arb_req_in[WideAw]    = (wide_aw_w_sel_q == SelAw) &&
-                                          wide_aw_rob_valid_out;
   assign floo_req_arb_req_in[WideAr]    = wide_ar_rob_valid_out;
   assign floo_rsp_arb_req_in[NarrowB]   = axi_narrow_meta_buf_rsp_out.b_valid;
   assign floo_rsp_arb_req_in[NarrowR]   = axi_narrow_meta_buf_rsp_out.r_valid;
   assign floo_rsp_arb_req_in[WideB]     = axi_wide_meta_buf_rsp_out.b_valid;
+  assign floo_wide_arb_req_in[WideAw]   = (wide_aw_w_sel_q == SelAw) &&
+                                          wide_aw_rob_valid_out;
   assign floo_wide_arb_req_in[WideW]    = (wide_aw_w_sel_q == SelW) &&
                                           axi_wide_req_in.w_valid;
   assign floo_wide_arb_req_in[WideR]    = axi_wide_meta_buf_rsp_out.r_valid;
@@ -805,7 +805,7 @@ module floo_narrow_wide_chimney
   assign axi_narrow_rsp_out.w_ready = floo_req_arb_gnt_out[NarrowW] &&
                                       (narrow_aw_w_sel_q == SelW);
   assign narrow_ar_rob_ready_in     = floo_req_arb_gnt_out[NarrowAr];
-  assign wide_aw_rob_ready_in       = floo_req_arb_gnt_out[WideAw] &&
+  assign wide_aw_rob_ready_in       = floo_wide_arb_gnt_out[WideAw] &&
                                       (wide_aw_w_sel_q == SelAw);
   assign axi_wide_rsp_out.w_ready   = floo_wide_arb_gnt_out[WideW] &&
                                       (wide_aw_w_sel_q == SelW);
@@ -814,11 +814,11 @@ module floo_narrow_wide_chimney
   assign floo_req_arb_in[NarrowAw].narrow_aw  = floo_narrow_aw;
   assign floo_req_arb_in[NarrowW].narrow_w    = floo_narrow_w;
   assign floo_req_arb_in[NarrowAr].narrow_ar  = floo_narrow_ar;
-  assign floo_req_arb_in[WideAw].wide_aw      = floo_wide_aw;
   assign floo_req_arb_in[WideAr].wide_ar      = floo_wide_ar;
   assign floo_rsp_arb_in[NarrowB].narrow_b    = floo_narrow_b;
   assign floo_rsp_arb_in[NarrowR].narrow_r    = floo_narrow_r;
   assign floo_rsp_arb_in[WideB].wide_b        = floo_wide_b;
+  assign floo_wide_arb_in[WideAw].wide_aw     = floo_wide_aw;
   assign floo_wide_arb_in[WideW].wide_w       = floo_wide_w;
   assign floo_wide_arb_in[WideR].wide_r       = floo_wide_r;
 
@@ -827,7 +827,7 @@ module floo_narrow_wide_chimney
   ///////////////////////
 
   floo_wormhole_arbiter #(
-    .NumRoutes  ( 5                       ),
+    .NumRoutes  ( 4                       ),
     .flit_t     ( floo_req_generic_flit_t )
   ) i_req_wormhole_arbiter (
     .clk_i,
@@ -855,7 +855,7 @@ module floo_narrow_wide_chimney
   );
 
   floo_wormhole_arbiter #(
-    .NumRoutes  ( 2                         ),
+    .NumRoutes  ( 3                         ),
     .flit_t     ( floo_wide_generic_flit_t  )
   ) i_wide_wormhole_arbiter (
     .clk_i,
@@ -888,7 +888,7 @@ module floo_narrow_wide_chimney
   assign axi_narrow_unpack_ar = floo_req_in.narrow_ar.ar;
   assign axi_narrow_unpack_r  = floo_rsp_in.narrow_r.r;
   assign axi_narrow_unpack_b  = floo_rsp_in.narrow_b.b;
-  assign axi_wide_unpack_aw   = floo_req_in.wide_aw.aw;
+  assign axi_wide_unpack_aw   = floo_wide_in.wide_aw.aw;
   assign axi_wide_unpack_w    = floo_wide_in.wide_w.w;
   assign axi_wide_unpack_ar   = floo_req_in.wide_ar.ar;
   assign axi_wide_unpack_r    = floo_wide_in.wide_r.r;

--- a/hw/floo_narrow_wide_chimney.sv
+++ b/hw/floo_narrow_wide_chimney.sv
@@ -998,29 +998,29 @@ module floo_narrow_wide_chimney
 
   assign narrow_aw_out_data_in = '{
     id: axi_narrow_unpack_aw.id,
-    rob_req: floo_req_unpack_generic.hdr.rob_req,
-    rob_idx: floo_req_unpack_generic.hdr.rob_idx,
-    src_id: floo_req_unpack_generic.hdr.src_id,
-    atop: floo_req_unpack_generic.hdr.atop
+    rob_req: floo_req_in.narrow_aw.hdr.rob_req,
+    rob_idx: floo_req_in.narrow_aw.hdr.rob_idx,
+    src_id: floo_req_in.narrow_aw.hdr.src_id,
+    atop: floo_req_in.narrow_aw.hdr.atop
   };
   assign narrow_ar_out_data_in = '{
     id: (is_atop && atop_has_r_rsp)? axi_narrow_unpack_aw.id : axi_narrow_unpack_ar.id,
-    rob_req: floo_req_unpack_generic.hdr.rob_req,
-    rob_idx: floo_req_unpack_generic.hdr.rob_idx,
-    src_id: floo_req_unpack_generic.hdr.src_id,
-    atop: floo_req_unpack_generic.hdr.atop
+    rob_req: floo_req_in.narrow_ar.hdr.rob_req,
+    rob_idx: floo_req_in.narrow_ar.hdr.rob_idx,
+    src_id: floo_req_in.narrow_ar.hdr.src_id,
+    atop: floo_req_in.narrow_ar.hdr.atop
   };
   assign wide_aw_out_data_in = '{
     id: axi_wide_unpack_aw.id,
-    rob_req: floo_req_unpack_generic.hdr.rob_req,
-    rob_idx: floo_req_unpack_generic.hdr.rob_idx,
-    src_id: floo_req_unpack_generic.hdr.src_id
+    rob_req: floo_wide_in.wide_aw.hdr.rob_req,
+    rob_idx: floo_wide_in.wide_aw.hdr.rob_idx,
+    src_id: floo_wide_in.wide_aw.hdr.src_id
   };
   assign wide_ar_out_data_in = '{
     id: axi_wide_unpack_ar.id,
-    rob_req: floo_req_unpack_generic.hdr.rob_req,
-    rob_idx: floo_req_unpack_generic.hdr.rob_idx,
-    src_id: floo_req_unpack_generic.hdr.src_id
+    rob_req: floo_req_in.wide_ar.hdr.rob_req,
+    rob_idx: floo_req_in.wide_ar.hdr.rob_idx,
+    src_id: floo_req_in.wide_ar.hdr.src_id
   };
 
   if (EnNarrowMgrPort) begin : gen_narrow_mgr_port

--- a/hw/floo_narrow_wide_chimney.sv
+++ b/hw/floo_narrow_wide_chimney.sv
@@ -826,46 +826,58 @@ module floo_narrow_wide_chimney
   // FLIT ARBITRATION  //
   ///////////////////////
 
-  floo_wormhole_arbiter #(
-    .NumRoutes  ( 4                       ),
-    .flit_t     ( floo_req_generic_flit_t )
+  rr_arb_tree #(
+    .NumIn      ( 4                       ),
+    .AxiVldRdy  ( 1'b1                    ),
+    .DataType   ( floo_req_generic_flit_t )
   ) i_req_wormhole_arbiter (
     .clk_i,
     .rst_ni,
-    .valid_i  ( floo_req_arb_req_in   ),
+    .flush_i  ( 1'b0                  ),
+    .rr_i     ( '0                    ),
+    .req_i    ( floo_req_arb_req_in   ),
+    .gnt_o    ( floo_req_arb_gnt_out  ),
     .data_i   ( floo_req_arb_in       ),
-    .ready_o  ( floo_req_arb_gnt_out  ),
+    .req_o    ( floo_req_o.valid      ),
+    .gnt_i    ( floo_req_i.ready      ),
     .data_o   ( floo_req_o.req        ),
-    .ready_i  ( floo_req_i.ready      ),
-    .valid_o  ( floo_req_o.valid      )
+    .idx_o    (                       )
   );
 
-  floo_wormhole_arbiter #(
-    .NumRoutes  ( 3                       ),
-    .flit_t     ( floo_rsp_generic_flit_t )
+  rr_arb_tree #(
+    .NumIn      ( 3                       ),
+    .AxiVldRdy  ( 1'b1                    ),
+    .DataType   ( floo_rsp_generic_flit_t )
   ) i_rsp_wormhole_arbiter (
     .clk_i,
     .rst_ni,
-    .valid_i  ( floo_rsp_arb_req_in   ),
+    .flush_i  ( 1'b0                  ),
+    .rr_i     ( '0                    ),
+    .req_i    ( floo_rsp_arb_req_in   ),
+    .gnt_o    ( floo_rsp_arb_gnt_out  ),
     .data_i   ( floo_rsp_arb_in       ),
-    .ready_o  ( floo_rsp_arb_gnt_out  ),
+    .req_o    ( floo_rsp_o.valid      ),
+    .gnt_i    ( floo_rsp_i.ready      ),
     .data_o   ( floo_rsp_o.rsp        ),
-    .ready_i  ( floo_rsp_i.ready      ),
-    .valid_o  ( floo_rsp_o.valid      )
+    .idx_o    (                       )
   );
 
-  floo_wormhole_arbiter #(
-    .NumRoutes  ( 3                         ),
-    .flit_t     ( floo_wide_generic_flit_t  )
+  rr_arb_tree #(
+    .NumIn      ( 3                         ),
+    .AxiVldRdy  ( 1'b1                      ),
+    .DataType   ( floo_wide_generic_flit_t  )
   ) i_wide_wormhole_arbiter (
     .clk_i,
     .rst_ni,
-    .valid_i  ( floo_wide_arb_req_in  ),
+    .flush_i  ( 1'b0                  ),
+    .rr_i     ( '0                    ),
+    .req_i    ( floo_wide_arb_req_in  ),
+    .gnt_o    ( floo_wide_arb_gnt_out ),
     .data_i   ( floo_wide_arb_in      ),
-    .ready_o  ( floo_wide_arb_gnt_out ),
+    .req_o    ( floo_wide_o.valid     ),
+    .gnt_i    ( floo_wide_i.ready     ),
     .data_o   ( floo_wide_o.wide      ),
-    .ready_i  ( floo_wide_i.ready     ),
-    .valid_o  ( floo_wide_o.valid     )
+    .idx_o    (                       )
   );
 
   ////////////////////

--- a/hw/floo_narrow_wide_chimney.sv
+++ b/hw/floo_narrow_wide_chimney.sv
@@ -826,58 +826,46 @@ module floo_narrow_wide_chimney
   // FLIT ARBITRATION  //
   ///////////////////////
 
-  rr_arb_tree #(
-    .NumIn      ( 4                       ),
-    .AxiVldRdy  ( 1'b1                    ),
-    .DataType   ( floo_req_generic_flit_t )
+  floo_wormhole_arbiter #(
+    .NumRoutes  ( 4                       ),
+    .flit_t     ( floo_req_generic_flit_t )
   ) i_req_wormhole_arbiter (
     .clk_i,
     .rst_ni,
-    .flush_i  ( 1'b0                  ),
-    .rr_i     ( '0                    ),
-    .req_i    ( floo_req_arb_req_in   ),
-    .gnt_o    ( floo_req_arb_gnt_out  ),
+    .valid_i  ( floo_req_arb_req_in   ),
     .data_i   ( floo_req_arb_in       ),
-    .req_o    ( floo_req_o.valid      ),
-    .gnt_i    ( floo_req_i.ready      ),
+    .ready_o  ( floo_req_arb_gnt_out  ),
     .data_o   ( floo_req_o.req        ),
-    .idx_o    (                       )
+    .ready_i  ( floo_req_i.ready      ),
+    .valid_o  ( floo_req_o.valid      )
   );
 
-  rr_arb_tree #(
-    .NumIn      ( 3                       ),
-    .AxiVldRdy  ( 1'b1                    ),
-    .DataType   ( floo_rsp_generic_flit_t )
+  floo_wormhole_arbiter #(
+    .NumRoutes  ( 3                       ),
+    .flit_t     ( floo_rsp_generic_flit_t )
   ) i_rsp_wormhole_arbiter (
     .clk_i,
     .rst_ni,
-    .flush_i  ( 1'b0                  ),
-    .rr_i     ( '0                    ),
-    .req_i    ( floo_rsp_arb_req_in   ),
-    .gnt_o    ( floo_rsp_arb_gnt_out  ),
+    .valid_i  ( floo_rsp_arb_req_in   ),
     .data_i   ( floo_rsp_arb_in       ),
-    .req_o    ( floo_rsp_o.valid      ),
-    .gnt_i    ( floo_rsp_i.ready      ),
+    .ready_o  ( floo_rsp_arb_gnt_out  ),
     .data_o   ( floo_rsp_o.rsp        ),
-    .idx_o    (                       )
+    .ready_i  ( floo_rsp_i.ready      ),
+    .valid_o  ( floo_rsp_o.valid      )
   );
 
-  rr_arb_tree #(
-    .NumIn      ( 3                         ),
-    .AxiVldRdy  ( 1'b1                      ),
-    .DataType   ( floo_wide_generic_flit_t  )
+  floo_wormhole_arbiter #(
+    .NumRoutes  ( 3                         ),
+    .flit_t     ( floo_wide_generic_flit_t  )
   ) i_wide_wormhole_arbiter (
     .clk_i,
     .rst_ni,
-    .flush_i  ( 1'b0                  ),
-    .rr_i     ( '0                    ),
-    .req_i    ( floo_wide_arb_req_in  ),
-    .gnt_o    ( floo_wide_arb_gnt_out ),
+    .valid_i  ( floo_wide_arb_req_in  ),
     .data_i   ( floo_wide_arb_in      ),
-    .req_o    ( floo_wide_o.valid     ),
-    .gnt_i    ( floo_wide_i.ready     ),
+    .ready_o  ( floo_wide_arb_gnt_out ),
     .data_o   ( floo_wide_o.wide      ),
-    .idx_o    (                       )
+    .ready_i  ( floo_wide_i.ready     ),
+    .valid_o  ( floo_wide_o.valid     )
   );
 
   ////////////////////

--- a/hw/floo_narrow_wide_pkg.sv
+++ b/hw/floo_narrow_wide_pkg.sv
@@ -18,11 +18,11 @@ package floo_narrow_wide_pkg;
     NarrowAw = 0,
     NarrowW = 1,
     NarrowAr = 2,
-    WideAw = 3,
-    WideAr = 4,
-    NarrowB = 5,
-    NarrowR = 6,
-    WideB = 7,
+    WideAr = 3,
+    NarrowB = 4,
+    NarrowR = 5,
+    WideB = 6,
+    WideAw = 7,
     WideW = 8,
     WideR = 9,
     NumAxiChannels = 10
@@ -172,7 +172,7 @@ package floo_narrow_wide_pkg;
   typedef struct packed {
     hdr_t hdr;
     axi_wide_in_aw_chan_t aw;
-    logic [0:0] rsvd;
+    logic [490:0] rsvd;
   } floo_wide_aw_flit_t;
 
   typedef struct packed {
@@ -223,7 +223,6 @@ package floo_narrow_wide_pkg;
     floo_narrow_aw_flit_t narrow_aw;
     floo_narrow_w_flit_t narrow_w;
     floo_narrow_ar_flit_t narrow_ar;
-    floo_wide_aw_flit_t wide_aw;
     floo_wide_ar_flit_t wide_ar;
     floo_req_generic_flit_t generic;
   } floo_req_chan_t;
@@ -236,6 +235,7 @@ package floo_narrow_wide_pkg;
   } floo_rsp_chan_t;
 
   typedef union packed {
+    floo_wide_aw_flit_t wide_aw;
     floo_wide_w_flit_t wide_w;
     floo_wide_r_flit_t wide_r;
     floo_wide_generic_flit_t generic;

--- a/hw/tb/wave/tb_floo_axi_chimney.wave.tcl
+++ b/hw/tb/wave/tb_floo_axi_chimney.wave.tcl
@@ -34,9 +34,9 @@ for {set i 0} {$i < 2} {incr i} {
     add wave -noupdate -expand -group $group_name -group Unpacker tb_floo_axi_chimney/i_floo_axi_chimney_${i}/axi_unpack_b
     add wave -noupdate -expand -group $group_name -group Unpacker tb_floo_axi_chimney/i_floo_axi_chimney_${i}/axi_unpack_r
 
-    add wave -noupdate -expand -group $group_name -group MetaBuffer tb_floo_axi_chimney/i_floo_axi_chimney_${i}/i_floo_meta_buffer/*
+    add wave -noupdate -expand -group $group_name -group MetaBuffer tb_floo_axi_chimney/i_floo_axi_chimney_${i}/gen_mgr_port/i_floo_meta_buffer/*
     try {
-        add wave -noupdate -expand -group $group_name -group MetaBuffer tb_floo_axi_chimney/i_floo_axi_chimney_${i}/i_floo_meta_buffer/gen_atop_support/*
+        add wave -noupdate -expand -group $group_name -group MetaBuffer tb_floo_axi_chimney/i_floo_axi_chimney_${i}/gen_mgr_port/i_floo_meta_buffer/gen_atop_support/*
     }
 
     if {$normal_rob} {


### PR DESCRIPTION
### Changed

- Wormhole routing for bursts was removed for some channels in the chimney since it is generally not necessary if the header information is sent in parallel to the payload.

### Fixed

- Write ordering in the narrow-wide version was incorrect. Sending `AW` and `W` beats over different channels would have allowed to arrive them out of order, if multiple managers are sending write requests to the same subordinate, which could result in interleaving of the data. This is now fixed by sending `AW` and `W` beats over the same wide channel. The `AW` and `W` beats are coupled together and wormhole routing prevents interleaving of the data.