### PR TITLE
hw: Add AW cuts to chimneys

### DIFF
--- a/Bender.yml
+++ b/Bender.yml
@@ -73,6 +73,7 @@ sources:
       - hw/test/axi_reorder_remap_compare.sv
       - hw/test/axi_bw_monitor.sv
       - hw/test/floo_hbm_model.sv
+      - hw/test/axi_aw_w_sync.sv
       # Level 2
       - hw/tb/tb_floo_axi_chimney.sv
       - hw/tb/tb_floo_nw_chimney.sv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Changed
 
 #### Hardware
+
 - The `floo_narrow_wide_*` modules and the corresponding testbenches were renamed to `floo_nw_*` to be more concise. (https://github.com/pulp-platform/FlooNoC/pull/65)
 - The flit type definitions are now implemented as SystemVerilog macros in `typedef.svh`. (https://github.com/pulp-platform/FlooNoC/pull/65)
 - The parametrization of the chimney modules has changed dramatically. They now use the newly introduced `*Cfg`'s from the `floo_pkg`. In the narrow-wide chimneys, both datapaths now have their own configs (i.e. `*CfgN` and `*CfgW`), to reduce the verbosity of the module instantiation. (https://github.com/pulp-platform/FlooNoC/pull/65)
@@ -39,6 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - The `ReorderBufferSize` parameters was shortened to `RoBSize`. (https://github.com/pulp-platform/FlooNoC/pull/65)
 - All testbenches were adapted to all changes. (https://github.com/pulp-platform/FlooNoC/pull/65)
 - All verification IPs were adapted to the new configuration structs. (https://github.com/pulp-platform/FlooNoC/pull/65)
+  Added spill registers for outgoing AW requests in the chimneys. This is necessary since AXI allows to wait for AW *and* W to be valid before asserting the ready. Since, the AW and W beats are sent over the same channel, this might cause a deadlock if there there are no buffers downstream.
 
 #### FlooGen
 - The link typedefs are now renderd with the macros in `typedef.svh` instead of rendering them in pure SystemVerilog. (https://github.com/pulp-platform/FlooNoC/pull/65)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Routers with `XYRouting` do now use the global `id_offset`, which was previously not accounted for (or had to be specified manually). (https://github.com/pulp-platform/FlooNoC/pull/72)
 - Fixed elaboration errors in the chimneys that occured. (https://github.com/pulp-platform/FlooNoC/pull/75)
 - Fixed Synopsys DC elaboration error due to concatenation in `id_i` port connection of chimneys and routers. (https://github.com/pulp-platform/FlooNoC/pull/103)
+- Undriven signals in `floo_meta_buffer` if `AtopSupport` is disabled.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - The `ReorderBufferSize` parameters was shortened to `RoBSize`. (https://github.com/pulp-platform/FlooNoC/pull/65)
 - All testbenches were adapted to all changes. (https://github.com/pulp-platform/FlooNoC/pull/65)
 - All verification IPs were adapted to the new configuration structs. (https://github.com/pulp-platform/FlooNoC/pull/65)
-  Added spill registers for outgoing AW requests in the chimneys. This is necessary since AXI allows to wait for AW *and* W to be valid before asserting the ready. Since, the AW and W beats are sent over the same channel, this might cause a deadlock if there there are no buffers downstream.
+- Added default spill registers for outgoing AW requests in the chimneys. This is necessary since AXI allows to wait for AW *and* W to be valid before asserting the ready. AW and W beats are sent over the same channel, so this might lead to deadlocks otherwise. (https://github.com/pulp-platform/FlooNoC/pull/89)
 
 #### FlooGen
 - The link typedefs are now renderd with the macros in `typedef.svh` instead of rendering them in pure SystemVerilog. (https://github.com/pulp-platform/FlooNoC/pull/65)
@@ -65,7 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Routers with `XYRouting` do now use the global `id_offset`, which was previously not accounted for (or had to be specified manually). (https://github.com/pulp-platform/FlooNoC/pull/72)
 - Fixed elaboration errors in the chimneys that occured. (https://github.com/pulp-platform/FlooNoC/pull/75)
 - Fixed Synopsys DC elaboration error due to concatenation in `id_i` port connection of chimneys and routers. (https://github.com/pulp-platform/FlooNoC/pull/103)
-- Undriven signals in `floo_meta_buffer` if `AtopSupport` is disabled.
+- Undriven signals in `floo_meta_buffer` if `AtopSupport` is disabled. (https://github.com/pulp-platform/FlooNoC/pull/89)
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ MKFILE_DIR  := $(dir $(MKFILE_PATH))
 
 .PHONY: all clean compile-sim run-sim run-sim-batch
 all: compile-sim
-clean: clean-sim clean-spyglass clean-jobs clean-sources clean-vcs
+clean: clean-vsim clean-spyglass clean-jobs clean-sources clean-vcs
 compile-sim: compile-vsim
 run-sim: run-vsim
 run-sim-batch: run-vsim-batch

--- a/hw/floo_axi_chimney.sv
+++ b/hw/floo_axi_chimney.sv
@@ -86,6 +86,7 @@ module floo_axi_chimney #(
 
   typedef logic [AxiCfg.AddrWidth-1:0] axi_addr_t;
   typedef logic [AxiCfg.InIdWidth-1:0] axi_in_id_t;
+  typedef logic [AxiCfg.OutIdWidth-1:0] axi_out_id_t;
   typedef logic [AxiCfg.UserWidth-1:0] axi_user_t;
   typedef logic [AxiCfg.DataWidth-1:0] axi_data_t;
   typedef logic [AxiCfg.DataWidth/8-1:0] axi_strb_t;
@@ -93,6 +94,7 @@ module floo_axi_chimney #(
   // (Re-) definitons of `axi_in` and `floo` types, for transport
   `AXI_TYPEDEF_ALL_CT(axi, axi_req_t, axi_rsp_t, axi_addr_t, axi_in_id_t,
                       axi_data_t, axi_strb_t, axi_user_t)
+  `AXI_TYPEDEF_AW_CHAN_T(axi_out_aw_chan_t, axi_addr_t, axi_out_id_t, axi_user_t)
   `FLOO_TYPEDEF_AXI_CHAN_ALL(axi, req, rsp, axi, AxiCfg, hdr_t)
 
   // Duplicate AXI port signals to degenerate ports
@@ -138,6 +140,8 @@ module floo_axi_chimney #(
   // Meta Buffer
   axi_req_t meta_buf_req_in;
   axi_rsp_t meta_buf_rsp_out;
+  axi_out_req_t meta_buf_req_out;
+  axi_out_rsp_t meta_buf_rsp_in;
 
   // Flit arbitration
   typedef enum logic {SelAw, SelW} aw_w_sel_e;
@@ -202,6 +206,34 @@ module floo_axi_chimney #(
       assign axi_ar_queue_valid_out = axi_in_req_i.ar_valid;
       assign axi_rsp_out.ar_ready = axi_ar_queue_ready_in;
     end
+
+    logic aw_out_queue_valid, aw_out_queue_ready;
+    axi_out_aw_chan_t axi_aw_queue_out;
+
+    // Since AW and W are transferred over the same link, it can happen that
+    // a downstream module does not accept the AW until the W is valid.
+    // Therefore, we need to add a spill register for the AW channel.
+    spill_register #(
+      .T (axi_out_aw_chan_t)
+    ) i_aw_out_queue (
+      .clk_i    ( clk_i                     ),
+      .rst_ni   ( rst_ni                    ),
+      .valid_i  ( meta_buf_req_out.aw_valid ),
+      .ready_o  ( aw_out_queue_ready        ),
+      .data_i   ( meta_buf_req_out.aw       ),
+      .valid_o  ( aw_out_queue_valid        ),
+      .ready_i  ( axi_out_rsp_i.aw_ready    ),
+      .data_o   ( axi_aw_queue_out          )
+    );
+
+    always_comb begin
+      axi_out_req_o = meta_buf_req_out;
+      axi_out_req_o.aw_valid = aw_out_queue_valid;
+      axi_out_req_o.aw = axi_aw_queue_out;
+      meta_buf_rsp_in = axi_out_rsp_i;
+      meta_buf_rsp_in.aw_ready = aw_out_queue_ready;
+    end
+
   end else begin : gen_err_slv_port
     axi_err_slv #(
       .AxiIdWidth ( AxiCfg.InIdWidth  ),
@@ -663,8 +695,8 @@ module floo_axi_chimney #(
       .test_enable_i,
       .axi_req_i  ( meta_buf_req_in   ),
       .axi_rsp_o  ( meta_buf_rsp_out  ),
-      .axi_req_o  ( axi_out_req_o     ),
-      .axi_rsp_i  ( axi_out_rsp_i     ),
+      .axi_req_o  ( meta_buf_req_out  ),
+      .axi_rsp_i  ( meta_buf_rsp_in   ),
       .aw_buf_i   ( aw_out_hdr_in     ),
       .ar_buf_i   ( ar_out_hdr_in     ),
       .r_buf_o    ( ar_out_hdr_out    ),
@@ -684,7 +716,6 @@ module floo_axi_chimney #(
       .slv_resp_o ( meta_buf_rsp_out  )
     );
 
-    assign axi_out_req_o = '0;
     assign ar_out_hdr_out = '0;
     assign aw_out_hdr_out = '0;
   end

--- a/hw/floo_axi_chimney.sv
+++ b/hw/floo_axi_chimney.sv
@@ -716,7 +716,7 @@ module floo_axi_chimney #(
       .slv_req_i  ( meta_buf_req_in   ),
       .slv_resp_o ( meta_buf_rsp_out  )
     );
-
+    assign meta_buf_req_out = '0;
     assign ar_out_hdr_out = '0;
     assign aw_out_hdr_out = '0;
   end

--- a/hw/floo_meta_buffer.sv
+++ b/hw/floo_meta_buffer.sv
@@ -292,6 +292,10 @@ module floo_meta_buffer #(
                             !no_atop_id_available : !aw_no_atop_buf_full);
     end
   end else begin : gen_no_atop_support
+
+    assign atop_r_buf          = '0;
+    assign atop_b_buf          = '0;
+
     always_comb begin
       `AXI_SET_REQ_STRUCT(axi_req_o, axi_req_i)
       `AXI_SET_RESP_STRUCT(axi_rsp_o, axi_rsp_i)

--- a/hw/floo_nw_chimney.sv
+++ b/hw/floo_nw_chimney.sv
@@ -125,7 +125,8 @@ module floo_nw_chimney #(
   `AXI_TYPEDEF_ALL_CT(axi_wide, axi_wide_req_t, axi_wide_rsp_t, axi_addr_t,
       axi_wide_in_id_t, axi_wide_data_t, axi_wide_strb_t, axi_wide_user_t)
   `AXI_TYPEDEF_AW_CHAN_T(axi_wide_out_aw_chan_t, axi_addr_t, axi_wide_out_id_t, axi_wide_user_t)
-  `AXI_TYPEDEF_AW_CHAN_T(axi_narrow_out_aw_chan_t, axi_addr_t, axi_narrow_out_id_t, axi_narrow_user_t)
+  `AXI_TYPEDEF_AW_CHAN_T(axi_narrow_out_aw_chan_t, axi_addr_t,
+                         axi_narrow_out_id_t, axi_narrow_user_t)
   `FLOO_TYPEDEF_NW_CHAN_ALL(axi, req, rsp, wide, axi_narrow, axi_wide, AxiCfgN, AxiCfgW, hdr_t)
 
   // Duplicate AXI port signals to degenerate ports

--- a/hw/floo_nw_chimney.sv
+++ b/hw/floo_nw_chimney.sv
@@ -1183,7 +1183,7 @@ module floo_nw_chimney #(
       .slv_req_i  ( axi_narrow_meta_buf_req_in  ),
       .slv_resp_o ( axi_narrow_meta_buf_rsp_out )
     );
-    assign axi_narrow_out_req_o = '0;
+    assign axi_narrow_meta_buf_req_out = '0;
     assign narrow_ar_buf_hdr_out = '0;
     assign narrow_aw_buf_hdr_out = '0;
   end
@@ -1227,7 +1227,7 @@ module floo_nw_chimney #(
       .slv_req_i  ( axi_wide_meta_buf_req_in  ),
       .slv_resp_o ( axi_wide_meta_buf_rsp_out )
     );
-    assign axi_wide_out_req_o = '0;
+    assign axi_wide_meta_buf_req_out = '0;
     assign wide_ar_buf_hdr_out = '0;
     assign wide_aw_buf_hdr_out = '0;
   end

--- a/hw/floo_route_select.sv
+++ b/hw/floo_route_select.sv
@@ -150,11 +150,13 @@ if (RouteAlgo == IdTable) begin : gen_id_table
     `FFL(route_sel_q, route_sel, ~locked_route_q, '0)
     `FFL(route_sel_id_q, route_sel_id, ~locked_route_q, '0)
 
-    always @(posedge clk_i) begin
-      if (ready_i && valid_i && locked_route_q &&
-              ((route_sel_id_q != route_sel_id) || (route_sel_q != route_sel)))
-        $warning("Mismatch in route selection!");
-    end
+    `ifndef TARGET_SYNTHESIS
+      always @(posedge clk_i) begin
+        if (ready_i && valid_i && locked_route_q &&
+                ((route_sel_id_q != route_sel_id) || (route_sel_q != route_sel)))
+          $warning("Mismatch in route selection!");
+      end
+    `endif
   end else begin : gen_no_lock
     assign route_sel_o = route_sel;
     assign route_sel_id_o = route_sel_id;

--- a/hw/tb/tb_floo_axi_chimney.sv
+++ b/hw/tb/tb_floo_axi_chimney.sv
@@ -34,15 +34,15 @@ module tb_floo_axi_chimney;
   axi_in_req_t [NumTargets-1:0] node_man_req;
   axi_in_rsp_t [NumTargets-1:0] node_man_rsp;
 
-  axi_out_req_t [NumTargets-1:0] node_sub_req;
-  axi_out_rsp_t [NumTargets-1:0] node_sub_rsp;
+  axi_out_req_t [NumTargets-1:0] node_sub_req, node_sub_req_sync;
+  axi_out_rsp_t [NumTargets-1:0] node_sub_rsp, node_sub_rsp_sync;
 
   axi_in_req_t [NumTargets-1:0] sub_req_id_assign;
   axi_in_rsp_t [NumTargets-1:0] sub_rsp_id_assign;
 
   for (genvar i = 0; i < NumTargets; i++) begin : gen_axi_assign
-    `AXI_ASSIGN_REQ_STRUCT(sub_req_id_assign[i], node_sub_req[i])
-    `AXI_ASSIGN_RESP_STRUCT(sub_rsp_id_assign[i], node_sub_rsp[i])
+    `AXI_ASSIGN_REQ_STRUCT(sub_req_id_assign[i], node_sub_req_sync[i])
+    `AXI_ASSIGN_RESP_STRUCT(sub_rsp_id_assign[i], node_sub_rsp_sync[i])
   end
 
   floo_req_t [NumTargets-1:0] chimney_req;
@@ -83,13 +83,13 @@ module tb_floo_axi_chimney;
     .NumReads       ( NumReads0                   ),
     .NumWrites      ( NumWrites0                  )
   ) i_test_node_0 (
-    .clk_i          ( clk             ),
-    .rst_ni         ( rst_n           ),
-    .mst_port_req_o ( node_man_req[0] ),
-    .mst_port_rsp_i ( node_man_rsp[0] ),
-    .slv_port_req_i ( node_sub_req[0] ),
-    .slv_port_rsp_o ( node_sub_rsp[0] ),
-    .end_of_sim     ( end_of_sim[0]   )
+    .clk_i          ( clk                   ),
+    .rst_ni         ( rst_n                 ),
+    .mst_port_req_o ( node_man_req[0]       ),
+    .mst_port_rsp_i ( node_man_rsp[0]       ),
+    .slv_port_req_i ( node_sub_req_sync[0]  ),
+    .slv_port_rsp_o ( node_sub_rsp_sync[0]  ),
+    .end_of_sim     ( end_of_sim[0]         )
   );
 
   axi_reorder_remap_compare #(
@@ -109,6 +109,18 @@ module tb_floo_axi_chimney;
     .mon_slv_req_i  ( sub_req_id_assign[1]  ),
     .mon_slv_rsp_i  ( sub_rsp_id_assign[1]  ),
     .end_of_sim_o   ( end_of_sim[1]         )
+  );
+
+  axi_aw_w_sync #(
+    .axi_req_t  ( axi_out_req_t ),
+    .axi_resp_t ( axi_out_rsp_t )
+  ) i_axi_aw_w_sync_0 (
+    .clk_i      ( clk                   ),
+    .rst_ni     ( rst_n                 ),
+    .slv_req_i  ( node_sub_req[0]       ),
+    .slv_resp_o ( node_sub_rsp[0]       ),
+    .mst_req_o  ( node_sub_req_sync[0]  ),
+    .mst_resp_i ( node_sub_rsp_sync[0]  )
   );
 
   floo_axi_chimney #(
@@ -173,6 +185,18 @@ module tb_floo_axi_chimney;
     .floo_rsp_i     ( chimney_rsp[0]        )
   );
 
+  axi_aw_w_sync #(
+    .axi_req_t  ( axi_out_req_t ),
+    .axi_resp_t ( axi_out_rsp_t )
+  ) i_axi_aw_w_sync_1 (
+    .clk_i      ( clk                   ),
+    .rst_ni     ( rst_n                 ),
+    .slv_req_i  ( node_sub_req[1]       ),
+    .slv_resp_o ( node_sub_rsp[1]       ),
+    .mst_req_o  ( node_sub_req_sync[1]  ),
+    .mst_resp_i ( node_sub_rsp_sync[1]  )
+  );
+
   axi_reorder_remap_compare #(
     .AxiInIdWidth   ( floo_test_pkg::AxiCfg.InIdWidth   ),
     .AxiOutIdWidth  ( floo_test_pkg::AxiCfg.OutIdWidth  ),
@@ -207,13 +231,13 @@ module tb_floo_axi_chimney;
     .NumReads       ( NumReads1                   ),
     .NumWrites      ( NumWrites1                  )
   ) i_test_node_1 (
-    .clk_i          ( clk             ),
-    .rst_ni         ( rst_n           ),
-    .mst_port_req_o ( node_man_req[1] ),
-    .mst_port_rsp_i ( node_man_rsp[1] ),
-    .slv_port_req_i ( node_sub_req[1] ),
-    .slv_port_rsp_o ( node_sub_rsp[1] ),
-    .end_of_sim     ( end_of_sim[3]   )
+    .clk_i          ( clk                   ),
+    .rst_ni         ( rst_n                 ),
+    .mst_port_req_o ( node_man_req[1]       ),
+    .mst_port_rsp_i ( node_man_rsp[1]       ),
+    .slv_port_req_i ( node_sub_req_sync[1]  ),
+    .slv_port_rsp_o ( node_sub_rsp_sync[1]  ),
+    .end_of_sim     ( end_of_sim[3]         )
   );
 
   axi_bw_monitor #(

--- a/hw/test/axi_aw_w_sync.sv
+++ b/hw/test/axi_aw_w_sync.sv
@@ -48,7 +48,8 @@
    assign aw_valid = w_completed_q && slv_req_i.aw_valid && slv_req_i.w_valid;
 
    // W is valid when corresponding AW is valid or sent
-   assign w_valid = slv_req_i.w_valid && (!w_completed_q || (aw_valid && mst_resp_i.aw_ready)); // This is probably pretty bad for timing
+   // This is probably pretty bad for timing!
+   assign w_valid = slv_req_i.w_valid && (!w_completed_q || (aw_valid && mst_resp_i.aw_ready));
 
    always_comb begin
      w_completed_d = w_completed_q;

--- a/hw/test/axi_aw_w_sync.sv
+++ b/hw/test/axi_aw_w_sync.sv
@@ -1,0 +1,70 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+
+// Authors:
+//  - Michael Rogenmoser <michaero@iis.ee.ethz.ch>
+
+
+/// Only allows passing of AW if corresponding W is valid.
+/// Only allows passing of W if corresponding AW is valid or sent.
+
+ `include "axi/assign.svh"
+ `include "common_cells/registers.svh"
+
+ module axi_aw_w_sync #(
+   parameter type axi_req_t  = logic,
+   parameter type axi_resp_t = logic
+ ) (
+   input  logic      clk_i,
+   input  logic      rst_ni,
+
+   input  axi_req_t  slv_req_i,
+   output axi_resp_t slv_resp_o,
+
+   output axi_req_t  mst_req_o,
+   input  axi_resp_t mst_resp_i
+ );
+
+   `AXI_ASSIGN_AR_STRUCT(mst_req_o.ar, slv_req_i.ar)
+   assign mst_req_o.ar_valid = slv_req_i.ar_valid;
+   assign slv_resp_o.ar_ready = mst_resp_i.ar_ready;
+   `AXI_ASSIGN_R_STRUCT(slv_resp_o.r, mst_resp_i.r)
+   assign slv_resp_o.r_valid = mst_resp_i.r_valid;
+   assign mst_req_o.r_ready = slv_req_i.r_ready;
+   `AXI_ASSIGN_B_STRUCT(slv_resp_o.b, mst_resp_i.b)
+   assign slv_resp_o.b_valid = mst_resp_i.b_valid;
+   assign mst_req_o.b_ready = slv_req_i.b_ready;
+
+   `AXI_ASSIGN_AW_STRUCT(mst_req_o.aw, slv_req_i.aw)
+   `AXI_ASSIGN_W_STRUCT(mst_req_o.w, slv_req_i.w)
+
+   logic aw_valid, w_valid;
+   logic w_completed_d, w_completed_q;
+   `FF(w_completed_q, w_completed_d, 1'b1)
+
+
+   // AW is valid when previous write completed and current AW and W are valid
+   assign aw_valid = w_completed_q && slv_req_i.aw_valid && slv_req_i.w_valid;
+
+   // W is valid when corresponding AW is valid or sent
+   assign w_valid = slv_req_i.w_valid && (!w_completed_q || (aw_valid && mst_resp_i.aw_ready)); // This is probably pretty bad for timing
+
+   always_comb begin
+     w_completed_d = w_completed_q;
+     // reset w_completed to 0 when a new AW request happens
+     if (aw_valid && mst_resp_i.aw_ready) begin
+       w_completed_d = 1'b0;
+     end
+     // assign w_completed to w_last when W handshake is done and W is ongoing
+     if (slv_req_i.w_valid && slv_resp_o.w_ready) begin
+       w_completed_d = slv_req_i.w.last;
+     end
+   end
+
+   assign mst_req_o.w_valid = w_valid;
+   assign slv_resp_o.w_ready = w_valid && mst_resp_i.w_ready;
+   assign mst_req_o.aw_valid = aw_valid;
+   assign slv_resp_o.aw_ready = aw_valid && mst_resp_i.aw_ready;
+
+ endmodule


### PR DESCRIPTION
There is a deadlock potential if the downstream AXI network tries to sync the AW and W channel. This is sometimes necessary and also allowed by the AXI specifications (e.g. the [`axi_to_mem`](https://github.com/pulp-platform/axi/blob/master/src/axi_to_detailed_mem.sv) module needs address and data at the same time to generate a memory request). The problem with FlooNoC is that AW and W are sent over the same channels, which can causes a deadlock if the downstream AXI network waits for the W to be valid, which waits for the AW to be consumed.

This PR fixes this by buffering the AWs. Since corresponding AWs and W are guaranteed to be consecutive (due to ordering issues), a buffer of size 1 is already enough to solve this deadlock situation.