### PR TITLE
floogen: Fix output directory + CI improvements

### DIFF
--- a/.github/workflows/floogen.yml
+++ b/.github/workflows/floogen.yml
@@ -46,15 +46,13 @@ jobs:
     - name: Install floogen
       run: |
         python -m pip install .
+    - name: Install Verible
+      uses: chipsalliance/verible-actions-common/install-verible@main
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: Generate NoCs
       run: |
-        floogen -c floogen/examples/${{ matrix.examples }}.yml -o generated --no-format
-    - name: Format generated NoCs
-      uses: chipsalliance/verible-formatter-action@main
-      with:
-        files:
-          ./generated/${{ matrix.examples }}_floo_noc.sv
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        floogen -c floogen/examples/${{ matrix.examples }}.yml -o generated
     - name: Upload artifact
       uses: actions/upload-artifact@v4
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
+- Output directory passed to `floogen` is now relative to the current working directory instead of the installation folder of `floogen`.
 - Write ordering in the narrow-wide version was incorrect. Sending `AW` and `W` beats over different channels would have allowed to arrive them out of order, if multiple managers are sending write requests to the same subordinate, which could result in interleaving of the data. This is now fixed by sending `AW` and `W` beats over the same wide channel. The `AW` and `W` beats are coupled together and wormhole routing prevents interleaving of the data.
 
 ## [0.3.0] - 2024-01-09


### PR DESCRIPTION
CI: Removes the [verible formatter action](https://github.com/chipsalliance/verible-formatter-action/tree/main) with an annoying reviewdog bot that spams the pull requests. It was replaced in favor of the [install-verible action](https://github.com/chipsalliance/verible-actions-common/tree/main/install-verible)

floogen: Paths for the output directory are not relative to the current working directory.