### PR TITLE
floogen: Add support for single-AXI networks

### DIFF
--- a/.github/workflows/floogen.yml
+++ b/.github/workflows/floogen.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        examples: ["single_cluster", "occamy_mesh", "occamy_tree", "occamy_mesh_src", "terapool"]
+        examples: ["single_cluster", "occamy_mesh_xy", "occamy_tree", "occamy_mesh_src", "terapool"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/Bender.yml
+++ b/Bender.yml
@@ -38,6 +38,8 @@ sources:
   - hw/floo_axi_chimney.sv
   - hw/floo_nw_chimney.sv
   - hw/floo_router.sv
+  # Level 3 (Wrappers)
+  - hw/floo_axi_router.sv
   - hw/floo_nw_router.sv
 
   - target: vc_router

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - The `RouteCfg` describes all the necessary routing information parameters required by the chimneys.
   - The `ChimneyCfg` describes all other parameters for the data path of the chimney (e.g. Mgr/Sbr port enable, number of oustanding transactions, RoB types & sizes, etc.)
 - The `floo_test_pkg` now defines default configurations for all the new configuration structs that are used by the testbenches.
+- Add `floo_axi_router` module, which is a wrapper similar to the `floo_nw_router` but for single-AXI configurations, and can be used in conjunction with `floo_axi_chimney`.
 
 #### FlooGen
 - The `data_width` and `user_width` fields for `protocols` are now also validated to be compatible with each other.
 - All the various `*Cfg`'s is now rendered by _FlooGen_, either in the `*_noc_pkg` or in the `*_noc` module itself.
+- Added support for single-AXI configuration networks.
 
 ### Changed
 
@@ -42,6 +44,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - The `direction` field in the `protocol` schema is no longer required, since the direction is determined when specifying `mgr_port_protocol` and `sbr_port_protocol`.
   - The `name` field must be unique now, since it is used by `mgr_port_protocol` and `sbr_port_protocol` to reference the exact protocol.
   - All examples were adapted to reflect those changes.
+- A FlooGen configuration file now requires a `network_type` field, to determine the type of network to generate. The options are `axi` for single-AXI networks and `narrow-wide` for the narrow-wide AXI configurations.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -162,16 +162,14 @@ The following example shows the configuration for a simple mesh topology with 4x
     use_id_table: true
 
   protocols:
-    - name: "example_axi"
+    - name: "axi_in"
       type: "AXI4"
-      direction: "manager"
       data_width: 64
       addr_width: 32
       id_width: 3
       user_width: 1
-    - name: "example_axi"
+    - name: "axi_out"
       type: "AXI4"
-      direction: "subordinate"
       data_width: 64
       addr_width: 32
       id_width: 3
@@ -184,9 +182,9 @@ The following example shows the configuration for a simple mesh topology with 4x
         base: 0x1000_0000
         size: 0x0004_0000
       mgr_port_protocol:
-        - "example_axi"
+        - "axi_in"
       sbr_port_protocol:
-        - "example_axi"
+        - "axi_out"
 
   routers:
     - name: "router"

--- a/docs/floogen.md
+++ b/docs/floogen.md
@@ -84,7 +84,6 @@ The protocols section describes the protocols used in the network. It is compose
 
 - `name`: name of the protocol. This will be used as a reference in the framework and in the generated RTL code to name the protocol module and the protocol signals. If the narrow-wide channels are used, they need to be named `narrow` and `wide` respectively.
 - `type`: Currently only `AXI4` is supported
-- `direction`: the direction of the protocol. It can be either `manager` or `subordinate`. If an endpoint is both manager and subordinate, two protocols need to be defined.
 - `data_width`: the data width of the protocol
 - `addr_width`: the address width of the protocol
 - `id_width`: the ID width of the protocol. Endpoints with different ID widths for the `manager` and `subordinate` protocols are supported.
@@ -157,7 +156,5 @@ where `<config_file>` is the configuration file and `<output_dir>` is the output
 Apart from the configuration file, `floogen` supports additional options to customize the generated RTL code. The following options are supported:
 
 - `--outdir`: the output directory where the generated RTL code will be placed. This is equivalent to the `-o` option. If it is not specified, the output is printed to stdout.
-- `--only-pkg`: only generate the package. This is useful if you want to test single IPs without generating a whole network.
-- `--pkg-outdir`: the output directory where the generated package will be placed. By default, the package in the `hw` folder is overwitten, since it is also the once that is used by `bender` for compiling the IPs. If you want to keep the original package, you can specify a different output directory here.
 - `--no-format`: do not format the generated RTL code. By default, the generated RTL code is formatted with verible format, for which the `verible-verilog-format` binary needs to be installed. If this option is set, the generated RTL code is not formatted.
 - `--visualize`: visualize the generated network. It will create a plot of the graph of the network. If the `--outdir` option is specified, the plot is saved in the output directory. Otherwise, it is shown in a window. This is mainly intended for a quick check of the generated network, not a tool for debugging.

--- a/docs/floogen.md
+++ b/docs/floogen.md
@@ -16,16 +16,14 @@ The following is an example of a configuration file for a 4x4 mesh network:
     use_id_table: true
 
   protocols:
-    - name: "example_axi"
+    - name: "axi_in"
       type: "AXI4"
-      direction: "manager"
       data_width: 64
       addr_width: 32
       id_width: 3
       user_width: 1
-    - name: "example_axi"
+    - name: "axi_out"
       type: "AXI4"
-      direction: "subordinate"
       data_width: 64
       addr_width: 32
       id_width: 3
@@ -38,9 +36,9 @@ The following is an example of a configuration file for a 4x4 mesh network:
         base: 0x1000_0000
         size: 0x0004_0000
       mgr_port_protocol:
-        - "example_axi"
+        - "axi_in"
       sbr_port_protocol:
-        - "example_axi"
+        - "axi_out"
 
   routers:
     - name: "router"

--- a/floogen/examples/axi_mesh_id.yml
+++ b/floogen/examples/axi_mesh_id.yml
@@ -1,0 +1,81 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: axi_mesh
+description: "AXI mesh configuration for FlooGen"
+network_type: "axi"
+
+routing:
+  route_algo: "ID"
+  use_id_table: true
+
+protocols:
+  - name: "axi_in"
+    protocol: "AXI4"
+    data_width: 64
+    addr_width: 48
+    id_width: 4
+    user_width: 1
+    type_prefix: # prevents `axi_axi` prefix
+  - name: "axi_out"
+    protocol: "AXI4"
+    data_width: 64
+    addr_width: 48
+    id_width: 2
+    user_width: 1
+    type_prefix: # prevents `axi_axi` prefix
+
+endpoints:
+  - name: "cluster"
+    array: [4, 4]
+    addr_range:
+      base: 0x0000_1000_0000
+      size: 0x0000_0004_0000
+    mgr_port_protocol:
+      - "axi_in"
+    sbr_port_protocol:
+      - "axi_out"
+  - name: "hbm"
+    array: [4]
+    addr_range:
+      base: 0x0000_8000_0000
+      size: 0x0000_4000_0000
+    sbr_port_protocol:
+      - "axi_out"
+  - name: "peripherals"
+    addr_range:
+      start: 0x0000_0000_0000
+      end: 0x0000_0fff_ffff
+    mgr_port_protocol:
+      - "axi_in"
+    sbr_port_protocol:
+      - "axi_out"
+
+routers:
+  - name: "router"
+    array: [4, 4]
+    degree: 5
+
+connections:
+  - src: "cluster"
+    dst: "router"
+    src_range:
+    - [0, 3]
+    - [0, 3]
+    dst_range:
+    - [0, 3]
+    - [0, 3]
+    dst_dir: "Eject"
+  - src: "hbm"
+    dst: "router"
+    src_range:
+    - [0, 3]
+    dst_range:
+    - [0, 0]
+    - [0, 3]
+    dst_dir: "West"
+  - src: "peripherals"
+    dst: "router"
+    dst_idx: [1, 3]
+    dst_dir: "North"

--- a/floogen/examples/axi_mesh_src.yml
+++ b/floogen/examples/axi_mesh_src.yml
@@ -1,0 +1,81 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: axi_mesh
+description: "AXI mesh configuration for FlooGen"
+network_type: "axi"
+
+routing:
+  route_algo: "SRC"
+  use_id_table: true
+
+protocols:
+  - name: "axi_in"
+    protocol: "AXI4"
+    data_width: 64
+    addr_width: 48
+    id_width: 4
+    user_width: 1
+    type_prefix: # prevents `axi_axi` prefix
+  - name: "axi_out"
+    protocol: "AXI4"
+    data_width: 64
+    addr_width: 48
+    id_width: 2
+    user_width: 1
+    type_prefix: # prevents `axi_axi` prefix
+
+endpoints:
+  - name: "cluster"
+    array: [4, 4]
+    addr_range:
+      base: 0x0000_1000_0000
+      size: 0x0000_0004_0000
+    mgr_port_protocol:
+      - "axi_in"
+    sbr_port_protocol:
+      - "axi_out"
+  - name: "hbm"
+    array: [4]
+    addr_range:
+      base: 0x0000_8000_0000
+      size: 0x0000_4000_0000
+    sbr_port_protocol:
+      - "axi_out"
+  - name: "peripherals"
+    addr_range:
+      start: 0x0000_0000_0000
+      end: 0x0000_0fff_ffff
+    mgr_port_protocol:
+      - "axi_in"
+    sbr_port_protocol:
+      - "axi_out"
+
+routers:
+  - name: "router"
+    array: [4, 4]
+    degree: 5
+
+connections:
+  - src: "cluster"
+    dst: "router"
+    src_range:
+    - [0, 3]
+    - [0, 3]
+    dst_range:
+    - [0, 3]
+    - [0, 3]
+    dst_dir: "Eject"
+  - src: "hbm"
+    dst: "router"
+    src_range:
+    - [0, 3]
+    dst_range:
+    - [0, 0]
+    - [0, 3]
+    dst_dir: "West"
+  - src: "peripherals"
+    dst: "router"
+    dst_idx: [1, 3]
+    dst_dir: "North"

--- a/floogen/examples/axi_mesh_xy.yml
+++ b/floogen/examples/axi_mesh_xy.yml
@@ -1,0 +1,81 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: axi_mesh
+description: "AXI mesh configuration for FlooGen"
+network_type: "axi"
+
+routing:
+  route_algo: "XY"
+  use_id_table: true
+
+protocols:
+  - name: "axi_in"
+    protocol: "AXI4"
+    data_width: 64
+    addr_width: 48
+    id_width: 4
+    user_width: 1
+    type_prefix: # prevents `axi_axi` prefix
+  - name: "axi_out"
+    protocol: "AXI4"
+    data_width: 64
+    addr_width: 48
+    id_width: 2
+    user_width: 1
+    type_prefix: # prevents `axi_axi` prefix
+
+endpoints:
+  - name: "cluster"
+    array: [4, 4]
+    addr_range:
+      base: 0x0000_1000_0000
+      size: 0x0000_0004_0000
+    mgr_port_protocol:
+      - "axi_in"
+    sbr_port_protocol:
+      - "axi_out"
+  - name: "hbm"
+    array: [4]
+    addr_range:
+      base: 0x0000_8000_0000
+      size: 0x0000_4000_0000
+    sbr_port_protocol:
+      - "axi_out"
+  - name: "peripherals"
+    addr_range:
+      start: 0x0000_0000_0000
+      end: 0x0000_0fff_ffff
+    mgr_port_protocol:
+      - "axi_in"
+    sbr_port_protocol:
+      - "axi_out"
+
+routers:
+  - name: "router"
+    array: [4, 4]
+    degree: 5
+
+connections:
+  - src: "cluster"
+    dst: "router"
+    src_range:
+    - [0, 3]
+    - [0, 3]
+    dst_range:
+    - [0, 3]
+    - [0, 3]
+    dst_dir: "Eject"
+  - src: "hbm"
+    dst: "router"
+    src_range:
+    - [0, 3]
+    dst_range:
+    - [0, 0]
+    - [0, 3]
+    dst_dir: "West"
+  - src: "peripherals"
+    dst: "router"
+    dst_idx: [1, 3]
+    dst_dir: "North"

--- a/floogen/examples/occamy_mesh_src.yml
+++ b/floogen/examples/occamy_mesh_src.yml
@@ -4,6 +4,7 @@
 
 name: occamy_mesh_src
 description: "Occamy mesh configuration for FlooGen with source-based routing"
+network_type: "narrow-wide"
 
 routing:
   route_algo: "SRC"

--- a/floogen/examples/occamy_mesh_xy.yml
+++ b/floogen/examples/occamy_mesh_xy.yml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-name: occamy_mesh
+name: occamy_mesh_xy
 description: "Occamy mesh configuration for FlooGen"
 network_type: "narrow-wide"
 

--- a/floogen/examples/occamy_mesh_xy.yml
+++ b/floogen/examples/occamy_mesh_xy.yml
@@ -4,6 +4,7 @@
 
 name: occamy_mesh
 description: "Occamy mesh configuration for FlooGen"
+network_type: "narrow-wide"
 
 routing:
   route_algo: "XY"

--- a/floogen/examples/occamy_tree.yml
+++ b/floogen/examples/occamy_tree.yml
@@ -4,6 +4,7 @@
 
 name: occamy_tree
 description: "Occamy configuration for FlooGen"
+network_type: "narrow-wide"
 
 routing:
   route_algo: "ID"

--- a/floogen/examples/single_cluster.yml
+++ b/floogen/examples/single_cluster.yml
@@ -4,6 +4,7 @@
 
 name: single_cluster
 description: "Single Cluster Configuration for FlooGen"
+network_type: "narrow-wide"
 
 routing:
   route_algo: "ID"

--- a/floogen/examples/terapool.yml
+++ b/floogen/examples/terapool.yml
@@ -4,6 +4,7 @@
 
 name: terapool
 description: "Terapool AXI NoC"
+network_type: "narrow-wide"
 
 routing:
   route_algo: "SRC"

--- a/floogen/model/link.py
+++ b/floogen/model/link.py
@@ -37,6 +37,41 @@ class Link(BaseModel, ABC):
     def render_ports(self):
         """Declare the ports of the link."""
 
+class AxiLink(Link):
+    """Link class to describe a AxiLink."""
+
+    req_type: ClassVar[str] = "floo_req_t"
+    rsp_type: ClassVar[str] = "floo_rsp_t"
+
+    def req_name(self):
+        """Return the narrow request name."""
+        return f"{self.source}_to_{self.dest}_req"
+
+    def rsp_name(self):
+        """Return the narrow response name."""
+        return f"{self.dest}_to_{self.source}_rsp"
+
+    @classmethod
+    def render_typedefs(cls, axi, cfg):
+        """Render the typedefs of the links."""
+        string = f"`FLOO_TYPEDEF_AXI_CHAN_ALL(axi, req, rsp, {axi}, {cfg}, hdr_t)\n\n"
+        string += "`FLOO_TYPEDEF_AXI_LINK_ALL(req, rsp, req, rsp)\n"
+        return string
+
+    def declare(self):
+        """Declare the link in the generated code."""
+        string = f"{self.req_type} {self.req_name()};\n"
+        string += f"{self.rsp_type} {self.rsp_name()};\n"
+        return string + "\n"
+
+    def render_ports(self, direction="input"):
+        """Declare the ports of the link."""
+        reverse_direction = "output" if direction == "input" else "input"
+        ports = []
+        ports.append(f"{direction} {self.req_type} {self.req_name()}")
+        ports.append(f"{reverse_direction} {self.rsp_type} {self.rsp_name()}")
+        return ports
+
 class NarrowWideLink(Link):
     """Link class to describe a NarrowWidelink."""
 

--- a/floogen/model/network_interface.py
+++ b/floogen/model/network_interface.py
@@ -13,7 +13,7 @@ from mako.lookup import Template
 
 from floogen.model.routing import Id, AddrRange, Routing, RouteMap
 from floogen.model.protocol import AXI4
-from floogen.model.link import NarrowWideLink
+from floogen.model.link import NarrowWideLink, AxiLink
 from floogen.model.endpoint import EndpointDesc
 import floogen.templates
 
@@ -46,6 +46,23 @@ class NetworkInterface(BaseModel):
         """Return true if the network interface is only a manager."""
         return self.endpoint.is_mgr() and not self.endpoint.is_sbr()
 
+
+class AxiNI(NetworkInterface):
+    """ Axi Network Interface class."""
+
+    with as_file(
+        files(floogen.templates).joinpath("floo_axi_chimney.sv.mako")
+    ) as _tpl_path:
+        tpl: ClassVar = Template(filename=str(_tpl_path))
+
+    mgr_port: Optional[AXI4] = None
+    sbr_port: Optional[AXI4] = None
+    mgr_link: AxiLink
+    sbr_link: AxiLink
+
+    def render(self, **kwargs) -> str:
+        """Render the network interface."""
+        return self.tpl.render(ni=self, **kwargs)
 
 class NarrowWideAxiNI(NetworkInterface):
     """ " NarrowWideNI class to describe a narrow-wide network interface."""

--- a/floogen/model/protocol.py
+++ b/floogen/model/protocol.py
@@ -17,7 +17,7 @@ class ProtocolDesc(BaseModel):
     name: str
     description: Optional[str] = ""
     protocol: Annotated[str, StringConstraints(pattern=r"AXI4")]
-    type: Annotated[str, StringConstraints(pattern=r"narrow|wide")]
+    type: Optional[Annotated[str, StringConstraints(pattern=r"narrow|wide")]] = None
     direction: Optional[str] = None
 
 class AXI4(ProtocolDesc):

--- a/floogen/model/router.py
+++ b/floogen/model/router.py
@@ -73,6 +73,18 @@ class Router(BaseModel, ABC):
                              f"outgoing links but should have {self.degree}")
         return self
 
+class AxiRouter(Router):
+    """Router class to describe a single-AXI router"""
+
+    with as_file(
+        files(floogen.templates).joinpath("floo_axi_router.sv.mako")
+    ) as _tpl_path:
+        _tpl: ClassVar = Template(filename=str(_tpl_path))
+
+    def render(self):
+        """Declare the router in the generated code."""
+        return self._tpl.render(router=self) + "\n"
+
 class NarrowWideRouter(Router):
     """Router class to describe a narrow-wide router"""
 

--- a/floogen/templates/floo_axi_chimney.sv.mako
+++ b/floogen/templates/floo_axi_chimney.sv.mako
@@ -1,0 +1,58 @@
+<%! from floogen.utils import snake_to_camel, bool_to_sv %>\
+<% actual_xy_id = ni.id - ni.routing.id_offset if ni.routing.id_offset is not None else ni.id %>\
+<% in_prot = next((prot for prot in noc.protocols if prot.direction == "input"), None) %>\
+<% out_prot = next((prot for prot in noc.protocols if prot.direction == "output"), None) %>\
+
+floo_axi_chimney  #(
+  .AxiCfg(AxiCfg),
+  .ChimneyCfg(set_ports(ChimneyDefaultCfg, ${bool_to_sv(ni.sbr_port != None)}, ${bool_to_sv(ni.mgr_port != None)})),
+  .RouteCfg(RouteCfg),
+  .id_t(id_t),
+  .rob_idx_t(rob_idx_t),
+% if ni.routing.route_algo.value == 'SourceRouting':
+  .route_t (route_t),
+  .dst_t   (route_t),
+% endif
+  .hdr_t  (hdr_t),
+  .sam_rule_t(sam_rule_t),
+  .Sam(Sam),
+  .axi_in_req_t(${in_prot.type_name()}_req_t),
+  .axi_in_rsp_t(${in_prot.type_name()}_rsp_t),
+  .axi_out_req_t(${out_prot.type_name()}_req_t),
+  .axi_out_rsp_t(${out_prot.type_name()}_rsp_t),
+  .floo_req_t(floo_req_t),
+  .floo_rsp_t(floo_rsp_t)
+) ${ni.name} (
+  .clk_i,
+  .rst_ni,
+  .test_enable_i,
+  .sram_cfg_i ( '0 ),
+% if ni.mgr_port is not None:
+  .axi_in_req_i  ( ${ni.mgr_port.req_name(port=True, idx=True)} ),
+  .axi_in_rsp_o  ( ${ni.mgr_port.rsp_name(port=True, idx=True)} ),
+% else:
+  .axi_in_req_i  ( '0 ),
+  .axi_in_rsp_o  (    ),
+% endif
+% if ni.sbr_port is not None:
+  .axi_out_req_o ( ${ni.sbr_port.req_name(port=True, idx=True)} ),
+  .axi_out_rsp_i ( ${ni.sbr_port.rsp_name(port=True, idx=True)} ),
+% else:
+  .axi_out_req_o (    ),
+  .axi_out_rsp_i ( '0 ),
+% endif
+% if ni.routing.route_algo.value == 'XYRouting':
+  .id_i             ( ${actual_xy_id.render()}    ),
+% else:
+  .id_i             ( id_t'(${ni.id.render()}) ),
+% endif
+% if ni.routing.route_algo.value == 'SourceRouting':
+  .route_table_i    ( RoutingTables[${snake_to_camel(ni.name)}]  ),
+% else:
+  .route_table_i    ( '0                          ),
+% endif
+  .floo_req_o       ( ${ni.mgr_link.req_name()}   ),
+  .floo_rsp_i       ( ${ni.mgr_link.rsp_name()}   ),
+  .floo_req_i       ( ${ni.sbr_link.req_name()}   ),
+  .floo_rsp_o       ( ${ni.sbr_link.rsp_name()}   )
+);

--- a/floogen/templates/floo_axi_router.sv.mako
+++ b/floogen/templates/floo_axi_router.sv.mako
@@ -1,0 +1,80 @@
+<%!
+    from floogen.model.routing import XYDirections, RouteAlgo
+%>\
+<% def camelcase(s):
+  return ''.join(x.capitalize() or '_' for x in s.split('_'))
+%>\
+<% req_type = next(d for d in router.incoming if d is not None).req_type %>\
+<% rsp_type = next(d for d in router.incoming if d is not None).rsp_type %>\
+% if router.route_algo == RouteAlgo.ID:
+${router.table.render()}
+% endif
+
+${req_type} [${len(router.incoming)-1}:0] ${router.name}_req_in;
+${rsp_type} [${len(router.incoming)-1}:0] ${router.name}_rsp_out;
+${req_type} [${len(router.outgoing)-1}:0] ${router.name}_req_out;
+${rsp_type} [${len(router.outgoing)-1}:0] ${router.name}_rsp_in;
+
+% for i, link in enumerate(router.incoming):
+  % if link is not None:
+    assign ${router.name}_req_in[${i}] = ${link.req_name()};
+  % else:
+    assign ${router.name}_req_in[${i}] = '0;
+  % endif
+% endfor
+
+% for i, link in enumerate(router.incoming):
+  % if link is not None:
+    assign ${link.rsp_name()} = ${router.name}_rsp_out[${i}];
+  % endif
+% endfor
+
+% for i, link in enumerate(router.outgoing):
+  % if link is not None:
+    assign ${link.req_name()} = ${router.name}_req_out[${i}];
+  % endif
+% endfor
+
+% for i, link in enumerate(router.outgoing):
+  % if link is not None:
+    assign ${router.name}_rsp_in[${i}] = ${link.rsp_name()};
+  % else:
+    assign ${router.name}_rsp_in[${i}] = '0;
+  % endif
+% endfor
+
+floo_axi_router #(
+  .AxiCfg(AxiCfg),
+  .RouteAlgo (${router.route_algo.value}),
+  .NumRoutes (${router.degree}),
+  .NumInputs (${len(router.incoming)}),
+  .NumOutputs (${len(router.outgoing)}),
+  .InFifoDepth (2),
+  .OutFifoDepth (2),
+  .id_t(id_t),
+  .hdr_t(hdr_t),
+% if router.route_algo == RouteAlgo.ID:
+  .NumAddrRules (${len(router.table.rules)}),
+  .addr_rule_t (${router.name}_map_rule_t),
+% endif
+  .floo_req_t(floo_req_t),
+  .floo_rsp_t(floo_rsp_t)
+) ${router.name} (
+  .clk_i,
+  .rst_ni,
+  .test_enable_i,
+% if router.route_algo == RouteAlgo.XY:
+  .id_i (${router.id.render()}),
+% else:
+  .id_i ('0),
+% endif
+% if router.route_algo == RouteAlgo.ID:
+  .id_route_map_i (${camelcase(router.name + "_map")}),
+% else:
+  .id_route_map_i ('0),
+% endif
+  .floo_req_i (${router.name}_req_in),
+  .floo_rsp_o (${router.name}_rsp_out),
+  .floo_req_o (${router.name}_req_out),
+  .floo_rsp_i (${router.name}_rsp_in)
+);

--- a/hw/floo_axi_router.sv
+++ b/hw/floo_axi_router.sv
@@ -1,0 +1,153 @@
+// Copyright 2023 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Tim Fischer <fischeti@iis.ee.ethz.ch>
+
+`include "axi/typedef.svh"
+`include "floo_noc/typedef.svh"
+
+/// Wrapper of a multi-link router for single-AXI links
+module floo_axi_router #(
+  /// Config of the AXI interfaces (see floo_pkg::axi_cfg_t for details)
+  parameter floo_pkg::axi_cfg_t AxiCfg        = '0,
+  /// Routing algorithm
+  parameter floo_pkg::route_algo_e RouteAlgo  = floo_pkg::XYRouting,
+  /// Number of input/output ports
+  parameter int unsigned NumRoutes            = 0,
+  /// Number of input ports
+  parameter int unsigned NumInputs            = NumRoutes,
+  /// Number of output ports
+  parameter int unsigned NumOutputs           = NumRoutes,
+  /// Input buffer depth
+  parameter int unsigned InFifoDepth          = 0,
+  /// Output buffer depth
+  parameter int unsigned OutFifoDepth         = 0,
+  /// Disable illegal connections in router
+  /// (only applies for `RouteAlgo == XYRouting`)
+  parameter bit          XYRouteOpt           = 1'b1,
+  /// Node ID type
+  parameter type id_t                         = logic,
+  /// Header type
+  parameter type hdr_t                        = logic,
+  /// Number of rules in the route table
+  /// (only used for `RouteAlgo == IdTable`)
+  parameter int unsigned NumAddrRules         = 0,
+  /// Address rule type
+  /// (only used for `RouteAlgo == IdTable`)
+  parameter type addr_rule_t                  = logic,
+  /// Floo `req` link type
+  parameter type floo_req_t                   = logic,
+  /// Floo `rsp` link type
+  parameter type floo_rsp_t                   = logic
+) (
+  input  logic   clk_i,
+  input  logic   rst_ni,
+  input  logic   test_enable_i,
+  /// Coordinate of the current node
+  /// (only used for `RouteAlgo == XYRouting`)
+  input  id_t id_i,
+  /// Routing table
+  /// (only used for `RouteAlgo == IdTable`)
+  input  addr_rule_t [NumAddrRules-1:0] id_route_map_i,
+  /// Input and output links
+  input   floo_req_t [NumInputs-1:0] floo_req_i,
+  input   floo_rsp_t [NumOutputs-1:0] floo_rsp_i,
+  output  floo_req_t [NumOutputs-1:0] floo_req_o,
+  output  floo_rsp_t [NumInputs-1:0] floo_rsp_o
+);
+
+  typedef logic [AxiCfg.AddrWidth-1:0] axi_addr_t;
+  typedef logic [AxiCfg.InIdWidth-1:0] axi_in_id_t;
+  typedef logic [AxiCfg.UserWidth-1:0] axi_user_t;
+  typedef logic [AxiCfg.DataWidth-1:0] axi_data_t;
+  typedef logic [AxiCfg.DataWidth/8-1:0] axi_strb_t;
+
+  // (Re-) definitons of `axi_in` and `floo` types, for transport
+  `AXI_TYPEDEF_ALL_CT(axi, axi_req_t, axi_rsp_t, axi_addr_t, axi_in_id_t,
+                      axi_data_t, axi_strb_t, axi_user_t)
+  `FLOO_TYPEDEF_AXI_CHAN_ALL(axi, req, rsp, axi, AxiCfg, hdr_t)
+
+  floo_req_chan_t [NumInputs-1:0] req_in;
+  floo_rsp_chan_t [NumInputs-1:0] rsp_out;
+  floo_req_chan_t [NumOutputs-1:0] req_out;
+  floo_rsp_chan_t [NumOutputs-1:0] rsp_in;
+  logic [NumInputs-1:0] req_valid_in, req_ready_out;
+  logic [NumInputs-1:0] rsp_valid_out, rsp_ready_in;
+  logic [NumOutputs-1:0] req_valid_out, req_ready_in;
+  logic [NumOutputs-1:0] rsp_valid_in, rsp_ready_out;
+
+  for (genvar i = 0; i < NumInputs; i++) begin : gen_chimney_req
+    assign req_valid_in[i] = floo_req_i[i].valid;
+    assign floo_req_o[i].ready = req_ready_out[i];
+    assign req_in[i] = floo_req_i[i].req;
+    assign floo_rsp_o[i].valid = rsp_valid_out[i];
+    assign rsp_ready_in[i] = floo_rsp_i[i].ready;
+    assign floo_rsp_o[i].rsp = rsp_out[i];
+  end
+
+  for (genvar i = 0; i < NumOutputs; i++) begin : gen_chimney_rsp
+    assign floo_req_o[i].valid = req_valid_out[i];
+    assign req_ready_in[i] = floo_req_i[i].ready;
+    assign floo_req_o[i].req = req_out[i];
+    assign rsp_valid_in[i] = floo_rsp_i[i].valid;
+    assign floo_rsp_o[i].ready = rsp_ready_out[i];
+    assign rsp_in[i] = floo_rsp_i[i].rsp;
+  end
+
+  floo_router #(
+    .NumPhysChannels  ( 1                       ),
+    .NumVirtChannels  ( 1                       ),
+    .NumInput         ( NumInputs               ),
+    .NumOutput        ( NumOutputs              ),
+    .flit_t           ( floo_req_generic_flit_t ),
+    .InFifoDepth      ( InFifoDepth             ),
+    .OutFifoDepth     ( OutFifoDepth            ),
+    .RouteAlgo        ( RouteAlgo               ),
+    .XYRouteOpt       ( XYRouteOpt              ),
+    .id_t             ( id_t                    ),
+    .NumAddrRules     ( NumAddrRules            ),
+    .addr_rule_t      ( addr_rule_t             )
+  ) i_req_floo_router (
+    .clk_i,
+    .rst_ni,
+    .test_enable_i,
+    .xy_id_i(id_i),
+    .id_route_map_i,
+    .valid_i        ( req_valid_in  ),
+    .ready_o        ( req_ready_out ),
+    .data_i         ( req_in        ),
+    .valid_o        ( req_valid_out ),
+    .ready_i        ( req_ready_in  ),
+    .data_o         ( req_out       )
+  );
+
+
+  floo_router #(
+    .NumPhysChannels  ( 1                       ),
+    .NumVirtChannels  ( 1                       ),
+    .NumInput         ( NumInputs               ),
+    .NumOutput        ( NumOutputs              ),
+    .InFifoDepth      ( InFifoDepth             ),
+    .OutFifoDepth     ( OutFifoDepth            ),
+    .RouteAlgo        ( RouteAlgo               ),
+    .XYRouteOpt       ( XYRouteOpt              ),
+    .flit_t           ( floo_rsp_generic_flit_t ),
+    .id_t             ( id_t                    ),
+    .NumAddrRules     ( NumAddrRules            ),
+    .addr_rule_t      ( addr_rule_t             )
+  ) i_rsp_floo_router (
+    .clk_i,
+    .rst_ni,
+    .test_enable_i,
+    .xy_id_i(id_i),
+    .id_route_map_i,
+    .valid_i        ( rsp_valid_in  ),
+    .ready_o        ( rsp_ready_out ),
+    .data_i         ( rsp_in        ),
+    .valid_o        ( rsp_valid_out ),
+    .ready_i        ( rsp_ready_in  ),
+    .data_o         ( rsp_out       )
+  );
+
+endmodule


### PR DESCRIPTION
Adds support for generating single-AXI networks with only the `req` and `rsp` channels. The configuration file now needs to have a `network_type` field, which determines whether a single-AXI network is generated (the options are `axi` or `narrow-wide`).