### PR TITLE
floogen: Fixed synthesis issue with concatenation in port connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - A bug in the calcuation of the RoB offset in `floo_rob` was fixed. Previously, the allocation and the write process used the same counter in bursts for offset calculation, which resulted in wrong offsets.
 - Routers with `XYRouting` do now use the global `id_offset`, which was previously not accounted for (or had to be specified manually).
 - Fixed elaboration errors in the chimneys that occured.
+- Fixed Synopsys DC elaboration error due to concatenation in `id_i` port connection of chimneys and routers.
 
 ### Removed
 

--- a/floogen/templates/floo_axi_chimney.sv.mako
+++ b/floogen/templates/floo_axi_chimney.sv.mako
@@ -3,6 +3,12 @@
 <% in_prot = next((prot for prot in noc.protocols if prot.direction == "input"), None) %>\
 <% out_prot = next((prot for prot in noc.protocols if prot.direction == "output"), None) %>\
 
+% if ni.routing.route_algo.value == 'XYRouting':
+  localparam id_t ${ni.name.upper()}_ID = ${actual_xy_id.render()};
+% else:
+  localparam id_t ${ni.name.upper()}_ID = id_t'(${ni.id.render()});
+% endif
+
 floo_axi_chimney  #(
   .AxiCfg(AxiCfg),
   .ChimneyCfg(set_ports(ChimneyDefaultCfg, ${bool_to_sv(ni.sbr_port != None)}, ${bool_to_sv(ni.mgr_port != None)})),
@@ -41,11 +47,7 @@ floo_axi_chimney  #(
   .axi_out_req_o (    ),
   .axi_out_rsp_i ( '0 ),
 % endif
-% if ni.routing.route_algo.value == 'XYRouting':
-  .id_i             ( ${actual_xy_id.render()}    ),
-% else:
-  .id_i             ( id_t'(${ni.id.render()}) ),
-% endif
+  .id_i             ( ${ni.name.upper()}_ID       ),
 % if ni.routing.route_algo.value == 'SourceRouting':
   .route_table_i    ( RoutingTables[${snake_to_camel(ni.render_enum_name())}]  ),
 % else:

--- a/floogen/templates/floo_axi_router.sv.mako
+++ b/floogen/templates/floo_axi_router.sv.mako
@@ -44,6 +44,10 @@ ${rsp_type} [${len(router.outgoing)-1}:0] ${router.name}_rsp_in;
   % endif
 % endfor
 
+% if router.route_algo == RouteAlgo.XY:
+  localparam id_t ${router.name.upper()}_ID = ${offset_xy_id.render()};
+% endif
+
 floo_axi_router #(
   .AxiCfg(AxiCfg),
   .RouteAlgo (${router.route_algo.value}),
@@ -65,7 +69,7 @@ floo_axi_router #(
   .rst_ni,
   .test_enable_i,
 % if router.route_algo == RouteAlgo.XY:
-  .id_i (${offset_xy_id.render()}),
+  .id_i (${router.name.upper()}_ID),
 % else:
   .id_i ('0),
 % endif

--- a/floogen/templates/floo_nw_chimney.sv.mako
+++ b/floogen/templates/floo_nw_chimney.sv.mako
@@ -5,6 +5,12 @@
 <% wide_in_prot = next((prot for prot in noc.protocols if prot.type == "wide" and prot.direction == "input"), None) %>\
 <% wide_out_prot = next((prot for prot in noc.protocols if prot.type == "wide" and prot.direction == "output"), None) %>\
 
+% if ni.routing.route_algo.value == 'XYRouting':
+  localparam id_t ${ni.name.upper()}_ID = ${actual_xy_id.render()};
+% else:
+  localparam id_t ${ni.name.upper()}_ID = id_t'(${ni.id.render()});
+% endif
+
 floo_nw_chimney  #(
   .AxiCfgN(AxiCfgN),
   .AxiCfgW(AxiCfgW),
@@ -64,11 +70,7 @@ floo_nw_chimney  #(
   .axi_wide_out_req_o (    ),
   .axi_wide_out_rsp_i ( '0 ),
 % endif
-% if ni.routing.route_algo.value == 'XYRouting':
-  .id_i             ( ${actual_xy_id.render()}    ),
-% else:
-  .id_i             ( id_t'(${ni.id.render()}) ),
-% endif
+  .id_i             ( ${ni.name.upper()}_ID       ),
 % if ni.routing.route_algo.value == 'SourceRouting':
   .route_table_i    ( RoutingTables[${snake_to_camel(ni.render_enum_name())}]  ),
 % else:

--- a/floogen/templates/floo_nw_router.sv.mako
+++ b/floogen/templates/floo_nw_router.sv.mako
@@ -61,6 +61,10 @@ ${wide_type} [${len(router.outgoing)-1}:0] ${router.name}_wide_out;
   % endif
 % endfor
 
+% if router.route_algo == RouteAlgo.XY:
+  localparam id_t ${router.name.upper()}_ID = ${offset_xy_id.render()};
+% endif
+
 floo_nw_router #(
   .AxiCfgN(AxiCfgN),
   .AxiCfgW(AxiCfgW),
@@ -84,7 +88,7 @@ floo_nw_router #(
   .rst_ni,
   .test_enable_i,
 % if router.route_algo == RouteAlgo.XY:
-  .id_i (${offset_xy_id.render()}),
+  .id_i (${router.name.upper()}_ID),
 % else:
   .id_i ('0),
 % endif


### PR DESCRIPTION
Replaced concatenation in port connections for the `id_i` input with `localparam`.