### PR TITLE
floogen: Align unique ID increments in 2D meshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - System address map was renamed from `AddrMap` to `Sam`.
 - The destination field in the flit header have a new type `dst_t` which is either set to `route_t` for the new source-based routing algorithm, and `id_t` for all the other routing algorithms.
 
+### Fixed
+
+- The generation of the unique ID has been changed resp. aligned for 2D meshes to increment Y-first and X-second. This way the address range and ID increment are consistent with each other.
+
 ## [0.4.0] - 2024-02-07
 
 ### Added

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -427,9 +427,9 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
                     ni_dict["addr_range"] = ep_desc.addr_range.model_copy().set_idx(node_idx)
 
                 # 2D array case
-                case (m, _):
+                case (_, n):
                     x, y = self.graph.get_node_arr_idx(ni_name)
-                    idx = y * m + x
+                    idx = x * n + y
                     ni_dict["arr_idx"] = Coord(x=x, y=y)
                     ni_dict["addr_range"] = ep_desc.addr_range.model_copy().set_idx(idx)
 


### PR DESCRIPTION
The generation of the unique ID has been changed resp. aligned for 2D meshes to increment Y-first and X-second. This way the address range and ID increment are consistent with each other.