### PR TITLE
hw: Support downstream multi-ID in chimneys 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 
 - Support for source-based routing algorithm in routers, chimnyes and `floogen`. The route is encoded in the header as a `route_t` field, and each router consumes a couple of bits to determine the output ports. In the chimney, a two-stage encoder was added to first determine the destination ID of the request, and then retrive the pre-computed route to that destination from a table. The `floogen` configuration was extended to support the new routing algorithm, and it will also generate the necessary tables for the chimneys.
+- Chimneys now support multiple AXI IDs for non-atomic transactions by specifying the `MaxUniqueids` parameter. This will mitigate ordering of transactions from initially different IDs or endpoints at the expense of some complexity in the `meta_buffer` which then uses `id_queue` to store the meta information required to return responses.
+- The conversion from req/rsp with different ID widths from/to NoC has been moved from the chimneys to the `floo_meta_buffer` module.
 
 ### Changed
 

--- a/hw/floo_axi_chimney.sv
+++ b/hw/floo_axi_chimney.sv
@@ -30,6 +30,9 @@ module floo_axi_chimney
   parameter int unsigned MaxAtomicTxns      = 1,
   /// ID address offset for ID routing
   parameter int unsigned MaxTxns            = 32,
+  /// The number of unique IDs that can be used to send out
+  /// requests
+  parameter int unsigned MaxUniqueIds       = 1,
   /// Maximum number of outstanding requests per ID
   parameter int unsigned MaxTxnsPerId       = MaxTxns,
   /// Type of the narrow reorder buffer
@@ -107,10 +110,8 @@ module floo_axi_chimney
   floo_rsp_generic_flit_t unpack_rsp_generic;
 
   // Meta Buffer
-  axi_in_req_t axi_meta_buf_req_in, axi_meta_buf_req_out;
-  axi_in_rsp_t axi_meta_buf_rsp_in, axi_meta_buf_rsp_out;
-  `AXI_ASSIGN_REQ_STRUCT(axi_out_req_o, axi_meta_buf_req_out)
-  `AXI_ASSIGN_RESP_STRUCT(axi_meta_buf_rsp_in, axi_out_rsp_i)
+  axi_in_req_t axi_meta_buf_req_in;
+  axi_in_rsp_t axi_meta_buf_rsp_out;
 
   // Flit arbitration
   typedef enum logic {SelAw, SelW} aw_w_sel_e;
@@ -615,21 +616,22 @@ module floo_axi_chimney
   if (EnSbrPort) begin : gen_mgr_port
     floo_meta_buffer #(
       .MaxTxns        ( MaxTxns       ),
+      .MaxUniqueIds   ( MaxUniqueIds  ),
       .AtopSupport    ( AtopSupport   ),
       .MaxAtomicTxns  ( MaxAtomicTxns ),
       .buf_t          ( id_out_buf_t  ),
-      .IdInWidth      ( AxiInIdWidth  ),
-      .IdOutWidth     ( AxiOutIdWidth ),
-      .axi_req_t      ( axi_in_req_t  ),
-      .axi_rsp_t      ( axi_in_rsp_t  )
+      .axi_in_req_t   ( axi_in_req_t  ),
+      .axi_in_rsp_t   ( axi_in_rsp_t  ),
+      .axi_out_req_t  ( axi_out_req_t ),
+      .axi_out_rsp_t  ( axi_out_rsp_t )
     ) i_floo_meta_buffer (
       .clk_i,
       .rst_ni,
       .test_enable_i,
       .axi_req_i  ( axi_meta_buf_req_in   ),
       .axi_rsp_o  ( axi_meta_buf_rsp_out  ),
-      .axi_req_o  ( axi_meta_buf_req_out  ),
-      .axi_rsp_i  ( axi_meta_buf_rsp_in   ),
+      .axi_req_o  ( axi_out_req_o         ),
+      .axi_rsp_i  ( axi_out_rsp_i         ),
       .aw_buf_i   ( aw_out_data_in        ),
       .ar_buf_i   ( ar_out_data_in        ),
       .r_buf_o    ( ar_out_data_out       ),
@@ -649,7 +651,7 @@ module floo_axi_chimney
       .slv_resp_o ( axi_meta_buf_rsp_out  )
     );
 
-    assign axi_meta_buf_req_out = '0;
+    assign axi_out_req_o = '0;
     assign ar_out_data_out = '0;
     assign aw_out_data_out = '0;
   end

--- a/hw/floo_axi_chimney.sv
+++ b/hw/floo_axi_chimney.sv
@@ -6,7 +6,6 @@
 
 `include "common_cells/registers.svh"
 `include "common_cells/assertions.svh"
-`include "axi/assign.svh"
 
 /// A bidirectional network interface for connecting AXI4 Buses to the NoC
 module floo_axi_chimney

--- a/hw/floo_meta_buffer.sv
+++ b/hw/floo_meta_buffer.sv
@@ -6,6 +6,7 @@
 
 `include "common_cells/registers.svh"
 `include "common_cells/assertions.svh"
+`include "axi/assign.svh"
 
 /// Queue to buffer meta information in the requests
 /// that need to be stored until the response arrives.
@@ -14,44 +15,42 @@ module floo_meta_buffer #(
   /// Maximum number of non-atomic outstanding requests
   parameter int MaxTxns       = 32'd0,
   /// Number of unique non-atomic IDs
-  parameter int MaxUniqueIDs  = 32'd1,
+  parameter int MaxUniqueIds  = 32'd1,
   /// Enable support for atomics
   parameter bit AtopSupport   = 1'b1,
   /// Number of outstanding atomic requests
   parameter int MaxAtomicTxns = 32'd1,
+  /// AXI in request channel
+  parameter type axi_in_req_t   = logic,
+  /// AXI in response channel
+  parameter type axi_in_rsp_t   = logic,
+  /// AXI out request channel
+  parameter type axi_out_req_t  = logic,
+  /// AXI out response channel
+  parameter type axi_out_rsp_t  = logic,
   /// Information to be buffered for responses
-  parameter type buf_t        = logic,
-  /// ID width of incoming requests
-  parameter int IdInWidth     = 32'd4,
-  /// ID width of outgoing requests
-  parameter int IdOutWidth    = 32'd2,
-  /// AXI request channel
-  parameter type axi_req_t    = logic,
-  /// AXI response channel
-  parameter type axi_rsp_t    = logic,
-  /// ID type for incoming requests
-  localparam type id_in_t      = logic[IdInWidth-1:0],
-  /// ID type for outgoing responses
-  localparam type id_out_t     = logic[IdOutWidth-1:0],
-  /// Minimum IdWidth
-  localparam int IdMinWidth    = (IdInWidth < IdOutWidth)? IdInWidth : IdOutWidth,
-  /// Minimum ID type
-  localparam type id_t         = logic[IdMinWidth-1:0],
-  /// Constant ID for non-atomic requests
-  localparam id_out_t  NonAtomicId = '1
+  parameter type buf_t          = logic
 ) (
   input  logic clk_i,
   input  logic rst_ni,
   input  logic test_enable_i,
-  input  axi_req_t axi_req_i,
-  output axi_rsp_t axi_rsp_o,
-  output axi_req_t axi_req_o,
-  input  axi_rsp_t axi_rsp_i,
+  input  axi_in_req_t axi_req_i,
+  output axi_in_rsp_t axi_rsp_o,
+  output axi_out_req_t axi_req_o,
+  input  axi_out_rsp_t axi_rsp_i,
   input  buf_t aw_buf_i,
   input  buf_t ar_buf_i,
   output buf_t r_buf_o,
   output buf_t b_buf_o
 );
+
+  // AXI parameters
+  localparam int unsigned IdInWidth = $bits(axi_req_i.aw.id);
+  localparam int unsigned IdOutWidth = $bits(axi_req_o.aw.id);
+  localparam int unsigned IdMinWidth = IdInWidth > IdOutWidth ? IdOutWidth : IdInWidth;
+  typedef logic [IdInWidth-1:0] id_in_t;
+  typedef logic [IdOutWidth-1:0] id_out_t;
+  typedef logic [IdMinWidth-1:0] id_min_t;
 
   logic ar_no_atop_buf_full, aw_no_atop_buf_full;
   logic ar_no_atop_push, aw_no_atop_push;
@@ -62,12 +61,13 @@ module floo_meta_buffer #(
   buf_t no_atop_r_buf, no_atop_b_buf;
   buf_t [MaxAtomicTxns-1:0] atop_r_buf, atop_b_buf;
 
-  id_t no_atop_aw_req_id, no_atop_ar_req_id;
+  id_out_t no_atop_aw_req_id, no_atop_ar_req_id;
 
-  if (MaxUniqueIDs == 1) begin : gen_no_atop_fifos
+  if (MaxUniqueIds == 1) begin : gen_no_atop_fifos
 
-    assign no_atop_aw_req_id = NonAtomicId;
-    assign no_atop_ar_req_id = NonAtomicId;
+    // The ID is set to the constant '1 for non-atomic transactions
+    assign no_atop_aw_req_id = '1;
+    assign no_atop_ar_req_id = '1;
 
     fifo_v3 #(
       .FALL_THROUGH ( 1'b0    ),
@@ -110,58 +110,70 @@ module floo_meta_buffer #(
     logic b_outp_gnt, b_oup_data_valid;
     logic r_outp_gnt, r_oup_data_valid;
 
-    assign no_atop_aw_req_id = NonAtomicId - id_t'(axi_req_i.aw.id);
-    assign no_atop_ar_req_id = NonAtomicId - id_t'(axi_req_i.ar.id);
+    id_out_t no_atop_aw_req_id_in, no_atop_ar_req_id_in;
+
+    // Non-atomic transaction IDs are assigned to the range [MaxAtomicTxns, 2**IdOutWidth-1),
+    // Therefore `MaxAtomicTxns` is added/subtracted to/from the ID to get the original ID
+    assign no_atop_aw_req_id = id_min_t'(MaxAtomicTxns) + id_min_t'(axi_req_i.aw.id);
+    assign no_atop_ar_req_id = id_min_t'(MaxAtomicTxns) + id_min_t'(axi_req_i.ar.id);
+    assign no_atop_aw_req_id_in = axi_rsp_i.b.id - id_min_t'(MaxAtomicTxns);
+    assign no_atop_ar_req_id_in = axi_rsp_i.r.id - id_min_t'(MaxAtomicTxns);
+    `ASSERT_INIT(TooFewIdBits2, MaxAtomicTxns + id_min_t'('1) < 2**IdOutWidth)
+
+    logic aw_no_atop_buf_not_full, ar_no_atop_buf_not_full;
 
     id_queue #(
-      .ID_WIDTH           (IdMinWidth),
-      .CAPACITY           (MaxTxns),
-      .FULL_BW            (1'b0),
-      .data_t             (buf_t)
+      .ID_WIDTH ( IdMinWidth  ),
+      .CAPACITY ( MaxTxns     ),
+      .FULL_BW  ( 1'b1        ),
+      .data_t   ( buf_t       )
     ) i_aw_no_atop_id_queue (
       .clk_i,
       .rst_ni,
-      .inp_id_i        (id_t'(axi_req_i.aw.id)),
-      .inp_data_i      (aw_buf_i),
-      .inp_req_i       (aw_no_atop_push),
-      .inp_gnt_o       (aw_no_atop_buf_full),
-      .exists_data_i   ('0),
-      .exists_mask_i   ('0),
-      .exists_req_i    ('0),
-      .exists_o        (),
-      .exists_gnt_o    (),
-      .oup_id_i        (axi_rsp_i.b.id),
-      .oup_pop_i       (aw_no_atop_pop),
-      .oup_req_i       (axi_rsp_i.b_valid),
-      .oup_data_o      (no_atop_b_buf),
-      .oup_data_valid_o(b_oup_data_valid),
-      .oup_gnt_o       (b_outp_gnt)
+      .inp_id_i         ( id_min_t'(axi_req_i.aw.id)  ),
+      .inp_data_i       ( aw_buf_i                    ),
+      .inp_req_i        ( aw_no_atop_push             ),
+      .inp_gnt_o        ( aw_no_atop_buf_not_full     ),
+      .exists_data_i    ( '0                          ),
+      .exists_mask_i    ( '0                          ),
+      .exists_req_i     ( '0                          ),
+      .exists_o         (                             ),
+      .exists_gnt_o     (                             ),
+      .oup_id_i         ( no_atop_aw_req_id_in        ),
+      .oup_pop_i        ( aw_no_atop_pop              ),
+      .oup_req_i        ( axi_rsp_i.b_valid           ),
+      .oup_data_o       ( no_atop_b_buf               ),
+      .oup_data_valid_o ( b_oup_data_valid            ),
+      .oup_gnt_o        ( b_outp_gnt                  )
     );
 
     id_queue #(
-      .ID_WIDTH           (IdMinWidth),
-      .CAPACITY           (MaxTxns),
-      .FULL_BW            (1'b0),
-      .data_t             (buf_t)
+      .ID_WIDTH ( IdMinWidth  ),
+      .CAPACITY ( MaxTxns     ),
+      .FULL_BW  ( 1'b1        ),
+      .data_t   ( buf_t       )
     ) i_ar_no_atop_id_queue (
       .clk_i,
       .rst_ni,
-      .inp_id_i        (id_t'(axi_req_i.ar.id)),
-      .inp_data_i      (ar_buf_i),
-      .inp_req_i       (ar_no_atop_push),
-      .inp_gnt_o       (ar_no_atop_buf_full),
-      .exists_data_i   ('0),
-      .exists_mask_i   ('0),
-      .exists_req_i    ('0),
-      .exists_o        (),
-      .exists_gnt_o    (),
-      .oup_id_i        (axi_rsp_i.r.id),
-      .oup_pop_i       (ar_no_atop_pop),
-      .oup_req_i       (axi_rsp_i.r_valid),
-      .oup_data_o      (no_atop_b_buf),
-      .oup_data_valid_o(r_oup_data_valid),
-      .oup_gnt_o       (r_oup_gnt)
+      .inp_id_i         ( id_min_t'(axi_req_i.ar.id)  ),
+      .inp_data_i       ( ar_buf_i                    ),
+      .inp_req_i        ( ar_no_atop_push             ),
+      .inp_gnt_o        ( ar_no_atop_buf_not_full     ),
+      .exists_data_i    ( '0                          ),
+      .exists_mask_i    ( '0                          ),
+      .exists_req_i     ( '0                          ),
+      .exists_o         (                             ),
+      .exists_gnt_o     (                             ),
+      .oup_id_i         ( no_atop_ar_req_id_in        ),
+      .oup_pop_i        ( ar_no_atop_pop              ),
+      .oup_req_i        ( axi_rsp_i.r_valid           ),
+      .oup_data_o       ( no_atop_r_buf               ),
+      .oup_data_valid_o ( r_oup_data_valid            ),
+      .oup_gnt_o        ( r_oup_gnt                   )
     );
+
+    assign ar_no_atop_buf_full = !ar_no_atop_buf_not_full;
+    assign aw_no_atop_buf_full = !aw_no_atop_buf_not_full;
 
     `ASSERT(NoBResponseIdQueue, axi_rsp_i.b_valid -> (b_oup_data_valid && b_outp_gnt),
             "Meta data for B response must exist in Id Queue!")
@@ -178,9 +190,9 @@ module floo_meta_buffer #(
   assign aw_no_atop_push = axi_req_o.aw_valid && axi_rsp_i.aw_ready && !is_atop_aw;
   assign aw_no_atop_pop = axi_rsp_o.b_valid && axi_req_i.b_ready && !is_atop_b_rsp;
 
-  assign is_atop_r_rsp = axi_rsp_i.r_valid && axi_rsp_i.r.id > MaxAtomicTxns;
-  assign is_atop_b_rsp = axi_rsp_i.b_valid && axi_rsp_i.b.id > MaxAtomicTxns;
-  `ASSERT(NoAtopSupport, !(!AtopSupport && is_atop_aw),
+  assign is_atop_r_rsp = AtopSupport && axi_rsp_i.r_valid && (axi_rsp_i.r.id < MaxAtomicTxns);
+  assign is_atop_b_rsp = AtopSupport && axi_rsp_i.b_valid && (axi_rsp_i.b.id < MaxAtomicTxns);
+  `ASSERT(NoAtopSupportAw, !(!AtopSupport && is_atop_aw),
           "Atomics not supported, but atomic request received!")
 
   assign r_buf_o = (is_atop_r_rsp && AtopSupport)? atop_r_buf[axi_rsp_i.r.id] : no_atop_r_buf;
@@ -262,25 +274,42 @@ module floo_meta_buffer #(
     end
 
     always_comb begin
-      axi_req_o = axi_req_i;
-      axi_rsp_o = axi_rsp_i;
+      `AXI_SET_REQ_STRUCT(axi_req_o, axi_req_i)
+      `AXI_SET_RESP_STRUCT(axi_rsp_o, axi_rsp_i)
       // Use fixed ID for non-atomic requests and unique ID for atomic requests
       axi_req_o.ar.id = no_atop_ar_req_id;
-      axi_req_o.aw.id = (is_atop_aw && AtopSupport)? atop_req_id : no_atop_aw_req_id;
+      axi_req_o.aw.id = (is_atop_aw)? atop_req_id : no_atop_aw_req_id;
       // Use original, buffered ID again for responses
-      axi_rsp_o.r.id = (is_atop_r_rsp && AtopSupport)?
-                        atop_r_buf[axi_rsp_i.r.id] : no_atop_r_buf.id;
-      axi_rsp_o.b.id = (is_atop_b_rsp && AtopSupport)?
-                        atop_b_buf[axi_rsp_i.b.id] : no_atop_b_buf.id;
+      axi_rsp_o.r.id = (is_atop_r_rsp)? atop_r_buf[axi_rsp_i.r.id] : no_atop_r_buf.id;
+      axi_rsp_o.b.id = (is_atop_b_rsp)? atop_b_buf[axi_rsp_i.b.id] : no_atop_b_buf.id;
       axi_req_o.ar_valid = axi_req_i.ar_valid && !ar_no_atop_buf_full;
       axi_rsp_o.ar_ready = axi_rsp_i.ar_ready && !ar_no_atop_buf_full;
-      axi_req_o.aw_valid = axi_req_i.aw_valid && ((is_atop_aw && AtopSupport)?
+      axi_req_o.aw_valid = axi_req_i.aw_valid && ((is_atop_aw)?
                             !no_atop_id_available : !aw_no_atop_buf_full);
-      axi_rsp_o.aw_ready = axi_rsp_i.aw_ready && ((is_atop_aw && AtopSupport)?
+      axi_rsp_o.aw_ready = axi_rsp_i.aw_ready && ((is_atop_aw)?
                             !no_atop_id_available : !aw_no_atop_buf_full);
+    end
+  end else begin : gen_no_atop_support
+    always_comb begin
+      `AXI_SET_REQ_STRUCT(axi_req_o, axi_req_i)
+      `AXI_SET_RESP_STRUCT(axi_rsp_o, axi_rsp_i)
+      // Use fixed ID for non-atomic requests and unique ID for atomic requests
+      axi_req_o.ar.id = no_atop_ar_req_id;
+      axi_req_o.aw.id = no_atop_aw_req_id;
+      // Use original, buffered ID again for responses
+      axi_rsp_o.r.id = no_atop_r_buf.id;
+      axi_rsp_o.b.id = no_atop_b_buf.id;
+      axi_req_o.ar_valid = axi_req_i.ar_valid && !ar_no_atop_buf_full;
+      axi_rsp_o.ar_ready = axi_rsp_i.ar_ready && !ar_no_atop_buf_full;
+      axi_req_o.aw_valid = axi_req_i.aw_valid && !aw_no_atop_buf_full;
+      axi_rsp_o.aw_ready = axi_rsp_i.aw_ready && !aw_no_atop_buf_full;
     end
   end
 
-  `ASSERT_INIT(InvalidMaxUniqueIDs, MaxUniqueIDs > 0)
+  // Check that `MaxAtomicTxns` is zero if atomics are not supported
+  `ASSERT_INIT(NoAtomicTxns, AtopSupport || (!AtopSupport && (MaxAtomicTxns == 0)))
+  // Multiple outstanding atomics need to use different IDs
+  // Non-atomic transactions all use the same ID
+  `ASSERT_INIT(TooFewIdBits1, MaxUniqueIds + MaxAtomicTxns <= 2**IdOutWidth)
 
 endmodule

--- a/hw/floo_narrow_wide_chimney.sv
+++ b/hw/floo_narrow_wide_chimney.sv
@@ -6,7 +6,6 @@
 
 `include "common_cells/registers.svh"
 `include "common_cells/assertions.svh"
-`include "axi/assign.svh"
 
 /// A bidirectional network interface for connecting narrow & wide AXI Buses to the multi-link NoC
 module floo_narrow_wide_chimney

--- a/hw/tb/tb_floo_narrow_wide_chimney.sv
+++ b/hw/tb/tb_floo_narrow_wide_chimney.sv
@@ -23,6 +23,8 @@ module tb_floo_narrow_wide_chimney;
   localparam int unsigned WideNumWrites = 1000;
 
   localparam bit AtopSupport = 1'b1;
+  localparam int unsigned WideMaxUniqueIds = 2;
+  localparam int unsigned MaxAtomicTxns = 3;
 
   localparam int unsigned NumTargets = 2;
 
@@ -187,11 +189,12 @@ module tb_floo_narrow_wide_chimney;
 
   floo_narrow_wide_chimney #(
     .AtopSupport              ( AtopSupport           ),
-    .MaxAtomicTxns            ( 1                     ),
+    .MaxAtomicTxns            ( MaxAtomicTxns         ),
     .NarrowMaxTxns            ( MaxTxns               ),
     .NarrowMaxTxnsPerId       ( MaxTxnsPerId          ),
     .NarrowReorderBufferSize  ( ReorderBufferSize     ),
     .WideMaxTxns              ( MaxTxns               ),
+    .WideMaxUniqueIds         ( WideMaxUniqueIds      ),
     .WideMaxTxnsPerId         ( MaxTxnsPerId          ),
     .WideReorderBufferSize    ( ReorderBufferSize     ),
     .CutAx                    ( 1'b0                  ),
@@ -221,11 +224,12 @@ module tb_floo_narrow_wide_chimney;
 
   floo_narrow_wide_chimney #(
     .AtopSupport              ( AtopSupport           ),
-    .MaxAtomicTxns            ( 1                     ),
+    .MaxAtomicTxns            ( MaxAtomicTxns         ),
     .NarrowMaxTxns            ( MaxTxns               ),
     .NarrowMaxTxnsPerId       ( MaxTxnsPerId          ),
     .NarrowReorderBufferSize  ( ReorderBufferSize     ),
     .WideMaxTxns              ( MaxTxns               ),
+    .WideMaxUniqueIds         ( WideMaxUniqueIds      ),
     .WideMaxTxnsPerId         ( MaxTxnsPerId          ),
     .WideReorderBufferSize    ( ReorderBufferSize     ),
     .CutAx                    ( 1'b0                  ),


### PR DESCRIPTION
This PR adds support for issuing non-atomic AXI transactions with multiple IDs downstream instead of serializing them by using a single constant ID as it is done now. This feature is mainly useful when the downstream AXI network itself has reordering capabilities, e.g., DDR controller. The cost is that the meta information needed to return responses has to be stored in an `id_queue` instead of a FIFO, which is known to have large complexity.