### PR TITLE
floogen: Replace deprecated functions

### DIFF
--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -7,7 +7,7 @@
 
 import pathlib
 from typing import Optional, List, ClassVar
-from importlib import resources
+from importlib.resources import files, as_file
 
 import networkx as nx
 import matplotlib.pyplot as plt
@@ -24,6 +24,7 @@ from floogen.model.link import NarrowWideLink, XYLinks, NarrowLink
 from floogen.model.network_interface import NarrowWideAxiNI
 from floogen.model.protocol import AXI4, AXI4Bus
 from floogen.utils import clog2
+import floogen.templates
 
 
 class Network(BaseModel):  # pylint: disable=too-many-public-methods
@@ -33,10 +34,10 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
-    with resources.path("floogen.templates", "floo_noc_top.sv.mako") as _tpl_path:
+    with as_file(files(floogen.templates).joinpath("floo_noc_top.sv.mako")) as _tpl_path:
         tpl: ClassVar = Template(filename=str(_tpl_path))
 
-    with resources.path("floogen.templates", "floo_flit_pkg.sv.mako") as _tpl_path:
+    with as_file(files(floogen.templates).joinpath("floo_flit_pkg.sv.mako")) as _tpl_path:
         tpl_pkg: ClassVar = Template(filename=str(_tpl_path))
 
     name: str

--- a/floogen/model/network_interface.py
+++ b/floogen/model/network_interface.py
@@ -6,7 +6,7 @@
 # Author: Tim Fischer <fischeti@iis.ee.ethz.ch>
 
 from typing import Optional, ClassVar
-from importlib import resources
+from importlib.resources import files, as_file
 
 from pydantic import BaseModel
 from mako.lookup import Template
@@ -15,6 +15,7 @@ from floogen.model.routing import Id, AddrRange, Routing, RouteMap
 from floogen.model.protocol import AXI4
 from floogen.model.link import NarrowWideLink
 from floogen.model.endpoint import EndpointDesc
+import floogen.templates
 
 
 class NetworkInterface(BaseModel):
@@ -49,7 +50,9 @@ class NetworkInterface(BaseModel):
 class NarrowWideAxiNI(NetworkInterface):
     """ " NarrowWideNI class to describe a narrow-wide network interface."""
 
-    with resources.path("floogen.templates", "floo_narrow_wide_chimney.sv.mako") as _tpl_path:
+    with as_file(
+        files(floogen.templates).joinpath("floo_narrow_wide_chimney.sv.mako")
+    ) as _tpl_path:
         tpl: ClassVar = Template(filename=str(_tpl_path))
 
     mgr_narrow_port: Optional[AXI4] = None

--- a/floogen/model/router.py
+++ b/floogen/model/router.py
@@ -7,7 +7,7 @@
 
 
 from typing import Optional, List, ClassVar, Tuple, Union
-from importlib import resources
+from importlib.resources import files, as_file
 from abc import ABC, abstractmethod
 
 from pydantic import BaseModel, field_validator
@@ -15,6 +15,7 @@ from mako.lookup import Template
 
 from floogen.model.routing import RouteMap, Id, Coord, RouteAlgo
 from floogen.model.link import Link, XYLinks
+import floogen.templates
 
 
 class RouterDesc(BaseModel):
@@ -76,7 +77,9 @@ class XYRouter(BaseModel, ABC):
 class NarrowWideRouter(Router):
     """Router class to describe a narrow-wide router"""
 
-    with resources.path("floogen.templates", "floo_narrow_wide_router.sv.mako") as _tpl_path:
+    with as_file(
+        files(floogen.templates).joinpath("floo_narrow_wide_router.sv.mako")
+    ) as _tpl_path:
         _tpl: ClassVar = Template(filename=str(_tpl_path))
 
     def render(self):
@@ -87,7 +90,9 @@ class NarrowWideRouter(Router):
 class NarrowWideXYRouter(XYRouter):
     """Router class to describe a narrow-wide router"""
 
-    with resources.path("floogen.templates", "floo_narrow_wide_xy_router.sv.mako") as _tpl_path:
+    with as_file(
+        files(floogen.templates).joinpath("floo_narrow_wide_xy_router.sv.mako")
+    ) as _tpl_path:
         _tpl: ClassVar = Template(filename=str(_tpl_path))
 
     def render(self):


### PR DESCRIPTION
pylint complained about deprecated functions from the `importlib` package.