### PR TITLE
hw: Minor fix for verilator compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Broadcasted input `id_i` in the chimneys should not throw an error anymore in elaboration.
 - The `id_offset` should not be correctly applied in the system address map. Before it resulted in negative coordinates.
 - The `axi_ch_e` types now have an explicit bitwidth. Previously, this caused issues during elaboration since a 32-bit integer was used as a type.
+- Fixed a typedef in `floo_vc_arbiter` when setting `NumVirtChannels` to 1, that caused issue when compiling with Verilator.
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ scripts/compile_vsim.tcl: Bender.yml
 	$(BENDER) script vsim --vlog-arg="$(VLOG_ARGS)" $(BENDER_FLAGS) | grep -v "set ROOT" >> scripts/compile_vsim.tcl
 	echo >> scripts/compile_vsim.tcl
 
-compile-sim: scripts/compile_vsim.tcl $(FLOOGEN_PKG_SRC)
+compile-sim: scripts/compile_vsim.tcl
 	$(VSIM) -64 -c -do "source scripts/compile_vsim.tcl; quit"
 
 run-sim:

--- a/hw/floo_vc_arbiter.sv
+++ b/hw/floo_vc_arbiter.sv
@@ -23,14 +23,13 @@ module floo_vc_arbiter import floo_pkg::*;
   output flit_t [NumPhysChannels-1:0] data_o
 );
 
-  typedef logic [$clog2(NumVirtChannels)-1:0] arb_idx_t;
+if (NumVirtChannels == NumPhysChannels) begin : gen_virt_eq_phys
+  assign valid_o = valid_i;
+  assign ready_o = ready_i;
+  assign data_o  = data_i;
+end else if (NumPhysChannels == 1) begin : gen_single_phys
 
-  if (NumVirtChannels == NumPhysChannels) begin : gen_virt_eq_phys
-    assign valid_o = valid_i;
-    assign ready_o = ready_i;
-    assign data_o  = data_i;
-  end else if (NumPhysChannels == 1) begin : gen_single_phys
-
+    typedef logic [$clog2(NumVirtChannels)-1:0] arb_idx_t;
     arb_idx_t vc_arb_idx;
 
     logic [NumVirtChannels-1:0] vc_arb_req_in;


### PR DESCRIPTION
Fixes a typedef in `floo_vc_arbiter` when setting `NumVirtChannels` to 1, that caused issue when compiling with Verilator.