### PR TITLE
pkg: Use explicit bitwidth for enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - The generation of the unique ID has been changed resp. aligned for 2D meshes to increment Y-first and X-second. This way the address range and ID increment are consistent with each other.
 - Broadcasted input `id_i` in the chimneys should not throw an error anymore in elaboration.
 - The `id_offset` should not be correctly applied in the system address map. Before it resulted in negative coordinates.
+- The `axi_ch_e` types now have an explicit bitwidth. Previously, this caused issues during elaboration since a 32-bit integer was used as a type.
 
 ### Removed
 

--- a/floogen/model/link.py
+++ b/floogen/model/link.py
@@ -46,10 +46,12 @@ class Link(BaseModel, ABC):
             for ch_type, axi_chs in mapping.items():
                 for axi_ch in axi_chs:
                     name = f"{ch_type}_{axi_ch}"
-                    string += f"{snake_to_camel(name)} = {i},\n"
+                    string += f"{snake_to_camel(name)} = TMP_BIT_WIDTH'd{i},\n"
                     i += 1
-        string = f"typedef enum logic [{clog2(i+1)-1}:0]{{" + string
-        string += f"NumAxiChannels = {i}\n}} axi_ch_e;\n"
+        bitwidth = clog2(i+1)
+        string = f"typedef enum logic [{bitwidth-1}:0]{{" + string
+        string = string.replace("TMP_BIT_WIDTH", str(bitwidth))
+        string += f"NumAxiChannels = {bitwidth}'d{i}\n}} axi_ch_e;\n"
         return string
 
     @classmethod

--- a/hw/floo_axi_pkg.sv
+++ b/hw/floo_axi_pkg.sv
@@ -15,12 +15,12 @@ package floo_axi_pkg;
   ////////////////////////
 
   typedef enum logic [2:0] {
-    AxiAw = 0,
-    AxiW = 1,
-    AxiAr = 2,
-    AxiB = 3,
-    AxiR = 4,
-    NumAxiChannels = 5
+    AxiAw = 3'd0,
+    AxiW = 3'd1,
+    AxiAr = 3'd2,
+    AxiB = 3'd3,
+    AxiR = 3'd4,
+    NumAxiChannels = 3'd5
   } axi_ch_e;
 
 

--- a/hw/floo_narrow_wide_pkg.sv
+++ b/hw/floo_narrow_wide_pkg.sv
@@ -15,17 +15,17 @@ package floo_narrow_wide_pkg;
   ////////////////////////
 
   typedef enum logic [3:0] {
-    NarrowAw = 0,
-    NarrowW = 1,
-    NarrowAr = 2,
-    WideAr = 3,
-    NarrowB = 4,
-    NarrowR = 5,
-    WideB = 6,
-    WideAw = 7,
-    WideW = 8,
-    WideR = 9,
-    NumAxiChannels = 10
+    NarrowAw = 4'd0,
+    NarrowW = 4'd1,
+    NarrowAr = 4'd2,
+    WideAr = 4'd3,
+    NarrowB = 4'd4,
+    NarrowR = 4'd5,
+    WideB = 4'd6,
+    WideAw = 4'd7,
+    WideW = 4'd8,
+    WideR = 4'd9,
+    NumAxiChannels = 4'd10
   } axi_ch_e;
 
 


### PR DESCRIPTION
This was initially the case, but during refactoring got lost. This caused issues in the elaboration when a 32-bit type is used for `axi_ch_e`.