### PR TITLE
floogen: Fix endpoint enum ordering and names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - A FlooGen configuration file now requires a `network_type` field, to determine the type of network to generate. The options are `axi` for single-AXI networks and `narrow-wide` for the narrow-wide AXI configurations.
 - The system address map `Sam` is now sorted correctly and can be indexed with `ep_id_e` values.
 - `id_offset` was renamed to `xy_id_offset`, since this is now only applicable in `XYRouting` networks. An ID offset does not make sense for other types of routing algorithms. The use of `id_offset` is anyway not recommended anymore, since the direction of the connections can be specified in the `connections` schema.
+- Endpoint names in the `ep_id_e` enum, which are created as 2D arrays now have clearer naming scheme by prefixing them with `X` and `Y`.
 
 ### Fixed
 

--- a/floogen/model/graph.py
+++ b/floogen/model/graph.py
@@ -287,15 +287,7 @@ class Graph(nx.DiGraph):  # pylint: disable=too-many-public-methods
     def create_unique_ep_id(self, node) -> int:
         """Return the endpoint id."""
         ep_nodes = [name for name, _ in self.get_ep_nodes(with_name=True)]
-
-        # Custom sorting function: extract numeric part after letters
-        def extract_number(name):
-            match = re.search(r"(\d+)$", name)
-            return int(match.group(1)) if match else -1
-
-        return sorted(
-            ep_nodes, key=lambda name: (re.sub(r"\d+$", "", name), extract_number(name))
-        ).index(node)
+        return ep_nodes.index(node)
 
     def get_node_id(self, node_name=None, node_obj=None):
         """Return the node id."""

--- a/floogen/model/graph.py
+++ b/floogen/model/graph.py
@@ -5,7 +5,6 @@
 #
 # Author: Tim Fischer <fischeti@iis.ee.ethz.ch>
 
-import re
 from typing import List, Tuple
 
 import networkx as nx

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -504,6 +504,7 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
                 # 1D array case
                 case (_,):
                     node_idx = self.graph.get_node_arr_idx(ni_name)[0]
+                    ni_dict["arr_idx"] = SimpleId(id=node_idx)
                     if ep_desc.is_sbr():
                         ni_dict["addr_range"] = [
                             rng.model_copy().set_idx(node_idx) for rng in ep_desc.addr_range
@@ -749,9 +750,10 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
 
     def render_ep_enum(self):
         """Render the endpoint enum in the generated code."""
-        fields_dict = {
-            ep.name: self.graph.get_node_uid(node_obj=ep).id for ep in self.graph.get_ni_nodes()
-        }
+        fields_dict = {}
+        for ni in self.graph.get_ni_nodes():
+            name = ni.render_enum_name()
+            fields_dict[name] = self.graph.get_node_uid(node_obj=ni).id
         fields_dict = dict(sorted(fields_dict.items(), key=lambda item: item[1]))
         fields_dict["num_endpoints"] = len(fields_dict)
         return sv_enum_typedef(name="ep_id_e", fields_dict=fields_dict)

--- a/floogen/model/network_interface.py
+++ b/floogen/model/network_interface.py
@@ -11,7 +11,7 @@ from importlib.resources import files, as_file
 from pydantic import BaseModel
 from mako.lookup import Template
 
-from floogen.model.routing import Id, SimpleId, AddrRange, Routing, RouteMap
+from floogen.model.routing import Id, SimpleId, Coord, AddrRange, Routing, RouteMap
 from floogen.model.protocol import AXI4
 from floogen.model.link import NarrowWideLink, AxiLink
 from floogen.model.endpoint import EndpointDesc
@@ -46,6 +46,15 @@ class NetworkInterface(BaseModel):
     def is_only_mgr(self) -> bool:
         """Return true if the network interface is only a manager."""
         return self.endpoint.is_mgr() and not self.endpoint.is_sbr()
+
+    def render_enum_name(self) -> str:
+        """Render the enum name."""
+        name = f"{self.endpoint.name}"
+        if isinstance(self.arr_idx, Coord):
+            name += f"_x{self.arr_idx.x}_y{self.arr_idx.y}"
+        elif isinstance(self.arr_idx, SimpleId):
+            name += f"_{self.arr_idx.id}"
+        return name
 
 
 class AxiNI(NetworkInterface):

--- a/floogen/templates/floo_axi_chimney.sv.mako
+++ b/floogen/templates/floo_axi_chimney.sv.mako
@@ -47,7 +47,7 @@ floo_axi_chimney  #(
   .id_i             ( id_t'(${ni.id.render()}) ),
 % endif
 % if ni.routing.route_algo.value == 'SourceRouting':
-  .route_table_i    ( RoutingTables[${snake_to_camel(ni.name)}]  ),
+  .route_table_i    ( RoutingTables[${snake_to_camel(ni.render_enum_name())}]  ),
 % else:
   .route_table_i    ( '0                          ),
 % endif

--- a/floogen/templates/floo_nw_chimney.sv.mako
+++ b/floogen/templates/floo_nw_chimney.sv.mako
@@ -70,7 +70,7 @@ floo_nw_chimney  #(
   .id_i             ( id_t'(${ni.id.render()}) ),
 % endif
 % if ni.routing.route_algo.value == 'SourceRouting':
-  .route_table_i    ( RoutingTables[${snake_to_camel(ni.name)}]  ),
+  .route_table_i    ( RoutingTables[${snake_to_camel(ni.render_enum_name())}]  ),
 % else:
   .route_table_i    ( '0                          ),
 % endif

--- a/hw/tb/tb_floo_axi_mesh.sv
+++ b/hw/tb/tb_floo_axi_mesh.sv
@@ -93,7 +93,7 @@ module tb_floo_axi_mesh;
       localparam string DmaName = $sformatf("dma_%0d_%0d", x, y);
 
       localparam int unsigned Index = x * NumY + y;
-      localparam addr_t MemBaseAddr = Sam[ClusterNi00+Index].start_addr;
+      localparam addr_t MemBaseAddr = Sam[ClusterX0Y0+Index].start_addr;
 
       floo_dma_test_node #(
         .TA             ( ApplTime                                  ),

--- a/hw/tb/tb_floo_nw_mesh.sv
+++ b/hw/tb/tb_floo_nw_mesh.sv
@@ -133,7 +133,7 @@ module tb_floo_nw_mesh;
       localparam string WideDmaName   = $sformatf("wide_dma_%0d_%0d", x, y);
 
       localparam int unsigned Index = x * NumY + y;
-      localparam addr_t MemBaseAddr = Sam[ClusterNi00+Index].start_addr;
+      localparam addr_t MemBaseAddr = Sam[ClusterX0Y0+Index].start_addr;
 
       floo_dma_test_node #(
         .TA             ( ApplTime                                  ),


### PR DESCRIPTION
This PR changes names and fixes the ordering in the `ep_id_e` enum structure. Now endpoints that are created as 2D arrays are named as `EndpointX0Y1` instead of `Endpoint01`. Furthermore, this PR also fixes the issue where indexes with multiple digits where incorrectly ordered i.e. `EndpointX10Y0` coming before `EndpointX2Y0`