### PR TITLE
ci: Remove python requirements in internal GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,6 @@ compile-vsim:
     - make compile-sim | tee compile.log 2>&1
     - '! grep "Error: " compile.log'
   needs:
-    - python-virtualenv
     - collect-bender-sources
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,6 @@
 variables:
   VSIM: questa-2023.4 vsim
   BENDER: bender
-  PYTHON: /home/fischeti/micromamba/envs/floo/bin/python
 
 stages:
   - init
@@ -23,20 +22,9 @@ collect-bender-sources:
       - .bender/
       - Bender.lock
 
-python-virtualenv:
-  stage: init
-  script:
-    - $PYTHON -m venv .venv
-    - source .venv/bin/activate
-    - pip install .
-  artifacts:
-    paths:
-      - .venv/
-
 compile-vsim:
   stage: build
   script:
-    - source .venv/bin/activate
     - make compile-sim | tee compile.log 2>&1
     - '! grep "Error: " compile.log'
   needs:

--- a/Makefile
+++ b/Makefile
@@ -79,14 +79,17 @@ FLOOGEN_TPL ?= $(shell find $(FLOOGEN_TPL_DIR) -name "*.mako")
 
 .PHONY: install-floogen pkg-sources sources clean-sources
 
+check-floogen:
+	@which $(FLOOGEN) > /dev/null || (echo "Error: floogen not found. Please install floogen." && exit 1)
+
 install-floogen:
 	@which $(FLOOGEN) > /dev/null || (echo "Installing floogen..." && pip install .)
 
-pkg-sources: install-floogen $(FLOOGEN_PKG_SRC)
+pkg-sources: check-floogen $(FLOOGEN_PKG_SRC)
 $(FLOOGEN_PKG_OUT_DIR)/floo_%_pkg.sv: $(FLOOGEN_CFG_DIR)/%_pkg.yml $(FLOOGEN_TPL)
 	$(FLOOGEN) -c $< --only-pkg --pkg-outdir $(FLOOGEN_PKG_OUT_DIR) $(FLOOGEN_ARGS)
 
-sources: install-floogen
+sources: check-floogen
 	$(FLOOGEN) -c $(FLOOGEN_CFG) -o $(FLOOGEN_OUT_DIR) --pkg-outdir $(FLOOGEN_PKG_OUT_DIR) $(FLOOGEN_ARGS)
 
 clean-sources:
@@ -117,13 +120,13 @@ clean-jobs:
 
 .PHONY: compile-sim run-sim run-sim-batch clean-sim
 
-scripts/compile_vsim.tcl: Bender.yml pkg-sources
+scripts/compile_vsim.tcl: Bender.yml
 	mkdir -p scripts
 	echo 'set ROOT [file normalize [file dirname [info script]]/..]' > scripts/compile_vsim.tcl
 	$(BENDER) script vsim --vlog-arg="$(VLOG_ARGS)" $(BENDER_FLAGS) | grep -v "set ROOT" >> scripts/compile_vsim.tcl
 	echo >> scripts/compile_vsim.tcl
 
-compile-sim: scripts/compile_vsim.tcl
+compile-sim: scripts/compile_vsim.tcl $(FLOOGEN_PKG_SRC)
 	$(VSIM) -64 -c -do "source scripts/compile_vsim.tcl; quit"
 
 run-sim:


### PR DESCRIPTION
`floogen` is not really needed for the RTL simulation as long as the auto-generated packages are up to date. The `floogen` prerequisite was therefore removed in the Makefile.