### PR TITLE
Merge Terapool-NoC adaptive routing supports

### DIFF
--- a/hw/floo_pkg.sv
+++ b/hw/floo_pkg.sv
@@ -36,7 +36,8 @@ package floo_pkg;
     /// and `XYAddrOffsetY`, or by indexing the system address map `Sam`. This
     /// is controlled with the `UseIdTable` parameter.
     XYRouting,
-    YXRouting
+    YXRouting,
+    O1Routing
   } route_algo_e;
 
   /// The directions in a 2D mesh network, mainly useful for indexing

--- a/hw/floo_pkg.sv
+++ b/hw/floo_pkg.sv
@@ -10,7 +10,7 @@
 package floo_pkg;
 
   /// Currently Supported Routing Algorithms
-  typedef enum logic[1:0] {
+  typedef enum logic[2:0] {
     /// `IdTable` routing uses a table of routing rules to determine to
     /// which output port a packet should be routed, based on the
     /// destination ID encoded in the header of the flit. Every router
@@ -35,7 +35,8 @@ package floo_pkg;
     ///  XY coordinates, which can be done with addressoffsets `XYAddrOffsetX`
     /// and `XYAddrOffsetY`, or by indexing the system address map `Sam`. This
     /// is controlled with the `UseIdTable` parameter.
-    XYRouting
+    XYRouting,
+    YXRouting
   } route_algo_e;
 
   /// The directions in a 2D mesh network, mainly useful for indexing

--- a/hw/floo_pkg.sv
+++ b/hw/floo_pkg.sv
@@ -37,6 +37,7 @@ package floo_pkg;
     /// is controlled with the `UseIdTable` parameter.
     XYRouting,
     YXRouting,
+    OddEvenRouting,
     O1Routing
   } route_algo_e;
 

--- a/hw/floo_route_select.sv
+++ b/hw/floo_route_select.sv
@@ -121,6 +121,32 @@ if (RouteAlgo == IdTable) begin : gen_id_table
 
     assign channel_o = channel_i;
 
+  end else if (RouteAlgo == YXRouting) begin : gen_yx_routing
+
+    id_t id_in;
+    assign id_in = id_t'(channel_i.hdr.dst_id);
+
+    always_comb begin : proc_route_sel
+      route_sel = '0;
+      if (id_in == xy_id_i) begin
+        route_sel[Eject] = 1'b1;
+      end else if (id_in.y == xy_id_i.y) begin
+        if (id_in.x < xy_id_i.x) begin
+          route_sel[West] = 1'b1;
+        end else begin
+          route_sel[East] = 1'b1;
+        end
+      end else begin
+        if (id_in.y < xy_id_i.y) begin
+          route_sel[South] = 1'b1;
+        end else begin
+          route_sel[North] = 1'b1;
+        end
+      end
+    end
+
+    assign channel_o = channel_i;
+
   end else begin : gen_err
     // Unknown or unimplemented routing otherwise
     initial begin

--- a/hw/floo_router.sv
+++ b/hw/floo_router.sv
@@ -83,9 +83,9 @@ module floo_router
         .ready_i    ( in_ready[in_route][v_chan]          )
       );
 
-      if (RouteAlgo == O1Routing) begin
+      if (RouteAlgo == O1Routing) begin: gen_o1routing
 
-        if (v_chan % 2 == 0) begin
+        if (v_chan % 2 == 0) begin: gen_o1routing_xy
           floo_route_select #(
             .NumRoutes    ( NumOutput    ),
             .flit_t       ( flit_t       ),
@@ -107,7 +107,7 @@ module floo_router
             .channel_o      ( in_routed_data[in_route][v_chan] ),
             .route_sel_o    ( route_mask    [in_route][v_chan] )
           );
-        end else begin
+        end else begin: gen_o1routing_yx
           floo_route_select #(
             .NumRoutes    ( NumOutput    ),
             .flit_t       ( flit_t       ),
@@ -131,7 +131,7 @@ module floo_router
           );
         end
 
-      end else begin
+      end else begin: gen_xyrouting
 
         floo_route_select #(
           .NumRoutes    ( NumOutput    ),

--- a/hw/floo_router.sv
+++ b/hw/floo_router.sv
@@ -133,30 +133,30 @@ module floo_router
 
       end else begin
 
-      floo_route_select #(
-        .NumRoutes    ( NumOutput    ),
-        .flit_t       ( flit_t       ),
-        .RouteAlgo    ( RouteAlgo    ),
-        .IdWidth      ( IdWidth      ),
-        .id_t         ( id_t         ),
-        .NumAddrRules ( NumAddrRules ),
-        .addr_rule_t  ( addr_rule_t  )
-      ) i_route_select (
-        .clk_i,
-        .rst_ni,
-        .test_enable_i,
+        floo_route_select #(
+          .NumRoutes    ( NumOutput    ),
+          .flit_t       ( flit_t       ),
+          .RouteAlgo    ( RouteAlgo    ),
+          .IdWidth      ( IdWidth      ),
+          .id_t         ( id_t         ),
+          .NumAddrRules ( NumAddrRules ),
+          .addr_rule_t  ( addr_rule_t  )
+        ) i_route_select (
+          .clk_i,
+          .rst_ni,
+          .test_enable_i,
 
-        .xy_id_i        ( xy_id_i                          ),
-        .id_route_map_i ( id_route_map_i                   ),
-        .channel_i      ( in_data       [in_route][v_chan] ),
-        .valid_i        ( in_valid      [in_route][v_chan] ),
-        .ready_i        ( in_ready      [in_route][v_chan] ),
-        .channel_o      ( in_routed_data[in_route][v_chan] ),
-        .route_sel_o    ( route_mask    [in_route][v_chan] ),
-        .route_sel_id_o (                                  )
-      );
+          .xy_id_i        ( xy_id_i                          ),
+          .id_route_map_i ( id_route_map_i                   ),
+          .channel_i      ( in_data       [in_route][v_chan] ),
+          .valid_i        ( in_valid      [in_route][v_chan] ),
+          .ready_i        ( in_ready      [in_route][v_chan] ),
+          .channel_o      ( in_routed_data[in_route][v_chan] ),
+          .route_sel_o    ( route_mask    [in_route][v_chan] ),
+          .route_sel_id_o (                                  )
+        );
 
-    end
+      end
 
     end
   end

--- a/hw/floo_router.sv
+++ b/hw/floo_router.sv
@@ -83,6 +83,56 @@ module floo_router
         .ready_i    ( in_ready[in_route][v_chan]          )
       );
 
+      if (RouteAlgo == O1Routing) begin
+
+        if (v_chan % 2 == 0) begin
+          floo_route_select #(
+            .NumRoutes    ( NumOutput    ),
+            .flit_t       ( flit_t       ),
+            .RouteAlgo    ( XYRouting    ),
+            .IdWidth      ( IdWidth      ),
+            .id_t         ( id_t         ),
+            .NumAddrRules ( NumAddrRules ),
+            .addr_rule_t  ( addr_rule_t  )
+          ) i_route_select (
+            .clk_i,
+            .rst_ni,
+            .test_enable_i,
+
+            .xy_id_i        ( xy_id_i                          ),
+            .id_route_map_i ( id_route_map_i                   ),
+            .channel_i      ( in_data       [in_route][v_chan] ),
+            .valid_i        ( in_valid      [in_route][v_chan] ),
+            .ready_i        ( in_ready      [in_route][v_chan] ),
+            .channel_o      ( in_routed_data[in_route][v_chan] ),
+            .route_sel_o    ( route_mask    [in_route][v_chan] )
+          );
+        end else begin
+          floo_route_select #(
+            .NumRoutes    ( NumOutput    ),
+            .flit_t       ( flit_t       ),
+            .RouteAlgo    ( YXRouting    ),
+            .IdWidth      ( IdWidth      ),
+            .id_t         ( id_t         ),
+            .NumAddrRules ( NumAddrRules ),
+            .addr_rule_t  ( addr_rule_t  )
+          ) i_route_select (
+            .clk_i,
+            .rst_ni,
+            .test_enable_i,
+
+            .xy_id_i        ( xy_id_i                          ),
+            .id_route_map_i ( id_route_map_i                   ),
+            .channel_i      ( in_data       [in_route][v_chan] ),
+            .valid_i        ( in_valid      [in_route][v_chan] ),
+            .ready_i        ( in_ready      [in_route][v_chan] ),
+            .channel_o      ( in_routed_data[in_route][v_chan] ),
+            .route_sel_o    ( route_mask    [in_route][v_chan] )
+          );
+        end
+
+      end else begin
+
       floo_route_select #(
         .NumRoutes    ( NumOutput    ),
         .flit_t       ( flit_t       ),
@@ -105,6 +155,8 @@ module floo_router
         .route_sel_o    ( route_mask    [in_route][v_chan] ),
         .route_sel_id_o (                                  )
       );
+
+    end
 
     end
   end


### PR DESCRIPTION
1. Add support for YX-Routing
2. Add support for O1-Routing (XY/YX according to VC id)
3. Add support for Odd-Even-Routing
