### PR TITLE
floogen: Support endpoints with multiple non-contiguous address ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - All the various `*Cfg`'s is now rendered by _FlooGen_, either in the `*_noc_pkg` or in the `*_noc` module itself.
 - Added support for single-AXI configuration networks.
 - Support for negative increments when specifying a `src_range` or `dst_range` in the `connections` schema.
+- Add support for multiple non-contiguous address ranges for endpoints.
 
 ### Changed
 

--- a/floogen/examples/terapool.yml
+++ b/floogen/examples/terapool.yml
@@ -51,13 +51,15 @@ endpoints:
     array: [16]
     addr_range:
       base: 0x0000_8000_0000
-      size: 0x0000_4000_0000
+      size: 0x0000_0400_0000
     sbr_port_protocol:
       - "wide_out"
   - name: "peripherals"
     addr_range:
-      start: 0x0000_0000_0000
-      end: 0x0000_0fff_ffff
+      - start: 0x0000_0000_0000
+        end: 0x0000_7fff_ffff
+      - start: 0x0000_C000_0000
+        end: 0x0000_C000_ffff
     mgr_port_protocol:
       - "wide_in"
     sbr_port_protocol:

--- a/floogen/model/endpoint.py
+++ b/floogen/model/endpoint.py
@@ -21,7 +21,7 @@ class EndpointDesc(BaseModel):
     name: str
     description: Optional[str] = ""
     array: Optional[Union[Tuple[int], Tuple[int, int]]] = None
-    addr_range: Optional[AddrRange] = None
+    addr_range: List[AddrRange] = []
     xy_id_offset: Optional[Id] = None
     mgr_port_protocol: Optional[List[str]] = None
     sbr_port_protocol: Optional[List[str]] = None
@@ -43,6 +43,14 @@ class EndpointDesc(BaseModel):
                 return None
             case {"x": x, "y": y}:
                 return Coord(x=x, y=y)
+
+    @field_validator("addr_range", mode="before")
+    @classmethod
+    def addr_range_to_list(cls, v):
+        """Convert single AddrRange to list."""
+        if not isinstance(v, List):
+            return [v]
+        return v
 
     @model_validator(mode="after")
     def check_addr_range(self):

--- a/floogen/model/network_interface.py
+++ b/floogen/model/network_interface.py
@@ -5,7 +5,7 @@
 #
 # Author: Tim Fischer <fischeti@iis.ee.ethz.ch>
 
-from typing import Optional, ClassVar
+from typing import Optional, ClassVar, List
 from importlib.resources import files, as_file
 
 from pydantic import BaseModel
@@ -29,7 +29,7 @@ class NetworkInterface(BaseModel):
     id: Optional[Id] = None
     uid: Optional[SimpleId] = None
     arr_idx: Optional[Id] = None
-    addr_range: Optional[AddrRange] = None
+    addr_range: Optional[List[AddrRange]] = None
 
     def is_sbr(self) -> bool:
         """Return true if the network interface is a subordinate."""

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -207,7 +207,7 @@ class AddrRange(BaseModel):
     def validate_output(self):
         """Validate the address range."""
         if self.start >= self.end:
-            raise ValueError("Invalid address range")
+            raise ValueError("Address range start must be less than end")
         return self
 
     def set_idx(self, idx):


### PR DESCRIPTION
Can be used like this in the configuration file:

```yml
addr_range:
  - start: 0x0000_0000
    end: 0x7fff_ffff
  - start: 0xC000_0000
    end: 0xC000_ffff
```