### PR TITLE
Fix unassigned signals to clean up spyglass

### DIFF
--- a/hw/floo_meta_buffer.sv
+++ b/hw/floo_meta_buffer.sv
@@ -292,10 +292,10 @@ module floo_meta_buffer #(
                             !no_atop_id_available : !aw_no_atop_buf_full);
     end
   end else begin : gen_no_atop_support
-    
+
     assign atop_r_buf          = '0;
     assign atop_b_buf          = '0;
-    
+
     always_comb begin
       `AXI_SET_REQ_STRUCT(axi_req_o, axi_req_i)
       `AXI_SET_RESP_STRUCT(axi_rsp_o, axi_rsp_i)

--- a/hw/floo_meta_buffer.sv
+++ b/hw/floo_meta_buffer.sv
@@ -292,6 +292,10 @@ module floo_meta_buffer #(
                             !no_atop_id_available : !aw_no_atop_buf_full);
     end
   end else begin : gen_no_atop_support
+    
+    assign atop_r_buf          = '0;
+    assign atop_b_buf          = '0;
+    
     always_comb begin
       `AXI_SET_REQ_STRUCT(axi_req_o, axi_req_i)
       `AXI_SET_RESP_STRUCT(axi_rsp_o, axi_rsp_i)

--- a/hw/floo_route_select.sv
+++ b/hw/floo_route_select.sv
@@ -150,11 +150,13 @@ if (RouteAlgo == IdTable) begin : gen_id_table
     `FFL(route_sel_q, route_sel, ~locked_route_q, '0)
     `FFL(route_sel_id_q, route_sel_id, ~locked_route_q, '0)
 
-    always @(posedge clk_i) begin
-      if (ready_i && valid_i && locked_route_q &&
-              ((route_sel_id_q != route_sel_id) || (route_sel_q != route_sel)))
-        $warning("Mismatch in route selection!");
-    end
+    `ifndef TARGET_SYNTHESIS
+      always @(posedge clk_i) begin
+        if (ready_i && valid_i && locked_route_q &&
+                ((route_sel_id_q != route_sel_id) || (route_sel_q != route_sel)))
+          $warning("Mismatch in route selection!");
+      end
+    `endif
   end else begin : gen_no_lock
     assign route_sel_o = route_sel;
     assign route_sel_id_o = route_sel_id;


### PR DESCRIPTION
- Fixed unassigned signals in route_select;
- Added definition for $warning function to clean spyglass error