### PR TITLE
Support collective operation in FlooNoC

### DIFF
--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -557,6 +557,9 @@ class Routing(BaseModel):
     port_id_bits: int = 1
     num_vc_id_bits: int = 0
     en_multicast: bool = False
+    en_parallel_reduction: bool = False
+    en_narrow_offload_reduction: bool = False
+    en_wide_offload_reduction: bool = False
 
     @field_validator("route_algo", mode="before")
     @classmethod
@@ -566,6 +569,28 @@ class Routing(BaseModel):
             v = RouteAlgo[v]
         return v
 
+    @model_validator(mode="after")
+    def validate_collective(self):
+        """Reduction can be supported with multicast only."""
+        if not self.en_multicast and (
+            self.en_parallel_reduction or
+            self.en_narrow_offload_reduction or
+            self.en_wide_offload_reduction
+        ):
+            raise ValueError(
+                "Multicast must be enabled to use any reduction feature "
+            )
+        return self
+
+    @model_validator(mode="after")
+    def validate_multicast_route_algo(self):
+        """Multicast is supported with XY routing only"""
+        if self.en_multicast and self.route_algo != RouteAlgo.XY:
+            raise ValueError(
+                "Multicast is only supported with XY routing algorithm, "
+                f"but got {self.route_algo}"
+            )
+        return self
     def render_param_decl(self) -> str:
         """Render the SystemVerilog parameter declaration."""
         string = ""
@@ -627,9 +652,15 @@ class Routing(BaseModel):
 
         if self.num_vc_id_bits == 0:
             if self.en_multicast:
-                return (
-                    f"`FLOO_TYPEDEF_HDR_T(hdr_t, {dst_type}, id_t, {ch_type}, rob_idx_t,"
-                    f"id_t, collect_comm_e)")
+                if self.en_parallel_reduction or self.en_narrow_offload_reduction or self.en_wide_offload_reduction:
+                    return (
+                        f"`FLOO_TYPEDEF_HDR_T(hdr_t, {dst_type}, id_t, {ch_type}, rob_idx_t,"
+                        f"id_t, collect_comm_e, reduction_op_t)")
+                else:
+                    return (
+                        f"`FLOO_TYPEDEF_HDR_T(hdr_t, {dst_type}, id_t, {ch_type}, rob_idx_t,"
+                        f"id_t, collect_comm_e)")
+                # TODO (lleone): Add error if multicast is not anbled but reduction it is. We cannot support only reduction.
             return f"`FLOO_TYPEDEF_HDR_T(hdr_t, {dst_type}, id_t, {ch_type}, rob_idx_t)"
         return f"`FLOO_TYPEDEF_VC_HDR_T(hdr_t, {dst_type}, id_t, {ch_type}, rob_idx_t, vc_id_t)"
 
@@ -645,6 +676,9 @@ class Routing(BaseModel):
                                 self.route_algo == RouteAlgo.ID and not self.use_id_table else 0,
             "NumSamRules": len(self.sam),
             "NumRoutes": self.num_endpoints if self.route_algo == RouteAlgo.SRC else 0,
-            "EnMultiCast": bool_to_sv(self.en_multicast)
+            "EnMultiCast": bool_to_sv(self.en_multicast),
+            "EnParallelReduction": bool_to_sv(self.en_parallel_reduction),
+            "EnNarrowOffloadReduction": bool_to_sv(self.en_narrow_offload_reduction),
+            "EnWideOffloadReduction": bool_to_sv(self.en_wide_offload_reduction)
         }
         return sv_param_decl(name, sv_struct_render(fields), dtype="route_cfg_t")

--- a/hw/floo_axi_chimney.sv
+++ b/hw/floo_axi_chimney.sv
@@ -613,7 +613,8 @@ module floo_axi_chimney #(
     floo_axi_b.hdr.atop     = aw_out_hdr_out.hdr.atop;
     floo_axi_b.payload      = meta_buf_rsp_out.b;
     floo_axi_b.payload.id   = aw_out_hdr_out.id;
-    floo_axi_b.hdr.commtype = (aw_out_hdr_out.hdr.commtype == Multicast)? CollectB : Unicast;
+    floo_axi_b.hdr.commtype = (aw_out_hdr_out.hdr.commtype == Multicast)?
+                              ParallelReduction : Unicast;
   end
 
   always_comb begin

--- a/hw/floo_nw_chimney.sv
+++ b/hw/floo_nw_chimney.sv
@@ -947,7 +947,7 @@ module floo_nw_chimney #(
     floo_narrow_b.payload      = axi_narrow_meta_buf_rsp_out.b;
     floo_narrow_b.payload.id   = narrow_aw_buf_hdr_out.id;
     floo_narrow_b.hdr.commtype = (narrow_aw_buf_hdr_out.hdr.commtype == Multicast)?
-                                 CollectB : Unicast;
+                                 ParallelReduction : Unicast;
   end
 
   always_comb begin
@@ -1015,7 +1015,8 @@ module floo_nw_chimney #(
     floo_wide_b.hdr.axi_ch  = WideB;
     floo_wide_b.payload     = axi_wide_meta_buf_rsp_out.b;
     floo_wide_b.payload.id  = wide_aw_buf_hdr_out.id;
-    floo_wide_b.hdr.commtype = (wide_aw_buf_hdr_out.hdr.commtype == Multicast)? CollectB : Unicast;
+    floo_wide_b.hdr.commtype = (wide_aw_buf_hdr_out.hdr.commtype == Multicast)?
+                               ParallelReduction : Unicast;
   end
 
   always_comb begin

--- a/hw/floo_output_arbiter.sv
+++ b/hw/floo_output_arbiter.sv
@@ -39,7 +39,7 @@ module floo_output_arbiter import floo_pkg::*;
 
   // Determine which input ports are to be reduced
   for (genvar i = 0; i < NumRoutes; i++) begin : gen_reduce_mask
-    assign reduce_mask[i] = (data_i[i].hdr.commtype == CollectB);
+    assign reduce_mask[i] = (data_i[i].hdr.commtype == ParallelReduction);
   end
 
   // Arbitrate unicasts

--- a/hw/floo_route_xymask.sv
+++ b/hw/floo_route_xymask.sv
@@ -36,8 +36,9 @@ module floo_route_xymask
   // `dst_id` in from the forward path.
   assign dst_id = (FwdMode)? channel_i.hdr.dst_id : channel_i.hdr.src_id;
   assign src_id = (FwdMode)? channel_i.hdr.src_id : channel_i.hdr.dst_id;
-  // TODO(fischeti): Clarify with Chen why `CollectB` are excluded
-  assign mask_in = (FwdMode && channel_i.hdr.commtype==CollectB)? '0 : channel_i.hdr.mask;
+  // TODO(fischeti): Clarify with Chen why `ParallelReduction` are excluded
+  assign mask_in = (FwdMode && channel_i.hdr.commtype==ParallelReduction)?
+                    '0 : channel_i.hdr.mask;
 
   // We compute minimum and maximum destination IDs, to decide whether
   // we need to send left and/or right resp. up and/or down.

--- a/hw/include/floo_noc/typedef.svh
+++ b/hw/include/floo_noc/typedef.svh
@@ -47,7 +47,7 @@
 //
 // For `SourceRouting`:
 // `FLOO_TYPEDEF_HDR_T(hdr_t, route_t, id_t, floo_pkg::axi_ch_e, logic)
-`define FLOO_TYPEDEF_HDR_T(hdr_t, dst_t, src_t, ch_t, rob_idx_t, mask_t = logic, collect_comm_t = logic)  \
+`define FLOO_TYPEDEF_HDR_T(hdr_t, dst_t, src_t, ch_t, rob_idx_t, mask_t = logic, collect_comm_t = logic, reduction_t = logic)  \
   typedef struct packed {                                         \
     logic rob_req;                                                \
     rob_idx_t rob_idx;                                            \
@@ -58,6 +58,7 @@
     logic atop;                                                   \
     ch_t axi_ch;                                                  \
     collect_comm_t commtype;                                      \
+    reduction_t reduction_op;                                     \
   } hdr_t;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/hw/test/floo_test_pkg.sv
+++ b/hw/test/floo_test_pkg.sv
@@ -33,7 +33,10 @@ package floo_test_pkg;
     IdAddrOffset: 0,
     NumSamRules: 1,
     NumRoutes: 1,
-    EnMultiCast: 1'b0
+    EnMultiCast: 1'b0,
+    EnParallelReduction: 1'b0,
+    EnNarrowOffloadReduction: 1'b0,
+    EnWideOffloadReduction: 1'b0
   };
 
   // Common chimney parameters


### PR DESCRIPTION
The goal of this PR is to allow FlooNoC to handle collective operation like multicast (already implemented) and reduction. Currently this PR only encompass the changes in the header, typedef and floogen.

* Extend the header / typedef

* Rename the existing "CollectB" to "ParallelReduction"

* Extend floogen to support reduction operations

* Extend the route configuration to support collectiv operations