### PR TITLE
The package import for axi_test.sv used in floo_axi_test_node.sv was missing

### DIFF
--- a/hw/test/floo_axi_test_node.sv
+++ b/hw/test/floo_axi_test_node.sv
@@ -5,6 +5,7 @@
 // Michael Rogenmoser <michaero@iis.ee.ethz.ch>
 
 `include "axi/assign.svh"
+import axi_test::*;
 
 /// A AXI4 Bus Master-Slave Node for generating random AXI transactions
 module floo_axi_test_node #(


### PR DESCRIPTION
axi_test.sv is a package used inside floo_axi_test_node.sv. However this package was not imported inside the floo_axi_test_node.sv file leading to compilation errors