### PR TITLE
floogen: Fix check for overlapping address ranges

### DIFF
--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -358,7 +358,7 @@ class RouteMap(BaseModel):
                     f"Overlapping ranges: {rules[i].addr_range} and {rules[i+1].addr_range}\n \
                     {self.pprint()}"
                 )
-        return rules
+        return self
 
     def trim(self):
         """Optimize the routing table."""


### PR DESCRIPTION
Model validators in pydantic should only return `self` (see [here](https://docs.pydantic.dev/latest/concepts/validators/#using-the-decorator-pattern)). Fixes https://github.com/pulp-platform/FlooNoC/issues/92