### PR TITLE
floogen: Use unique IDs for endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
   - All examples were adapted to reflect those changes.
 - A FlooGen configuration file now requires a `network_type` field, to determine the type of network to generate. The options are `axi` for single-AXI networks and `narrow-wide` for the narrow-wide AXI configurations.
 - The system address map `Sam` is now sorted correctly and can be indexed with `ep_id_e` values.
+- `id_offset` was renamed to `xy_id_offset`, since this is now only applicable in `XYRouting` networks. An ID offset does not make sense for other types of routing algorithms. The use of `id_offset` is anyway not recommended anymore, since the direction of the connections can be specified in the `connections` schema.
 
 ### Fixed
 

--- a/floogen/model/endpoint.py
+++ b/floogen/model/endpoint.py
@@ -22,7 +22,7 @@ class EndpointDesc(BaseModel):
     description: Optional[str] = ""
     array: Optional[Union[Tuple[int], Tuple[int, int]]] = None
     addr_range: Optional[AddrRange] = None
-    id_offset: Optional[Id] = None
+    xy_id_offset: Optional[Id] = None
     mgr_port_protocol: Optional[List[str]] = None
     sbr_port_protocol: Optional[List[str]] = None
 
@@ -34,7 +34,7 @@ class EndpointDesc(BaseModel):
             return (v,)
         return v
 
-    @field_validator("id_offset", mode="before")
+    @field_validator("xy_id_offset", mode="before")
     @classmethod
     def dict_to_coord_obj(cls, v):
         """Convert dict to Coord object."""

--- a/floogen/model/graph.py
+++ b/floogen/model/graph.py
@@ -87,66 +87,70 @@ class Graph(nx.DiGraph):  # pylint: disable=too-many-public-methods
         """Return whether the edge is a link edge."""
         return self.edges[edge]["type"] == "link"
 
-    def get_nodes(self, filters=None, with_name=False):
+    def get_nodes(self, filters=None, with_obj=True, with_name=False):
         """Filter the nodes from the graph."""
         nodes = self.nodes
         if filters is not None:
             for flt in filters:
                 nodes = list(filter(flt, nodes))
-        if with_name:
+        if with_obj and with_name:
             return [(node, self.get_node_obj(node)) for node in nodes]
-        return [self.get_node_obj(node) for node in nodes]
+        if with_obj:
+            return [self.get_node_obj(node) for node in nodes]
+        return nodes
 
-    def get_edges(self, filters=None, with_name=False):
+    def get_edges(self, filters=None, with_obj=True, with_name=False):
         """Filter the edges from the graph."""
         edges = self.edges
         if filters is not None:
             for flt in filters:
                 edges = list(filter(flt, edges))
-        if with_name:
+        if with_obj and with_name:
             return [(edge, self.get_edge_obj(edge)) for edge in edges]
-        return [self.get_edge_obj(edge) for edge in edges]
+        if with_obj:
+            return [self.get_edge_obj(edge) for edge in edges]
+        return edges
 
-    def get_edges_from(self, node, filters=None, with_name=False):
+    def get_edges_from(self, node, filters=None, with_obj=True, with_name=False):
         """Return the outgoing edges from the node."""
         if filters is None:
             filters = []
         filters = [lambda e: e[0] == node] + filters
-        return self.get_edges(filters=filters, with_name=with_name)
+        return self.get_edges(filters=filters, with_obj=with_obj, with_name=with_name)
 
-    def get_edges_to(self, node, filters=None, with_name=False):
+    def get_edges_to(self, node, filters=None, with_obj=True, with_name=False):
         """Return the incoming edges to the node."""
         if filters is None:
             filters = []
         filters = [lambda e: e[1] == node] + filters
-        return self.get_edges(filters=filters, with_name=with_name)
+        return self.get_edges(filters=filters, with_obj=with_obj, with_name=with_name)
 
-    def get_edges_of(self, node, filters=None, with_name=False):
+    def get_edges_of(self, node, filters=None, with_obj=True, with_name=False):
         """Return the edges of the node."""
         if filters is None:
             filters = []
         filters = [lambda e: node in e] + filters
-        return self.get_edges(filters=filters, with_name=with_name)
+        return self.get_edges(filters=filters, with_obj=with_obj, with_name=with_name)
 
-    def get_ni_nodes(self, with_name=False):
+    def get_ni_nodes(self, with_obj=True, with_name=False):
         """Return the ni nodes."""
-        return self.get_nodes(filters=[self.is_ni_node], with_name=with_name)
+        return self.get_nodes(filters=[self.is_ni_node], with_obj=with_obj, with_name=with_name)
 
-    def get_rt_nodes(self, with_name=False):
+    def get_rt_nodes(self, with_obj=True, with_name=False):
         """Return the router nodes."""
-        return self.get_nodes(filters=[self.is_rt_node], with_name=with_name)
+        return self.get_nodes(filters=[self.is_rt_node], with_obj=with_obj, with_name=with_name)
 
-    def get_ep_nodes(self, with_name=False):
+    def get_ep_nodes(self, with_obj=True, with_name=False):
         """Return the endpoint nodes."""
-        return self.get_nodes(filters=[self.is_ep_node], with_name=with_name)
+        return self.get_nodes(filters=[self.is_ep_node], with_obj=with_obj, with_name=with_name)
 
-    def get_prot_edges(self, with_name=False):
+    def get_prot_edges(self, with_obj=True, with_name=False):
         """Return the protocol edges."""
-        return self.get_edges(filters=[self.is_prot_edge], with_name=with_name)
+        return self.get_edges(filters=[self.is_prot_edge], with_obj=with_obj, with_name=with_name)
 
-    def get_link_edges(self, with_name=False):
+    def get_link_edges(self, with_obj=True, with_name=False):
         """Return the link edges."""
-        return self.get_edges(filters=[self.is_link_edge], with_name=with_name)
+        return self.get_edges(filters=[self.is_link_edge], with_obj=with_obj, with_name=with_name)
 
     def get_nodes_from_range(self, node: str, rng: List[Tuple[int]]):
         """Return the nodes from the range."""

--- a/floogen/model/graph.py
+++ b/floogen/model/graph.py
@@ -287,3 +287,11 @@ class Graph(nx.DiGraph):  # pylint: disable=too-many-public-methods
     def get_node_id(self, node):
         """Return the node id."""
         return self.nodes[node]["id"]
+
+    def get_node_uid(self, node_name=None, node_obj=None):
+        """Return the unique node id."""
+        if node_name is not None:
+            return self.nodes[node_name]["uid"]
+        if node_obj is not None:
+            return self.nodes[node_obj.name]["uid"]
+        raise ValueError("Node name or object not provided")

--- a/floogen/model/graph.py
+++ b/floogen/model/graph.py
@@ -5,6 +5,7 @@
 #
 # Author: Tim Fischer <fischeti@iis.ee.ethz.ch>
 
+import re
 from typing import List, Tuple
 
 import networkx as nx
@@ -286,7 +287,15 @@ class Graph(nx.DiGraph):  # pylint: disable=too-many-public-methods
     def create_unique_ep_id(self, node) -> int:
         """Return the endpoint id."""
         ep_nodes = [name for name, _ in self.get_ep_nodes(with_name=True)]
-        return sorted(ep_nodes).index(node)
+
+        # Custom sorting function: extract numeric part after letters
+        def extract_number(name):
+            match = re.search(r"(\d+)$", name)
+            return int(match.group(1)) if match else -1
+
+        return sorted(
+            ep_nodes, key=lambda name: (re.sub(r"\d+$", "", name), extract_number(name))
+        ).index(node)
 
     def get_node_id(self, node_name=None, node_obj=None):
         """Return the node id."""

--- a/floogen/model/graph.py
+++ b/floogen/model/graph.py
@@ -284,9 +284,13 @@ class Graph(nx.DiGraph):  # pylint: disable=too-many-public-methods
         ep_nodes = [name for name, _ in self.get_ep_nodes(with_name=True)]
         return sorted(ep_nodes).index(node)
 
-    def get_node_id(self, node):
+    def get_node_id(self, node_name=None, node_obj=None):
         """Return the node id."""
-        return self.nodes[node]["id"]
+        if node_name is not None:
+            return self.nodes[node_name]["id"]
+        if node_obj is not None:
+            return self.nodes[node_obj.name]["id"]
+        raise ValueError("Node name or object not provided")
 
     def get_node_uid(self, node_name=None, node_obj=None):
         """Return the unique node id."""

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -720,7 +720,11 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
     def render_ni_tables(self):
         """Render the network interfaces tables in the generated code."""
         string = ""
-        sorted_ni_list = sorted(self.graph.get_ni_nodes(), key=lambda ni: ni.id.id, reverse=True)
+        sorted_ni_list = sorted(
+            self.graph.get_ni_nodes(),
+            key=lambda ni: self.graph.get_node_id(node_obj=ni),
+            reverse=True
+        )
         for ni in sorted_ni_list:
             string += ni.table.render(
                 num_route_bits=self.routing.num_route_bits, no_decl=True)

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -337,8 +337,6 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
             case RouteAlgo.ID | RouteAlgo.SRC:
                 for ep_name, ep in self.graph.get_ep_nodes(with_name=True):
                     node_id = SimpleId(id=self.graph.create_unique_ep_id(ep_name))
-                    if ep.id_offset is not None:
-                        node_id += ep.id_offset
                     ni_name = ep.get_ni_name(ep_name)
                     self.graph.nodes[ep_name]["id"] = node_id
                     self.graph.nodes[ni_name]["id"] = node_id

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -351,7 +351,7 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
 
     def compile_links(self):
         """Infer the link type from the network."""
-        for edge, _ in self.graph.get_link_edges(with_name=True):
+        for edge in self.graph.get_link_edges(with_obj=False, with_name=True):
             # Check if link is bidirectional
             is_bidirectional = self.graph.has_edge(edge[1], edge[0])
             link = {
@@ -759,8 +759,8 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
 
     def visualize(self, savefig=True, filename: pathlib.Path = "network.png"):
         """Visualize the network graph."""
-        ni_nodes = [name for name, _ in self.graph.get_ni_nodes(with_name=True)]
-        router_nodes = [name for name, _ in self.graph.get_rt_nodes(with_name=True)]
+        ni_nodes = self.graph.get_ni_nodes(with_obj=False, with_name=True)
+        router_nodes = self.graph.get_rt_nodes(with_obj=False, with_name=True)
         filtered_graph = self.graph.subgraph(ni_nodes + router_nodes)
         nx.draw(filtered_graph, with_labels=True)
         if savefig:

--- a/floogen/model/network_interface.py
+++ b/floogen/model/network_interface.py
@@ -11,7 +11,7 @@ from importlib.resources import files, as_file
 from pydantic import BaseModel
 from mako.lookup import Template
 
-from floogen.model.routing import Id, AddrRange, Routing, RouteMap
+from floogen.model.routing import Id, SimpleId, AddrRange, Routing, RouteMap
 from floogen.model.protocol import AXI4
 from floogen.model.link import NarrowWideLink, AxiLink
 from floogen.model.endpoint import EndpointDesc
@@ -27,6 +27,7 @@ class NetworkInterface(BaseModel):
     routing: Routing
     table: Optional[RouteMap] = None
     id: Optional[Id] = None
+    uid: Optional[SimpleId] = None
     arr_idx: Optional[Id] = None
     addr_range: Optional[AddrRange] = None
 

--- a/floogen/model/router.py
+++ b/floogen/model/router.py
@@ -26,7 +26,7 @@ class RouterDesc(BaseModel):
     name: str
     array: Optional[Union[Tuple[int], Tuple[int, int]]] = None
     tree: Optional[List[int]] = None
-    id_offset: Optional[Id] = None
+    xy_id_offset: Optional[Id] = None
     auto_connect: Optional[bool] = True
     degree: Optional[int] = None
 

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -440,7 +440,7 @@ class Routing(BaseModel):
     sam: Optional[RouteMap] = None
     table: Optional[RouteMap] = None
     addr_offset_bits: Optional[int] = None
-    id_offset: Optional[Id] = None
+    xy_id_offset: Optional[Id] = None
     num_endpoints: Optional[int] = None
     num_id_bits: Optional[int] = None
     num_x_bits: Optional[int] = None

--- a/floogen/templates/floo_axi_chimney.sv.mako
+++ b/floogen/templates/floo_axi_chimney.sv.mako
@@ -1,5 +1,5 @@
 <%! from floogen.utils import snake_to_camel, bool_to_sv %>\
-<% actual_xy_id = ni.id - ni.routing.id_offset if ni.routing.id_offset is not None else ni.id %>\
+<% actual_xy_id = ni.id - ni.routing.xy_id_offset if ni.routing.xy_id_offset is not None else ni.id %>\
 <% in_prot = next((prot for prot in noc.protocols if prot.direction == "input"), None) %>\
 <% out_prot = next((prot for prot in noc.protocols if prot.direction == "output"), None) %>\
 

--- a/floogen/templates/floo_axi_router.sv.mako
+++ b/floogen/templates/floo_axi_router.sv.mako
@@ -4,7 +4,7 @@
 <% def camelcase(s):
   return ''.join(x.capitalize() or '_' for x in s.split('_'))
 %>\
-<% offset_xy_id = router.id - network.routing.id_offset if network.routing.id_offset is not None else router.id %>\
+<% offset_xy_id = router.id - network.routing.xy_id_offset if network.routing.xy_id_offset is not None else router.id %>\
 <% req_type = next(d for d in router.incoming if d is not None).req_type %>\
 <% rsp_type = next(d for d in router.incoming if d is not None).rsp_type %>\
 % if router.route_algo == RouteAlgo.ID:

--- a/floogen/templates/floo_nw_chimney.sv.mako
+++ b/floogen/templates/floo_nw_chimney.sv.mako
@@ -1,5 +1,5 @@
 <%! from floogen.utils import snake_to_camel, bool_to_sv %>\
-<% actual_xy_id = ni.id - ni.routing.id_offset if ni.routing.id_offset is not None else ni.id %>\
+<% actual_xy_id = ni.id - ni.routing.xy_id_offset if ni.routing.xy_id_offset is not None else ni.id %>\
 <% narrow_in_prot = next((prot for prot in noc.protocols if prot.type == "narrow" and prot.direction == "input"), None) %>\
 <% narrow_out_prot = next((prot for prot in noc.protocols if prot.type == "narrow" and prot.direction == "output"), None) %>\
 <% wide_in_prot = next((prot for prot in noc.protocols if prot.type == "wide" and prot.direction == "input"), None) %>\

--- a/floogen/templates/floo_nw_router.sv.mako
+++ b/floogen/templates/floo_nw_router.sv.mako
@@ -4,7 +4,7 @@
 <% def camelcase(s):
   return ''.join(x.capitalize() or '_' for x in s.split('_'))
 %>\
-<% offset_xy_id = router.id - network.routing.id_offset if network.routing.id_offset is not None else router.id %>\
+<% offset_xy_id = router.id - network.routing.xy_id_offset if network.routing.xy_id_offset is not None else router.id %>\
 <% req_type = next(d for d in router.incoming if d is not None).req_type %>\
 <% rsp_type = next(d for d in router.incoming if d is not None).rsp_type %>\
 <% wide_type = next(d for d in router.incoming if d is not None).wide_type %>\


### PR DESCRIPTION
Before, the unique ID was restricted to the `SourceRouting` and `IdTable` routing algorithm, since it is actually required for routing. The `XYRouting` algorithm used XY coordinates instead.

However, FlooGen creates a SV enum of all endpoints, for which a unique ID is necessary independent of the routing algorithm.

Also fixes the alphanumeric ordering of the endpoints enum.