### PR TITLE
hw: add offload reduction capabilities to FlooNoC

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -10,7 +10,7 @@ packages:
     revision: f07498d53ecd5518b277c7d213ec3b71ca4df93c
     version: 0.39.7
     source:
-      Git: https://github.com/pulp-platform/axi.git
+      Git: https://github.com/Lura518/axi.git
     dependencies:
     - common_cells
     - common_verification
@@ -45,6 +45,21 @@ packages:
     source:
       Git: https://github.com/pulp-platform/common_verification.git
     dependencies: []
+  fpnew:
+    revision: a8e0cba6dd50f357ece73c2c955d96efc3c6c315
+    version: null
+    source:
+      Git: https://github.com/pulp-platform/cvfpu.git
+    dependencies:
+    - common_cells
+    - fpu_div_sqrt_mvp
+  fpu_div_sqrt_mvp:
+    revision: 86e1f558b3c95e91577c41b2fc452c86b04e85ac
+    version: 1.0.4
+    source:
+      Git: https://github.com/pulp-platform/fpu_div_sqrt_mvp.git
+    dependencies:
+    - common_cells
   idma:
     revision: ff5d56fffb3767814db88d6bf8f381974ea33aa5
     version: 0.6.4

--- a/Bender.yml
+++ b/Bender.yml
@@ -15,6 +15,7 @@ dependencies:
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.3 }
   axi: { git: "https://github.com/pulp-platform/axi.git", version: 0.39.7 }
   axi_riscv_atomics: { git: "https://github.com/pulp-platform/axi_riscv_atomics.git", version: 0.8.2 }
+  FPnew:              { git: "https://github.com/pulp-platform/cvfpu.git",        rev:      pulp-v0.1.3 }
 
 export_include_dirs:
   - hw/include
@@ -35,11 +36,17 @@ sources:
   - hw/floo_rob_wrapper.sv
   - hw/floo_reduction_sync.sv
   - hw/floo_route_xymask.sv
+  - hw/floo_alu.sv
+  - hw/floo_offload_reduction_stalling.sv
+  - hw/floo_offload_reduction_buffer.sv
+  - hw/floo_offload_reduction_taggen.sv
+  - hw/floo_offload_reduction_controller.sv
   # Level 2
   - hw/floo_route_select.sv
   - hw/floo_route_comp.sv
   - hw/floo_meta_buffer.sv
   - hw/floo_reduction_arbiter.sv
+  - hw/floo_offload_reduction.sv
   # Level 3
   - hw/floo_output_arbiter.sv
   # Level 4
@@ -83,6 +90,7 @@ sources:
       - hw/test/axi_reorder_remap_compare.sv
       - hw/test/axi_bw_monitor.sv
       - hw/test/floo_hbm_model.sv
+      - hw/test/floo_reduction_offloads.sv
       - hw/test/axi_aw_w_sync.sv
       # Level 2
       - hw/tb/tb_floo_axi_chimney.sv

--- a/hw/floo_alu.sv
+++ b/hw/floo_alu.sv
@@ -1,0 +1,394 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Raphael Roth <raroth@student.ethz.ch>
+
+// This 32 bit alu is designed to be used as an easy offload unit for the offload reduction.
+// It should resemble the FPU from openhw group and could potentially be extended.
+
+`include "common_cells/assertions.svh"
+
+package alu_pkg;
+  // STRONGLY Inspired by the fpnew from openhw group!
+
+  // ---------
+  // INT TYPES
+  // ---------
+  // | Enumerator | Width  |
+  // |:----------:|-------:|
+  // | INT8       |  8 bit |
+  // | UINT8      |  8 bit |
+  // | INT16      | 16 bit |
+  // | UINT16     | 16 bit |
+  // | INT32      | 32 bit |
+  // | UINT32     | 32 bit |
+  // | INT64      | 64 bit |
+  // | UINT64     | 64 bit |
+  // *NOTE:* Add new formats only at the end of the enumeration for backwards compatibilty!
+  localparam int unsigned NUM_INT_FORMATS = 8;
+  localparam int unsigned INT_FORMAT_BITS = $clog2(NUM_INT_FORMATS);
+
+  // Int formats (Uint required for differentation between signed / unsigned min max)
+  typedef enum logic [INT_FORMAT_BITS-1:0] {
+    INT8,
+    UINT8,
+    INT16,
+    UINT16,
+    INT32,
+    UINT32,
+    INT64,
+    UINT64
+    // add new formats here
+  } alu_int_format_e;
+
+    // Returns the width of an INT format by index
+  function automatic int unsigned int_width(alu_int_format_e ifmt);
+    unique case (ifmt)
+      INT8:  return 8;
+      UINT8:  return 8;
+      INT16: return 16;
+      UINT16: return 16;
+      INT32: return 32;
+      UINT32: return 32;
+      INT64: return 64;
+      UINT64: return 64;
+      default: begin
+        // pragma translate_off
+        $fatal(1, "Invalid INT format supplied");
+        // pragma translate_on
+        // just return any integer to avoid any latches
+        // hopefully this error is caught by simulation
+        return INT8;
+      end
+    endcase
+  endfunction
+
+  // --------------
+  // ALU OPERATIONS
+  // --------------
+  localparam int unsigned NUM_INT_OPERATION = 4;
+  localparam int unsigned INT_OPERATION_BITS = $clog2(NUM_INT_OPERATION);
+
+  // Int Operation
+  typedef enum logic [INT_OPERATION_BITS-1:0] { 
+    ADD,
+    MUL,
+    MIN,
+    MAX
+  } alu_operation_e;
+
+  // --------------
+  // STATUS
+  // --------------
+  typedef struct packed {
+    logic is_zero;
+  } alu_status_t;
+
+endpackage
+
+// Wrapper incl. decoder for the ALU
+module floo_reduction_alu import floo_pkg::*; #() (
+  input  logic              clk_i,
+  input  logic              rst_ni,
+  input  logic              flush_i,
+  /// IF towards external FPU
+  input  logic[63:0]        alu_req_op1_i,
+  input  logic[63:0]        alu_req_op2_i,
+  input  reduction_op_t     alu_req_type_i,
+  input  logic              alu_req_valid_i,
+  output logic              alu_req_ready_o,
+  /// IF from external ALU
+  output logic[63:0]        alu_resp_data_o,
+  output logic              alu_resp_valid_o,
+  input  logic              alu_resp_ready_i
+);
+
+  /* All local parameter */
+
+  /* All Typedef Vars */
+
+  // Typedef for the input of the ALU
+  typedef struct packed {
+    logic [1:0][63:0]         operands;
+    alu_pkg::alu_operation_e  op;
+    alu_pkg::alu_int_format_e fmt;
+    logic                     vectorial_op;
+  } alu_in_t;
+
+  // Typedef for the output of the ALU
+  typedef struct packed {
+    logic [63:0] result;
+  } alu_out_t;
+
+  /* Variable declaration */
+  alu_in_t alu_in;
+  alu_out_t alu_out;
+
+  /* Module Declaration */
+
+  // Parse the ALU request
+  always_comb begin
+    // Init default values
+    alu_in = '0;
+
+    // Set default Values
+    alu_in.vectorial_op = 1'b0;
+    alu_in.operands[0] = alu_req_op1_i;
+    alu_in.operands[1] = alu_req_op2_i;
+
+    // Define the operation we want to execute on the FPU
+    unique casez (alu_req_type_i)
+      (floo_pkg::A_Add) : begin
+        alu_in.op = alu_pkg::ADD;
+        alu_in.fmt = alu_pkg::INT32;
+      end
+      (floo_pkg::A_Mul) : begin
+        alu_in.op = alu_pkg::MUL;
+        alu_in.fmt = alu_pkg::INT32;
+      end                
+      (floo_pkg::A_Min_S) : begin
+        alu_in.op = alu_pkg::MIN;
+        alu_in.fmt = alu_pkg::INT32;
+      end
+      (floo_pkg::A_Min_U) : begin
+        alu_in.op = alu_pkg::MIN;
+        alu_in.fmt = alu_pkg::UINT32;
+      end
+      (floo_pkg::A_Max_S) : begin
+        alu_in.op = alu_pkg::MAX;
+        alu_in.fmt = alu_pkg::INT32;
+      end
+      (floo_pkg::A_Max_U) : begin
+        alu_in.op = alu_pkg::MAX;
+        alu_in.fmt = alu_pkg::UINT32;
+      end
+      default : begin
+        alu_in.op = alu_pkg::ADD;
+        alu_in.fmt = alu_pkg::INT32;
+      end
+    endcase
+  end
+
+  // Instanciate the ALU
+  floo_alu_top #(
+    .tag_t                (logic),
+    .CutOutput            (1'b1),
+    .CutInput             (1'b0)
+  ) i_alu (
+    .clk_i                (clk_i),
+    .rst_ni               (rst_ni),
+    .flush_i              (flush_i),
+    .operands_i           (alu_in.operands),
+    .op_i                 (alu_in.op),
+    .fmt_i                (alu_in.fmt),
+    .vector_mode_i        (alu_in.vectorial_op),
+    .tag_i                (1'b0),
+    .in_valid_i           (alu_req_valid_i),
+    .in_ready_o           (alu_req_ready_o),
+    .result_o             (alu_out.result),
+    .status_o             (),
+    .tag_o                (),
+    .out_valid_o          (alu_resp_valid_o),
+    .out_ready_i          (alu_resp_ready_i)
+  );
+
+  // Assign the output signal of the ALU
+  assign alu_resp_data_o = alu_out.result;
+
+endmodule
+
+// ALU Module which should similar to the fpnew module from the openhw group
+module floo_alu_top #(
+  parameter type          tag_t = logic,
+  parameter bit           CutOutput = 1'b1,
+  parameter bit           CutInput = 1'b1,
+  // Do not change
+  localparam int unsigned WIDTH = 64,
+  localparam int unsigned NUM_OPERANDS = 2
+) (
+  input logic                                 clk_i,
+  input logic                                 rst_ni,
+  input logic                                 flush_i,
+  /// Input Signal
+  input logic [NUM_OPERANDS-1:0][WIDTH-1:0]   operands_i,
+  input alu_pkg::alu_operation_e              op_i,
+  input alu_pkg::alu_int_format_e             fmt_i,
+  input logic                                 vector_mode_i,
+  input tag_t                                 tag_i,
+  input logic                                 in_valid_i,
+  output logic                                in_ready_o,
+  /// Output Signal
+  output logic [WIDTH-1:0]                    result_o,
+  output alu_pkg::alu_status_t                status_o,
+  output tag_t                                tag_o,
+  output logic                                out_valid_o,
+  input  logic                                out_ready_i
+);
+
+/* All local parameter */
+
+/* All Typedef Vars */
+
+// Typedefs for the cut to avoid a cut for everything
+typedef struct packed {
+  logic [NUM_OPERANDS-1:0][WIDTH-1:0] operands;
+  alu_pkg::alu_operation_e op;
+  alu_pkg::alu_int_format_e fmt;
+  logic vector_mode;
+  tag_t tag;
+} cut_input_t;
+
+typedef struct packed {
+  logic [WIDTH-1:0] result;
+  alu_pkg::alu_status_t status;
+  tag_t tag;
+} cut_output_t;
+
+/* Variable declaration */
+
+// Vars after the input cut
+logic [NUM_OPERANDS-1:0][WIDTH-1:0]   operands_q;
+alu_pkg::alu_operation_e op_q;
+alu_pkg::alu_int_format_e fmt_q;
+logic vector_mode_q;
+tag_t tag_q;
+logic in_valid_q;
+logic in_ready_q;
+
+// Vars with the result infront of the output cut
+logic [WIDTH-1:0] result_d;
+alu_pkg::alu_status_t status_d;
+tag_t tag_d;
+logic out_valid_d;
+logic out_ready_d;
+
+// trunc'ed signal to support only 32 Bit signal
+logic [NUM_OPERANDS-1:0][31:0]        operands_32;
+logic [31:0] res_32;
+logic [31:0] adder_res_32;
+logic [31:0] mul_res_32;
+logic [31:0] min_res_32;
+logic [31:0] max_res_32;
+
+/* Module Declaration */
+
+// Input Cut to split the ALU from the rest of the system
+if (CutInput == 1'b1) begin
+  spill_register_flushable #(
+    .T                  (cut_input_t),
+    .Bypass             (1'b0)
+  ) i_output_cut (
+    .clk_i              (clk_i),
+    .rst_ni             (rst_ni),
+    .valid_i            (in_valid_i),
+    .flush_i            (flush_i),
+    .ready_o            (in_ready_o),
+    .data_i             ({operands_i, op_i, fmt_i, vector_mode_i, tag_i}),
+    .valid_o            (in_valid_q),
+    .ready_i            (in_ready_q),
+    .data_o             ({operands_q, op_q, fmt_q, vector_mode_q, tag_q})
+  );
+end else begin
+  assign operands_q = operands_i;
+  assign op_q = op_i;
+  assign fmt_q = fmt_i;
+  assign vector_mode_q = vector_mode_i;
+  assign tag_q = tag_i;
+  assign in_valid_q = in_valid_i;
+  assign in_ready_o = in_ready_q;
+end
+
+// Implement ALU here
+// Parse both operands to 32 Bit
+for (genvar i = 0; i < NUM_OPERANDS;i++) begin
+  assign operands_32[i] = operands_q[i][31:0];
+end
+
+// Adder Path
+assign adder_res_32 = operands_32[1] + operands_32[0];
+
+// Multiplier Path
+always_comb begin
+  mul_res_32 = '0;
+  for (int i = 0; i < 32; i++) begin
+    mul_res_32 = (|((operands_32[0] >> i) & 1)) ? mul_res_32 + (operands_32[1] << i) : mul_res_32;
+  end
+end
+
+// Min / Max Path
+always_comb begin : gen_minmax
+  logic sign;
+
+  max_res_32 = '0;
+  min_res_32 = '0;
+  sign = 1'b0;
+
+  // Determint if we require sign > When we extend the signal by 1 bit then we can use the signed hw
+  // for both the signed and unsigned case.
+  if(fmt_q == alu_pkg::INT32) begin
+    sign = 1'b1;
+  end
+
+  // Calc the min / max signal in the same case
+  if($signed({sign & operands_32[0][31], operands_32[0]}) > $signed({sign & operands_32[1][31], operands_32[1]})) begin
+    max_res_32 = operands_32[0];
+    min_res_32 = operands_32[1];
+  end else begin
+    max_res_32 = operands_32[1];
+    min_res_32 = operands_32[0];
+  end
+end
+
+// Mux the result together
+always_comb begin : result_mux
+  res_32 = '0;
+  unique case (op_i)
+    alu_pkg::ADD:   res_32 = adder_res_32;
+    alu_pkg::MUL:   res_32 = mul_res_32;
+    alu_pkg::MIN:   res_32 = min_res_32;
+    alu_pkg::MAX:   res_32 = max_res_32;
+    default:        res_32 = '0;
+  endcase
+end
+
+// Sign extend the 32 Bit result
+assign result_d = {{32{res_32[31]}},res_32};
+
+// Bypass tag & handshake
+assign tag_d = tag_q;
+assign out_valid_d = in_valid_q;
+assign in_ready_q = out_ready_d;
+assign status_d.is_zero = ~ (|res_32); // Or Connect all signal and invert to determin if we have a 0 signal
+
+// introduce cut at output of ALU
+if (CutOutput == 1'b1) begin
+  spill_register_flushable #(
+    .T                  (cut_output_t),
+    .Bypass             (1'b0)
+  ) i_output_cut (
+    .clk_i              (clk_i),
+    .rst_ni             (rst_ni),
+    .valid_i            (out_valid_d),
+    .flush_i            (flush_i),
+    .ready_o            (out_ready_d),
+    .data_i             ({result_d, status_d, tag_d}),
+    .valid_o            (out_valid_o),
+    .ready_i            (out_ready_i),
+    .data_o             ({result_o, status_o, tag_o})
+  );
+end else begin
+  assign result_o = result_d;
+  assign status_o = status_d;
+  assign tag_o = tag_d;
+  assign out_valid_o = out_valid_d;
+  assign out_ready_d = out_ready_i;
+end
+
+/* Assertions for the module */
+
+// Currently we only support 32Bit operations! Could be extended in the future
+`ASSERT(Invalid_Input, !((fmt_i != alu_pkg::INT32) && (fmt_i != alu_pkg::UINT32)))
+`ASSERT(Invalid_Vector_Ops, !(vector_mode_i != 1'b0))
+
+endmodule

--- a/hw/floo_mask_decode.sv
+++ b/hw/floo_mask_decode.sv
@@ -1,0 +1,32 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Chen Wu <chenwu@student.ethz.ch>
+
+/// This module is similar to addr decoder
+module floo_mask_decode #(
+    parameter int unsigned NumSamRules = '0,
+    parameter type         id_t        = logic,
+    /// The type of the address rules
+    parameter type         addr_rule_t = logic,
+    parameter type         mask_sel_t  = logic
+) (
+    input  id_t                          id_i,
+    input  addr_rule_t [NumSamRules-1:0] addr_map_i,
+    output mask_sel_t                    mask_x_mask_o,
+    output mask_sel_t                    mask_y_mask_o,
+    output logic                         dec_error_o
+);
+
+  always_comb begin
+    dec_error_o = 1;
+    for (int unsigned i = 0; i < NumSamRules; i++) begin
+      if (addr_map_i[i].id == id_i) begin
+        mask_x_mask_o = addr_map_i[i].mask_x;
+        mask_y_mask_o = addr_map_i[i].mask_y;
+        dec_error_o   = 0;
+      end
+    end
+  end
+endmodule

--- a/hw/floo_mask_extract.sv
+++ b/hw/floo_mask_extract.sv
@@ -1,0 +1,40 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Tim Fischer <fischeti@iis.ee.ethz.ch>
+
+`include "common_cells/assertions.svh"
+
+/// This module returns the bits of the input data that are set in the mask.
+/// For instance, if the mask is `4'b1010` and the input data is `4'b1101`, the output
+/// will be `2'b10` (the first and third bits of the input data).
+module floo_mask_extract #(
+  /// The width of the mask and the input data
+  parameter int unsigned MaskWidth = 1,
+  /// The mask/input type
+  parameter type in_t = logic [MaskWidth-1:0],
+  /// The resulting output type, typically `logic[$countones(Mask)-1:0]`
+  parameter type out_t = logic,
+  /// The mask to select the bits that should be extracted
+  parameter in_t Mask = '0
+) (
+  input in_t data_i,
+  output out_t data_o
+);
+
+  always_comb begin : gen_mask_extract
+    automatic int incr = 0;
+    for (int i = 0; i < MaskWidth; i++) begin
+      if (Mask[i]) begin
+        data_o[incr] = data_i[i];
+        incr++;
+      end
+    end
+  end
+
+  // Assert that the output width is equal to the number of bits set in the mask
+  // `ASSERT_INIT(CountOnes, $countones(Mask) == $bits(out_t),
+  //     "Number of bits set in the mask and output width don't match")
+
+endmodule

--- a/hw/floo_nw_chimney.sv
+++ b/hw/floo_nw_chimney.sv
@@ -32,6 +32,20 @@ module floo_nw_chimney #(
   /// Every atomic transactions needs to have a unique ID
   /// and one ID is reserved for non-atomic transactions
   parameter int unsigned MaxAtomicTxns           = 1,
+  /// Enable collective operation (subfiel type and operation)
+  parameter bit EnWideCollectiveOperation               = 1'b0,
+  /// Enable narrow collective operation (subfiel type and operation required)
+  parameter bit EnNarrowCollectiveOperation             = 1'b0,
+  /// Enable the b-response for wide collectiv operation 
+  /// Chimney can be the destination but not a source! e.g. it reacts only with
+  /// the approbriate B-Response
+  parameter bit EnBRespWideCollectiveOperation          = EnWideCollectiveOperation,
+  /// Enable the b-response for narrow collectiv operation 
+  parameter bit EnBRespNarrowCollectiveOperation        = EnNarrowCollectiveOperation,
+  /// Mask incoming wide collectiv operation when sending the user field to the axi port!
+  parameter bit EnMaskingWideCollectivOperation         = 1'b0,
+  /// Mask incoming narrow collectiv operation when sending the user field to the axi port!
+  parameter bit EnMaskingNarrowCollectivOperation       = 1'b0,
   /// Node ID type for routing
   parameter type id_t                                   = logic,
   /// RoB index type for reordering.
@@ -83,9 +97,12 @@ module floo_nw_chimney #(
   /// SRAM configuration type `tc_sram_impl` in RoB
   /// Only used if technology-dependent SRAM is used
   parameter type sram_cfg_t                             = logic,
-  /// Struct for user field in AXI
+  /// Struct for the narrow user field in AXI
   /// currently only used if EnMultiCast
-  parameter type user_struct_t                          = logic
+  parameter type user_narrow_struct_t                   = logic,
+  /// Struct for the wide user field in AXI
+  /// currently only used if EnMultiCast
+  parameter type user_wide_struct_t                     = logic
 ) (
   input  logic clk_i,
   input  logic rst_ni,
@@ -142,7 +159,7 @@ module floo_nw_chimney #(
 
   // Type of the mask encoded in the user field.
   // It's always equal to the address field.
-  // For future extension, add an extra opcode in the user_struct_t
+  // For future extension, add an extra opcode in the user_narrow_struct_t
   typedef axi_addr_t user_mask_t ;
 
   // Duplicate AXI port signals to degenerate ports
@@ -152,6 +169,10 @@ module floo_nw_chimney #(
   axi_wide_req_t axi_wide_req_in;
   axi_wide_rsp_t axi_wide_rsp_out;
   user_mask_t axi_narrow_req_in_mask, axi_wide_req_in_mask;
+  floo_pkg::collect_comm_e axi_narrow_req_in_red_comm_type;
+  floo_pkg::collect_comm_e axi_wide_req_in_red_comm_type;
+  floo_pkg::reduction_op_t axi_narrow_req_in_red_op;
+  floo_pkg::reduction_op_t axi_wide_req_in_red_op;
 
   // AX queue
   axi_narrow_aw_chan_t axi_narrow_aw_queue;
@@ -163,6 +184,10 @@ module floo_nw_chimney #(
   logic axi_wide_aw_queue_valid_out, axi_wide_aw_queue_ready_in;
   logic axi_wide_ar_queue_valid_out, axi_wide_ar_queue_ready_in;
   user_mask_t axi_narrow_mask_queue, axi_wide_mask_queue;
+  floo_pkg::collect_comm_e axi_narrow_red_comm_type_queue;
+  floo_pkg::collect_comm_e axi_wide_red_comm_type_queue;
+  floo_pkg::reduction_op_t axi_narrow_red_op_queue;
+  floo_pkg::reduction_op_t axi_wide_red_op_queue;
 
   // AXI req/rsp arbiter
   floo_req_chan_t [WideAr:NarrowAw] floo_req_arb_in;
@@ -259,12 +284,23 @@ module floo_nw_chimney #(
 
     // Extract the multicast mask bits from the AXI user bits
     if (RouteCfg.EnMultiCast) begin : gen_mask
-      user_struct_t user;
+      user_narrow_struct_t user;
       assign user = axi_narrow_in_req_i.aw.user;
       // TODO(lleone): Check subfield name is `mcast_mask`
       assign axi_narrow_req_in_mask = user.mcast_mask;
     end else begin : gen_no_mask
       assign axi_narrow_req_in_mask = '0;
+    end
+
+    // Extract the reduction information if from the narrow AXI user bits
+    if(EnNarrowCollectiveOperation) begin : gen_narrow_collectiv_operation
+      user_narrow_struct_t user;
+      assign user = axi_narrow_in_req_i.aw.user;
+      assign axi_narrow_req_in_red_comm_type = user.coll_type;
+      assign axi_narrow_req_in_red_op = user.coll_op;
+    end else begin : gen_no_collectiv_operation
+      assign axi_narrow_req_in_red_comm_type = '0;
+      assign axi_narrow_req_in_red_op = '0;
     end
 
     if (ChimneyCfgN.CutAx) begin : gen_ax_cuts
@@ -311,6 +347,36 @@ module floo_nw_chimney #(
         assign axi_narrow_mask_queue = '0;
       end
 
+      // Cut all signals used for the collectiv operations (type of operation and operation)
+      if(EnNarrowCollectiveOperation) begin : gen_collectiv_operation_cuts
+        spill_register #(
+          .T (floo_pkg::collect_comm_e)
+        ) i_coll_type_queue (
+          .clk_i,
+          .rst_ni,
+          .data_i   ( axi_narrow_req_in_red_comm_type ),
+          .valid_i  ( axi_narrow_req_in.aw_valid ),
+          .ready_o  (  ),
+          .data_o   ( axi_narrow_red_comm_type_queue ),
+          .valid_o  (  ),
+          .ready_i  ( axi_narrow_aw_queue_ready_in )
+        );
+        spill_register #(
+          .T (floo_pkg::reduction_op_t)
+        ) i_coll_operation_queue (
+          .clk_i,
+          .rst_ni,
+          .data_i   ( axi_narrow_req_in_red_op ),
+          .valid_i  ( axi_narrow_req_in.aw_valid ),
+          .ready_o  (  ),
+          .data_o   ( axi_narrow_red_op_queue ),
+          .valid_o  (  ),
+          .ready_i  ( axi_narrow_aw_queue_ready_in )
+        );
+      end else begin : gen_no_collectiv_operation_cuts
+        assign axi_narrow_red_comm_type_queue = '0;
+        assign axi_narrow_red_op_queue = '0;
+      end
 
     end else begin : gen_ax_no_cuts
       assign axi_narrow_aw_queue = axi_narrow_req_in.aw;
@@ -320,6 +386,8 @@ module floo_nw_chimney #(
       assign axi_narrow_ar_queue_valid_out = axi_narrow_req_in.ar_valid;
       assign axi_narrow_rsp_out.ar_ready = axi_narrow_ar_queue_ready_in;
       assign axi_narrow_mask_queue = axi_narrow_req_in_mask;
+      assign axi_narrow_red_comm_type_queue = axi_narrow_req_in_red_comm_type;
+      assign axi_narrow_red_op_queue = axi_narrow_req_in_red_op;
     end
 
   end else begin : gen_narrow_err_slv_port
@@ -341,6 +409,8 @@ module floo_nw_chimney #(
     assign axi_narrow_aw_queue_valid_out = 1'b0;
     assign axi_narrow_ar_queue_valid_out = 1'b0;
     assign axi_narrow_mask_queue = '0;
+    assign axi_narrow_red_comm_type_queue = '0;
+    assign axi_narrow_red_op_queue = '0;
   end
 
   if (ChimneyCfgW.EnMgrPort) begin : gen_wide_sbr_port
@@ -350,9 +420,22 @@ module floo_nw_chimney #(
     `AXI_ASSIGN_RESP_STRUCT(axi_wide_in_rsp_o, axi_wide_rsp_out)
 
     if (RouteCfg.EnMultiCast) begin : gen_mask
-      assign axi_wide_req_in_mask = axi_wide_in_req_i.aw.user;
+      user_wide_struct_t user;
+      assign user = axi_wide_in_req_i.aw.user;
+      assign axi_wide_req_in_mask = user.mcast_mask;
     end else begin : gen_no_mask
       assign axi_wide_req_in_mask = '0;
+    end
+
+    // Extract the reduction information if from the narrow AXI user bits
+    if(EnWideCollectiveOperation) begin : gen_narrow_collectiv_operation
+      user_wide_struct_t user;
+      assign user = axi_wide_in_req_i.aw.user;
+      assign axi_wide_req_in_red_comm_type = user.coll_type;
+      assign axi_wide_req_in_red_op = user.coll_op;
+    end else begin : gen_no_collectiv_operation
+      assign axi_wide_req_in_red_comm_type = '0;
+      assign axi_wide_req_in_red_op = '0;
     end
 
     if (ChimneyCfgW.CutAx) begin : gen_ax_cuts
@@ -399,6 +482,37 @@ module floo_nw_chimney #(
         assign axi_wide_mask_queue = '0;
       end
 
+      // Cut all signals used for the collectiv operations (type of operation and operation)
+      if(EnWideCollectiveOperation) begin : gen_collectiv_operation_cuts
+        spill_register #(
+          .T (floo_pkg::collect_comm_e)
+        ) i_coll_type_queue (
+          .clk_i,
+          .rst_ni,
+          .data_i   ( axi_wide_req_in_red_comm_type ),
+          .valid_i  ( axi_wide_req_in.aw_valid ),
+          .ready_o  (  ),
+          .data_o   ( axi_wide_red_comm_type_queue ),
+          .valid_o  (  ),
+          .ready_i  ( axi_wide_aw_queue_ready_in )
+        );
+        spill_register #(
+          .T (floo_pkg::reduction_op_t)
+        ) i_coll_operation_queue (
+          .clk_i,
+          .rst_ni,
+          .data_i   ( axi_wide_req_in_red_op ),
+          .valid_i  ( axi_wide_req_in.aw_valid ),
+          .ready_o  (  ),
+          .data_o   ( axi_wide_red_op_queue ),
+          .valid_o  (  ),
+          .ready_i  ( axi_wide_aw_queue_ready_in )
+        );
+      end else begin : gen_no_collectiv_operation_cuts
+        assign axi_wide_red_comm_type_queue = '0;
+        assign axi_wide_red_op_queue = '0;
+      end
+
     end else begin : gen_ax_no_cuts
       assign axi_wide_aw_queue = axi_wide_req_in.aw;
       assign axi_wide_aw_queue_valid_out = axi_wide_req_in.aw_valid;
@@ -407,6 +521,8 @@ module floo_nw_chimney #(
       assign axi_wide_ar_queue_valid_out = axi_wide_req_in.ar_valid;
       assign axi_wide_rsp_out.ar_ready = axi_wide_ar_queue_ready_in;
       assign axi_wide_mask_queue = axi_wide_req_in_mask;
+      assign axi_wide_red_comm_type_queue = axi_wide_req_in_red_comm_type;
+      assign axi_wide_red_op_queue = axi_wide_req_in_red_op;
     end
 
   end else begin : gen_wide_err_slv_port
@@ -428,6 +544,8 @@ module floo_nw_chimney #(
     assign axi_wide_aw_queue_valid_out = 1'b0;
     assign axi_wide_ar_queue_valid_out = 1'b0;
     assign axi_wide_mask_queue = '0;
+    assign axi_wide_red_comm_type_queue = '0;
+    assign axi_wide_red_op_queue = '0;
   end
 
   if (ChimneyCfgN.CutRsp && ChimneyCfgW.CutRsp) begin : gen_rsp_cuts
@@ -530,6 +648,41 @@ module floo_nw_chimney #(
     `AXI_SET_AW_STRUCT(axi_wide_out_req_o.aw, axi_wide_aw_queue_out);
     axi_wide_meta_buf_rsp_in = axi_wide_out_rsp_i;
     axi_wide_meta_buf_rsp_in.aw_ready = wide_aw_out_queue_ready;
+    // If the option is enabled: mask the collective operation bits here
+    // Do it in this way so potential future fields are passed without any problems
+    if(EnMaskingWideCollectivOperation) begin
+      user_wide_struct_t user_aw;
+      user_wide_struct_t user_w;
+      // Mask the AW Channel
+      user_aw = axi_wide_out_req_o.aw.user;
+      user_aw.mcast_mask = '0;
+      user_aw.coll_type = Unicast;
+      user_aw.coll_op = '0;
+      axi_wide_out_req_o.aw.user = user_aw;
+      // Mask the W Channel
+      user_w = axi_wide_out_req_o.w.user;
+      user_w.mcast_mask = '0;
+      user_w.coll_type = Unicast;
+      user_w.coll_op = '0;
+      axi_wide_out_req_o.w.user = user_w;
+    end
+    
+    if(EnMaskingNarrowCollectivOperation) begin
+      user_narrow_struct_t user_aw;
+      user_narrow_struct_t user_w;
+      // Mask the AW Channel
+      user_aw = axi_narrow_out_req_o.aw.user;
+      user_aw.mcast_mask = '0;
+      user_aw.coll_type = Unicast;
+      user_aw.coll_op = '0;
+      axi_narrow_out_req_o.aw.user = user_aw;
+      // Mask the W Channel
+      user_w = axi_narrow_out_req_o.w.user;
+      user_w.mcast_mask = '0;
+      user_w.coll_type = Unicast;
+      user_w.coll_op = '0;
+      axi_narrow_out_req_o.w.user = user_w;
+    end
   end
 
   ///////////////////////
@@ -775,6 +928,13 @@ module floo_nw_chimney #(
   id_t [NumNWAxiChannels-1:0] axi_rsp_src_id;
   mask_sel_t [NumNWAxiChannels-1:0] x_mask_sel, y_mask_sel;
 
+  floo_pkg::collect_comm_e [NumNWAxiChannels-1:0] red_coll_type;
+  floo_pkg::collect_comm_e red_narrow_coll_type_q;
+  floo_pkg::collect_comm_e red_wide_coll_type_q;
+  floo_pkg::reduction_op_t [NumNWAxiChannels-1:0] red_coll_operation;
+  floo_pkg::reduction_op_t red_narrow_coll_operation_q;
+  floo_pkg::reduction_op_t red_wide_coll_operation_q;
+
   assign axi_req_addr[NarrowAw] = axi_narrow_aw_queue.addr;
   assign axi_req_addr[NarrowAr] = axi_narrow_ar_queue.addr;
   assign axi_req_addr[WideAw]   = axi_wide_aw_queue.addr;
@@ -890,6 +1050,51 @@ module floo_nw_chimney #(
     assign mcast_mask = '0;
   end
 
+  // Because the W doesn't have a user field it is required to store the AW user field
+  // for all following W beats! For the collectiv operations this encompass the type and the
+  // operation we want to apply to the data!
+
+  // Currently any reduction have to either be on the AW/W channel
+  // If the chimney receives an Multicast / Reduction it will automatically update the resonse
+  // to the appropriate type (Multicast => Paralle Reduction with CollectB / Reduction => Multicast B Response)
+  if(EnNarrowCollectiveOperation) begin : gen_cache_collectiv_operation_data
+    // Assign all collective type
+    assign red_coll_type[NarrowAw] = axi_narrow_red_comm_type_queue;
+    assign red_coll_type[NarrowAr] = '0;
+    assign red_coll_type[WideAw]   = axi_wide_red_comm_type_queue;
+    assign red_coll_type[WideAr]   = '0;
+    assign red_coll_type[NarrowW]  = red_narrow_coll_type_q;
+    assign red_coll_type[WideW]    = red_wide_coll_type_q;
+    assign red_coll_type[NarrowR]  = '0;
+    assign red_coll_type[NarrowB]  = '0;
+    assign red_coll_type[WideR]    = '0;
+    assign red_coll_type[WideB]    = '0;
+
+    // Store the coll type!
+    `FFL(red_narrow_coll_type_q, axi_narrow_red_comm_type_queue, axi_narrow_aw_queue_valid_out && axi_narrow_aw_queue_ready_in, '0)
+    `FFL(red_wide_coll_type_q, axi_wide_red_comm_type_queue, axi_wide_aw_queue_valid_out && axi_wide_aw_queue_ready_in, '0)
+
+    // Assign all collective operation
+    assign red_coll_operation[NarrowAw] = axi_narrow_red_op_queue;
+    assign red_coll_operation[NarrowAr] = '0;
+    assign red_coll_operation[WideAw]   = axi_wide_red_op_queue;
+    assign red_coll_operation[WideAr]   = '0;
+    assign red_coll_operation[NarrowW]  = red_narrow_coll_operation_q;
+    assign red_coll_operation[WideW]    = red_wide_coll_operation_q;
+    assign red_coll_operation[NarrowR]  = '0;
+    assign red_coll_operation[NarrowB]  = '0;
+    assign red_coll_operation[WideR]    = '0;
+    assign red_coll_operation[WideB]    = '0;
+
+    // Store the coll operation!
+    `FFL(red_narrow_coll_operation_q, axi_narrow_red_op_queue, axi_narrow_aw_queue_valid_out && axi_narrow_aw_queue_ready_in, '0)
+    `FFL(red_wide_coll_operation_q, axi_wide_red_op_queue, axi_wide_aw_queue_valid_out && axi_wide_aw_queue_ready_in, '0)
+
+  end else begin : gen_no_collectiv_operation_data
+    assign red_coll_type = '0;
+    assign red_coll_operation = '0;
+  end
+
   ///////////////////
   // FLIT PACKING  //
   ///////////////////
@@ -905,7 +1110,17 @@ module floo_nw_chimney #(
     floo_narrow_aw.hdr.axi_ch   = NarrowAw;
     floo_narrow_aw.hdr.atop     = axi_narrow_aw_queue.atop != axi_pkg::ATOP_NONE;
     floo_narrow_aw.payload      = axi_narrow_aw_queue;
-    floo_narrow_aw.hdr.commtype = (mcast_mask[NarrowAw] != '0)? Multicast : Unicast;
+    // Assign the commtype and operation to the narrow AW flit
+    if(EnNarrowCollectiveOperation) begin
+      floo_narrow_aw.hdr.commtype = red_coll_type[NarrowAw];
+      if(red_coll_type[NarrowAw] == OffloadReduction) begin
+        floo_narrow_aw.hdr.reduction_op = R_Select;
+      end else if(red_coll_type[NarrowAw] == ParallelReduction) begin
+        floo_narrow_aw.hdr.reduction_op = SelectAW;
+      end
+    end else begin
+      floo_narrow_aw.hdr.commtype = (mcast_mask[NarrowAw] != '0)? Multicast : Unicast;
+    end
   end
 
   always_comb begin
@@ -918,7 +1133,13 @@ module floo_nw_chimney #(
     floo_narrow_w.hdr.last      = axi_narrow_req_in.w.last;
     floo_narrow_w.hdr.axi_ch    = NarrowW;
     floo_narrow_w.payload       = axi_narrow_req_in.w;
-    floo_narrow_w.hdr.commtype  = (mcast_mask[NarrowW] != '0)? Multicast : Unicast;
+    // Assign the commtype and operation to the narrow W flit
+    if(EnNarrowCollectiveOperation) begin
+      floo_narrow_w.hdr.commtype = red_coll_type[NarrowW];
+      floo_narrow_w.hdr.reduction_op = red_coll_operation[NarrowW];
+    end else begin
+      floo_narrow_w.hdr.commtype  = (mcast_mask[NarrowW] != '0)? Multicast : Unicast;
+    end
   end
 
   always_comb begin
@@ -946,8 +1167,22 @@ module floo_nw_chimney #(
     floo_narrow_b.hdr.atop     = narrow_aw_buf_hdr_out.hdr.atop;
     floo_narrow_b.payload      = axi_narrow_meta_buf_rsp_out.b;
     floo_narrow_b.payload.id   = narrow_aw_buf_hdr_out.id;
-    floo_narrow_b.hdr.commtype = (narrow_aw_buf_hdr_out.hdr.commtype == Multicast)?
-                                 ParallelReduction : Unicast;
+    // We need to adapt the B Response according to the incoming AW Request earlier
+    // The AXI member on the chimney should not be aware of a reduction / multicast!
+    // Multicast --> Collect the B responses in a parallel reduction
+    // Reduction --> Multicast the B response to all members
+    if(EnBRespNarrowCollectiveOperation) begin
+      if(narrow_aw_buf_hdr_out.hdr.commtype == Multicast) begin
+        floo_narrow_b.hdr.commtype = ParallelReduction;
+        floo_narrow_b.hdr.reduction_op = CollectB;
+      end else if((narrow_aw_buf_hdr_out.hdr.commtype == OffloadReduction) || (narrow_aw_buf_hdr_out.hdr.commtype == ParallelReduction)) begin
+        floo_narrow_b.hdr.commtype = Multicast;
+      end else begin
+        floo_narrow_b.hdr.commtype = Unicast;
+      end
+    end else begin
+      floo_narrow_b.hdr.commtype = (narrow_aw_buf_hdr_out.hdr.commtype == Multicast)? ParallelReduction : Unicast;
+    end
   end
 
   always_comb begin
@@ -975,7 +1210,16 @@ module floo_nw_chimney #(
     floo_wide_aw.hdr.last     = 1'b0;  // AW and W need to be sent together
     floo_wide_aw.hdr.axi_ch   = WideAw;
     floo_wide_aw.payload      = axi_wide_aw_queue;
-    floo_wide_aw.hdr.commtype = (mcast_mask[WideAw] != '0)? Multicast : Unicast;
+    // Assign the commtype and operation to the wide AW flit
+    if(EnWideCollectiveOperation) begin
+      floo_wide_aw.hdr.commtype = red_coll_type[WideAw];
+      if(red_coll_type[WideAw] == OffloadReduction) begin
+        floo_wide_aw.hdr.reduction_op = R_Select;
+      end else if(red_coll_type[WideAw] == ParallelReduction) begin
+        floo_wide_aw.hdr.reduction_op = SelectAW;
+      end    end else begin
+      floo_wide_aw.hdr.commtype = (mcast_mask[WideAw] != '0)? Multicast : Unicast;
+    end
   end
 
   always_comb begin
@@ -988,7 +1232,13 @@ module floo_nw_chimney #(
     floo_wide_w.hdr.last    = axi_wide_req_in.w.last;
     floo_wide_w.hdr.axi_ch  = WideW;
     floo_wide_w.payload     = axi_wide_req_in.w;
-    floo_wide_w.hdr.commtype = (mcast_mask[WideW] != '0)? Multicast : Unicast;
+    // Assign the commtype and operation to the wide W flit
+    if(EnWideCollectiveOperation) begin
+      floo_wide_w.hdr.commtype = red_coll_type[WideW];
+      floo_wide_w.hdr.reduction_op = red_coll_operation[WideW];
+    end else begin
+      floo_wide_w.hdr.commtype  = (mcast_mask[WideW] != '0)? Multicast : Unicast;
+    end
   end
 
   always_comb begin
@@ -1015,8 +1265,23 @@ module floo_nw_chimney #(
     floo_wide_b.hdr.axi_ch  = WideB;
     floo_wide_b.payload     = axi_wide_meta_buf_rsp_out.b;
     floo_wide_b.payload.id  = wide_aw_buf_hdr_out.id;
-    floo_wide_b.hdr.commtype = (wide_aw_buf_hdr_out.hdr.commtype == Multicast)?
-                               ParallelReduction : Unicast;
+
+    // We need to adapt the B Response according to the incoming AW Request earlier
+    // The AXI member on the chimney should not be aware of a reduction / multicast!
+    // Multicast --> Collect the B responses in a parallel reduction
+    // Reduction --> Multicast the B response to all members
+    if(EnBRespWideCollectiveOperation == 1'b1) begin
+      if(wide_aw_buf_hdr_out.hdr.commtype == Multicast) begin
+        floo_wide_b.hdr.commtype = ParallelReduction;
+        floo_wide_b.hdr.reduction_op = CollectB;
+      end else if((wide_aw_buf_hdr_out.hdr.commtype == OffloadReduction) || (wide_aw_buf_hdr_out.hdr.commtype == ParallelReduction)) begin
+        floo_wide_b.hdr.commtype = Multicast;
+      end else begin
+        floo_wide_b.hdr.commtype = Unicast;
+      end
+    end else begin
+      floo_wide_b.hdr.commtype = (wide_aw_buf_hdr_out.hdr.commtype == Multicast)? ParallelReduction : Unicast;
+    end
   end
 
   always_comb begin
@@ -1451,5 +1716,15 @@ module floo_nw_chimney #(
                            (floo_req_unpack_generic.hdr.axi_ch == WideAr)))
   `ASSERT(NoWideSbrPortWRequest,  ChimneyCfgW.EnSbrPort || !(floo_wide_in_valid &&
                            (floo_wide_unpack_generic.hdr.axi_ch == WideW)))
+
+  // We do not support reduction with ROB Buffer
+  `ASSERT_INIT(NoRobReduction, !(EnWideCollectiveOperation | EnNarrowCollectiveOperation) || 
+                          (ChimneyCfgN.BRoBType == NoRoB && 
+                           ChimneyCfgN.RRoBType == NoRoB &&
+                           ChimneyCfgW.BRoBType == NoRoB &&
+                           ChimneyCfgW.RRoBType == NoRoB))
+
+  // We do not support reduction without multicast
+  `ASSERT_INIT(NoWideReductionWithoutMulticast, (RouteCfg.EnMultiCast || !(EnWideCollectiveOperation | EnNarrowCollectiveOperation)))
 
 endmodule

--- a/hw/floo_offload_reduction.sv
+++ b/hw/floo_offload_reduction.sv
@@ -277,6 +277,7 @@ floo_offload_reduction_controller #(
   .operand_valid_o              (input_mapped_operands_valid),
   .operand_ready_i              (input_mapped_operands_ready),
   .reduction_req_operation_o    (reduction_scheduled_operation),
+  .reduction_req_mask_i         (merged_data[0].mask | merged_data[1].mask),
   .reduction_req_valid_i        (reduction_req_valid_o),
   .reduction_req_ready_i        (reduction_req_ready_i),
   .fully_red_data_i             (fully_reduced_data),

--- a/hw/floo_offload_reduction.sv
+++ b/hw/floo_offload_reduction.sv
@@ -1,0 +1,493 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Raphael Roth <raroth@student.ethz.ch>
+
+// This module describes the datapath of the offload reduction. The controller is part of the
+// "floo_offload_reduction_buffer.sv" module and describes there.
+// The selected operation we want to support for now are defined under floo_pkg::reduction_op_t!
+//
+// The main design goal was to allow a fully pipelined operation e.g. if out inputs provide each
+// cycle a new elements to reduce then the underlying reduction utilization should be 100% during 
+// the reduction. However as this required more tracking effort we support other modes too.
+// When we reduce elements from at tleast three different inputs we are required to have a
+// partial result buffer for intermidiate results.
+//
+// Overall three modes are supported: Generic, Stalling, Simple, see the controller for more
+// documentation.
+//
+// For the generic system we require a tag based system to allow tracking of each elements as we
+// elementsfrom different reduction iteration in-fligth. All elements which hold the same tag
+// need to be reduced together. This allows to separate the tag generation and the reduction logic.
+//
+// Additionally ever element gets an mask which indicates which elements are already reduced in 
+// the reduction_data as reduction with more than two inputs require two (or more) iterations.
+// The mask allows for an easy comparison for the final result e.g. if it is equal to the input 
+// mask then all required inputs are reduced together.
+//
+// For the full documentation see the Masterthesis of Raphael Roth
+
+// Restriction:
+// - Currently we only support reduction of elements belonging to the same reduction stream.
+//   In AXI term: different beats beloning to the same burst are okay but not two different
+//   burts.
+// - The max number of input is currently fixed to 6. This can be extended but th size of 
+//   the tag_t depends on it.
+// - We only support symmetric configurations e.g. NumInput and NumOutput needs to be equal
+
+// Open Points:
+// - The status of the reduction logic (e.g. FPU) is currently not evaluated by the contoller!
+
+`include "common_cells/assertions.svh"
+
+module floo_offload_reduction import floo_pkg::*; #(
+  /// Number of Routes (Currently support only symmetric configurations)
+  parameter int unsigned NumRoutes              = 1,
+  /// Various types used by floonoc / routing
+  parameter type         flit_t                 = logic,
+  parameter type         hdr_t                  = logic,
+  parameter type         id_t                   = logic,
+  /// Data payload size to extract from the floo flit
+  parameter type         RdData_t               = logic,
+  /// Possible reduction operation(s)
+  parameter type         RdOperation_t          = logic,
+  /// Parameter for the reduction configuration
+  parameter reduction_cfg_t RdCfg               = '0,
+  /// Axi Configuration
+  parameter axi_cfg_t    AxiCfg                 = '0
+) (
+  /// Control Inputs
+  input  logic                                  clk_i,
+  input  logic                                  rst_ni,
+  input  logic                                  flush_i,
+  input  id_t                                   node_id_i,
+  /// Ports towards the input routes
+  input  logic  [NumRoutes-1:0]                 valid_i,
+  output logic  [NumRoutes-1:0]                 ready_o,
+  input  flit_t [NumRoutes-1:0]                 data_i,
+  input  logic  [NumRoutes-1:0][NumRoutes-1:0]  output_route_i,
+  input  logic  [NumRoutes-1:0][NumRoutes-1:0]  expected_input_i,
+  /// Ports towards the output routes
+  output logic  [NumRoutes-1:0]                 valid_o,
+  input  logic  [NumRoutes-1:0]                 ready_i,
+  output flit_t [NumRoutes-1:0]                 data_o,
+  /// IF towards external reduction
+  output RdOperation_t                          reduction_req_type_o,
+  output RdData_t                               reduction_req_op1_o,
+  output RdData_t                               reduction_req_op2_o,
+  output logic                                  reduction_req_valid_o,
+  input  logic                                  reduction_req_ready_i,
+  /// IF from external reduction
+  input  RdData_t                               reduction_resp_data_i,
+  input  logic                                  reduction_resp_valid_i,
+  output logic                                  reduction_resp_ready_o
+);
+
+/* All local parameter */
+
+// Set the complexity of the Controller
+localparam bit GENERIC  = (RdCfg.RdControllConf == ControllerGeneric) ? 1'b1 : 1'b0;
+localparam bit SIMPLE   = (RdCfg.RdControllConf == ControllerSimple) ? 1'b1 : 1'b0;
+localparam bit STALLING = (RdCfg.RdControllConf == ControllerStalling) ? 1'b1 : 1'b0;
+
+/* All Typedef Vars */
+// Index Variable to control the crossbar and the partial buffer
+typedef logic [cf_math_pkg::idx_width(RdCfg.RdPartialBufferSize)-1:0] part_res_idx_t;
+
+// Generate the types for the mask, the tag and the red_data
+typedef logic [RdCfg.RdTagBits-1:0] tag_t;
+typedef logic [NumRoutes-1:0] mask_t;
+
+// dfferent combination between flit / data / tag / mask for the main data path
+typedef struct packed {
+  flit_t flit;
+  mask_t input_exp;
+  mask_t output_dir;
+  tag_t tag;
+} flit_in_out_dir_tag_t;
+
+typedef struct packed {
+  flit_t flit;
+  mask_t mask;
+  tag_t tag;
+} flit_mask_tag_t;
+
+typedef struct packed {
+  RdData_t data;
+  mask_t mask;
+  tag_t tag;
+} red_data_mask_tag_t;
+
+typedef struct packed {
+  RdData_t data;
+  mask_t mask;
+} red_data_mask_t;
+
+typedef struct packed {
+  RdData_t data;
+  tag_t tag;
+} red_data_tag_t;
+
+/* Variable declaration */
+
+// Variable for the tag generation
+tag_t  [NumRoutes-1:0] fifo_tag;
+
+// Output signals from the input FIFO's
+flit_in_out_dir_tag_t [NumRoutes-1:0] fifo_out_data;
+logic                 [NumRoutes-1:0] fifo_out_valid;
+logic                 [NumRoutes-1:0] fifo_out_ready;
+
+// Input signals which are already mapped to the corresponding operand
+red_data_mask_tag_t [1:0] input_mapped_operands_data;
+logic               [1:0] input_mapped_operands_valid;
+logic               [1:0] input_mapped_operands_ready;
+
+// Signal from the partial result buffer
+red_data_mask_tag_t [1:0] partial_result_buffer_data;
+logic               [1:0] partial_result_buffer_valid;
+logic               [1:0] partial_result_buffer_ready;
+
+// Signal after the merge between the partial result buffer and the inputs
+red_data_mask_tag_t [1:0] merged_data;
+logic               [1:0] merged_valid;
+logic               [1:0] merged_ready;
+
+// Signal after joining the handsake
+logic join_operands_valid;
+logic join_operands_ready;
+
+// Var to determint the executed operation
+RdOperation_t reduction_scheduled_operation;
+
+// Signal for the FPU response
+red_data_mask_tag_t reduction_resp_data;
+
+// Singal to the partial result buffer
+red_data_mask_tag_t input_partial_result_buf_data;
+logic               input_partial_result_buf_valid;
+logic               input_partial_result_buf_ready;
+
+// Signal for the fully reduced result
+red_data_tag_t  fully_reduced_data;
+logic           fully_reduced_valid;
+logic           fully_reduced_ready;
+
+// Signal toward the output of the reduction logic
+flit_mask_tag_t final_flit;
+logic           final_valid;
+logic           final_ready;
+
+// Control Signal to either merge the partial buffer or the inputs
+logic [1:0] ctrl_sel_part_res;
+
+// Control Signal for the output demultiplexer
+logic ctrl_demux;
+
+// Selector for the partial result buffer
+part_res_idx_t [1:0] ctrl_sel_buffer_idx;
+
+// Spyglass signals from the partial result buffer
+tag_t [RdCfg.RdPartialBufferSize-1:0] spyglass_tag;
+logic [RdCfg.RdPartialBufferSize-1:0] spyglass_valid;
+
+/* Module Declaration */
+
+// The tag is only required for the Generic configuration
+// For each incoming element generate the corresponding tag.
+if(GENERIC == 1'b1) begin : gen_tag_generation
+  floo_offload_reduction_taggen #(
+      .NumRoutes        (NumRoutes),
+      .TAG_T            (tag_t),
+      .RdTagBits        (RdCfg.RdTagBits)
+  ) i_gen_tag (
+      .clk_i            (clk_i),
+      .rst_ni           (rst_ni),
+      .flush_i          (flush_i),
+      .mask_i           (expected_input_i),
+      .valid_i          (valid_i),
+      .ready_i          (ready_o),
+      .tag_o            (fifo_tag)
+  );
+end else begin : gen_bypass_tag_generation
+  assign fifo_tag = '0;
+end
+
+// Fifo's for all inputs to ack the incoming data
+// and to reduce unnecessary backpressure into the system.
+if(RdCfg.RdFifoDepth > 0) begin : gen_input_fifo
+  for (genvar i = 0; i < NumRoutes; i++) begin : gen_routes
+      stream_fifo #(
+        .FALL_THROUGH           (RdCfg.RdFifoFallThrough),
+        .DEPTH                  (RdCfg.RdFifoDepth),
+        .T                      (flit_in_out_dir_tag_t)
+      ) i_in_fifo_generic (
+        .clk_i                  (clk_i),
+        .rst_ni                 (rst_ni),
+        .flush_i                (flush_i),
+        .testmode_i             (1'b0),
+        .usage_o                (),
+        .data_i                 ({data_i[i], expected_input_i[i], output_route_i[i], fifo_tag[i]}),
+        .valid_i                (valid_i[i]),
+        .ready_o                (ready_o[i]),
+        .data_o                 (fifo_out_data[i]),
+        .valid_o                (fifo_out_valid[i]),
+        .ready_i                (fifo_out_ready[i])
+      );
+  end
+end else begin : gen_no_input_fifo
+  for (genvar i = 0; i < NumRoutes; i++) begin : gen_routes
+    assign fifo_out_data[i] = {data_i[i], expected_input_i[i], output_route_i[i], fifo_tag[i]};
+    assign fifo_out_valid[i] = valid_i[i];
+    assign ready_o[i] = fifo_out_ready[i];
+  end
+end
+
+// Controller which runs the hole reduction
+floo_offload_reduction_controller #(
+  .NumRoutes                    (NumRoutes),
+  .RdPartialBufferSize          (RdCfg.RdPartialBufferSize),
+  .RdPipelineDepth              (RdCfg.RdPipelineDepth),
+  .RdData_t                     (RdData_t),
+  .RdOperation_t                (RdOperation_t),
+  .tag_t                        (tag_t),
+  .mask_t                       (mask_t),
+  .flit_t                       (flit_t),
+  .hdr_t                        (hdr_t),
+  .data_tag_t                   (red_data_tag_t),
+  .data_mask_tag_t              (red_data_mask_tag_t),
+  .flit_mask_tag_t              (flit_mask_tag_t),
+  .flit_in_out_dir_tag_t        (flit_in_out_dir_tag_t),
+  .idx_part_res_t               (part_res_idx_t),
+  .GENERIC                      (GENERIC),
+  .SIMPLE                       (SIMPLE),
+  .STALLING                     (STALLING),
+  .RdSupportAxi                 (RdCfg.RdSupportAxi),
+  .AxiCfg                       (AxiCfg),
+  .RdEnableBypass               (RdCfg.RdEnableBypass)
+) i_reduction_controller (
+  .clk_i                        (clk_i),
+  .rst_ni                       (rst_ni),
+  .flush_i                      (flush_i),
+  .head_fifo_flit_i             (fifo_out_data),
+  .head_fifo_valid_i            (fifo_out_valid),
+  .head_fifo_ready_o            (fifo_out_ready),
+  .operand_data_o               (input_mapped_operands_data),
+  .operand_valid_o              (input_mapped_operands_valid),
+  .operand_ready_i              (input_mapped_operands_ready),
+  .reduction_req_operation_o    (reduction_scheduled_operation),
+  .reduction_req_valid_i        (reduction_req_valid_o),
+  .reduction_req_ready_i        (reduction_req_ready_i),
+  .fully_red_data_i             (fully_reduced_data),
+  .fully_red_valid_i            (fully_reduced_valid),
+  .fully_red_ready_o            (fully_reduced_ready),
+  .reduction_resp_mask_i        (reduction_resp_data.mask),
+  .reduction_resp_tag_i         (reduction_resp_data.tag),
+  .reduction_resp_valid_i       (reduction_resp_valid_i),
+  .reduction_resp_ready_i       (reduction_resp_ready_o),
+  .final_flit_o                 (final_flit),
+  .final_valid_o                (final_valid),
+  .final_ready_i                (final_ready),
+  .buf_spyglass_tag_i           (spyglass_tag),
+  .buf_spyglass_valid_i         (spyglass_valid),
+  .select_partial_result_idx_o  (ctrl_sel_buffer_idx),
+  .ctrl_part_res_mux_o          (ctrl_sel_part_res),
+  .ctrl_output_demux_o          (ctrl_demux)
+);
+
+// Generate the MUX to include the partial buffer
+if((GENERIC == 1'b1) || (STALLING == 1'b1)) begin : gen_mux_partial_result
+  for (genvar i = 0; i < 2; i++) begin : gen_mux_partial_result_loop
+      stream_mux #(
+          .DATA_T             (red_data_mask_tag_t),
+          .N_INP              (2)
+      ) i_merge_part_res_and_input (
+          .inp_data_i         ({partial_result_buffer_data[i], input_mapped_operands_data[i]}),
+          .inp_valid_i        ({partial_result_buffer_valid[i], input_mapped_operands_valid[i]}),
+          .inp_ready_o        ({partial_result_buffer_ready[i], input_mapped_operands_ready[i]}),
+          .inp_sel_i          (ctrl_sel_part_res[i]),
+          .oup_data_o         (merged_data[i]),
+          .oup_valid_o        (merged_valid[i]),
+          .oup_ready_i        (merged_ready[i])
+      );
+  end
+end else begin : gen_bypass_mux_partial_result
+  assign merged_data = input_mapped_operands_data;
+  assign merged_valid = input_mapped_operands_valid;
+  assign input_mapped_operands_ready = merged_ready;
+  assign partial_result_buffer_ready = '0;
+end
+
+// Join the Handshake for the operands controll path's
+stream_join #(
+    .N_INP                  (2)
+) i_join_controlpath_operands (
+    .inp_valid_i            (merged_valid),
+    .inp_ready_o            (merged_ready),
+    .oup_valid_o            (join_operands_valid),
+    .oup_ready_i            (join_operands_ready)
+);
+
+// Connect the HS for the output request to the FPU
+assign reduction_req_valid_o = join_operands_valid;
+assign join_operands_ready = reduction_req_ready_i;
+
+// Output the operands here
+assign reduction_req_op1_o = merged_data[0].data;
+assign reduction_req_op2_o = merged_data[1].data;
+assign reduction_req_type_o = reduction_scheduled_operation;
+
+// Note: At this position in the dataflow of this file lies the external reduction hardware
+// After some (5) cycles the request turns comes back as response.
+// The external Reduction requires at least 1 cycle to avoid hw-loops!
+
+// We buffer the tag internally rather than pass it to the outside
+// TODO: Add assertion that if "reduction_req_valid_o" is set that both tag are equal!
+if(GENERIC == 1'b1) begin : gen_fifo_for_tag
+  fifo_v3 #(
+      .FALL_THROUGH     (1'b0),
+      .dtype            (tag_t),
+      .DEPTH            (RdCfg.RdPipelineDepth+2)
+  ) i_fifo_mask_parallel_fpu (
+      .clk_i            (clk_i),
+      .rst_ni           (rst_ni),
+      .flush_i          (flush_i),
+      .testmode_i       (1'b0),
+      .full_o           (),
+      .empty_o          (),
+      .usage_o          (),
+      .data_i           (merged_data[0].tag), 
+      .push_i           (reduction_req_ready_i & reduction_req_valid_o),  // active fpu req hs
+      .data_o           (reduction_resp_data.tag),
+      .pop_i            (reduction_resp_valid_i & reduction_resp_ready_o) // active fpu resp hs
+  );
+end else begin
+  assign reduction_resp_data.tag = '0;
+end
+
+// We buffer the mask internally rather than pass it to the outside
+// The mask is or-connected because the results are "added"
+// The mask field determins which input element is already
+// reduced in the given element.
+// from partial buffer: more than 1 bit set
+// from input: only 1 bit set
+// TODO: Add assertion that if "reduction_req_valid_o" is set that no bit position is set
+//       in both mask as this would mean we have already added the element once!
+if((GENERIC == 1'b1) || (STALLING == 1'b1)) begin : gen_fifo_for_mask
+  fifo_v3 #(
+      .FALL_THROUGH     (1'b0),
+      .dtype            (mask_t),
+      .DEPTH            (RdCfg.RdPipelineDepth+2)
+  ) i_fifo_mask_parallel_fpu (
+      .clk_i            (clk_i),
+      .rst_ni           (rst_ni),
+      .flush_i          (flush_i),
+      .testmode_i       (1'b0),
+      .full_o           (),
+      .empty_o          (),
+      .usage_o          (),
+      .data_i           (merged_data[0].mask | merged_data[1].mask),
+      .push_i           (reduction_req_ready_i & reduction_req_valid_o),  // active fpu req hs
+      .data_o           (reduction_resp_data.mask),
+      .pop_i            (reduction_resp_valid_i & reduction_resp_ready_o) // active fpu resp hs
+  );
+end else begin
+  assign reduction_resp_data.mask = '0;
+end
+
+// Merge the response from the reduction with the interal tag / mask storage
+assign reduction_resp_data.data = reduction_resp_data_i;
+
+// Demux the output of the fpu
+if((GENERIC == 1'b1) || (STALLING == 1'b1)) begin : gen_demux_partial_result
+  stream_demux #(
+    .N_OUP              (2)
+  ) i_stream_demux_output_fpu (
+    .inp_valid_i        (reduction_resp_valid_i),
+    .inp_ready_o        (reduction_resp_ready_o),
+    .oup_sel_i          (ctrl_demux),
+    .oup_valid_o        ({fully_reduced_valid, input_partial_result_buf_valid}),
+    .oup_ready_i        ({fully_reduced_ready, input_partial_result_buf_ready})
+  );
+end else begin
+  assign fully_reduced_valid = reduction_resp_valid_i;
+  assign reduction_resp_ready_o = fully_reduced_ready;
+  assign input_partial_result_buf_valid = 1'b0;
+end
+
+// Assign the data beloning to the mux
+assign input_partial_result_buf_data = reduction_resp_data;
+assign fully_reduced_data.data = reduction_resp_data.data;
+assign fully_reduced_data.tag = reduction_resp_data.tag;
+
+// Dynammically fork the data into the correct output direction
+// (Currently only 1 output direction is set by the dyn fork. 
+// Potentially we could support here a reduce and multicast operation
+// if more than one output is set.
+stream_fork_dynamic #(
+  .N_OUP          (NumRoutes)
+) i_dynamic_fork (
+  .clk_i          (clk_i),
+  .rst_ni         (rst_ni),
+  .valid_i        (final_valid),
+  .ready_o        (final_ready),
+  .sel_i          (final_flit.mask),
+  .sel_valid_i    (final_valid),
+  .sel_ready_o    (),
+  .valid_o        (valid_o),
+  .ready_i        (ready_i)
+);
+
+// Dublicate the output data for all output IF
+always_comb begin : gen_dublicate_output_data
+  data_o = '0;
+  for(int i = 0; i < NumRoutes;i++) begin
+    data_o[i] = final_flit.flit;
+  end
+end
+
+// Generate the partial result buffer only if we are in the GENERIC or the STALLING case
+if((GENERIC == 1'b1) || (STALLING == 1'b1)) begin : gen_partial_result_buffer
+  floo_offload_reduction_buffer #(
+      .data_mask_tag_t    (red_data_mask_tag_t),
+      .tag_t              (tag_t),
+      .NElements          (RdCfg.RdPartialBufferSize),
+      .NOutPorts          (2)
+  ) i_buf_part_result (
+      .clk_i              (clk_i),
+      .rst_ni             (rst_ni),
+      .flush_i            (flush_i),
+      .inp_data_i         (input_partial_result_buf_data),
+      .inp_valid_i        (input_partial_result_buf_valid),
+      .inp_ready_o        (input_partial_result_buf_ready),
+      .oup_data_o         (partial_result_buffer_data),
+      .oup_valid_o        (partial_result_buffer_valid),
+      .oup_ready_i        (partial_result_buffer_ready),
+      .inp_sel_valid_i    (ctrl_sel_part_res),
+      .inp_sel_i          (ctrl_sel_buffer_idx),
+      .spyglass_valid_o   (spyglass_valid), 
+      .spyglass_tag_o     (spyglass_tag)
+  );
+end else begin
+  assign input_partial_result_buf_ready = 1'b0;
+  assign partial_result_buffer_data = '0;
+  assign partial_result_buffer_valid = '0;
+  assign spyglass_valid = '0;
+  assign spyglass_tag = '0;
+end
+
+/* ASSERTION Checks */
+// The fp reduction supports up to 6 operands
+`ASSERT_INIT(Number_Input_Route_Invalid, !(NumRoutes > 6))
+// Currently we only support reduction extension with an pipeline depth of at least 1 cycle as otherwise loops could be generated!
+`ASSERT_INIT(ReductionPipelineDepth, !(RdCfg.RdPipelineDepth == 0))
+// The size needs to be at least 2 for the partial buffer for the generic / stalling proceessor
+`ASSERT_INIT(PartialBufferSize, !((GENERIC | STALLING) && (RdCfg.RdPartialBufferSize < 2)))
+// We can only run GENERIC or SIMPLE or STALLING
+`ASSERT_INIT(Invalid_Configuration_1, !(GENERIC & SIMPLE))
+`ASSERT_INIT(Invalid_Configuration_2, !(STALLING & SIMPLE))
+`ASSERT_INIT(Invalid_Configuration_3, !(GENERIC & STALLING))
+`ASSERT_INIT(Invalid_Configuration_4, (GENERIC | STALLING | SIMPLE))
+
+endmodule

--- a/hw/floo_offload_reduction_buffer.sv
+++ b/hw/floo_offload_reduction_buffer.sv
@@ -1,0 +1,127 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Raphael Roth <raroth@student.ethz.ch>
+
+// This module creates a buffer in which all elements can be accessed from the outside.
+// The module is implemented as a 0-cycle buffer where the current output is selected
+// by an index input. This index is guarded with an valid signal so that the data only
+// change if an valid is applied.
+
+`include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
+
+module floo_offload_reduction_buffer #(
+    /// Parameter type for reduction
+    parameter type data_mask_tag_t                      = logic,
+    /// Tag type for the spyglass
+    parameter type tag_t                                = logic,
+    /// Number of elements for the partial result buffer
+    parameter integer NElements                         = 0,
+    /// Number of outputs for the buffer
+    parameter integer NOutPorts                         = 1,
+    /// Dependent parameters, DO NOT OVERRIDE!
+    parameter integer LogNElements                      = (NElements > 32'd1) ? unsigned'($clog2(NElements)) : 1'b1
+) (
+    /// Control Inputs
+    input  logic                                        clk_i,
+    input  logic                                        rst_ni,
+    input  logic                                        flush_i,
+    /// All Input Connections
+    input  data_mask_tag_t                              inp_data_i,
+    input  logic                                        inp_valid_i,
+    output logic                                        inp_ready_o,
+    /// All Output Connections
+    output data_mask_tag_t [NOutPorts-1:0]              oup_data_o,
+    output logic  [NOutPorts-1:0]                       oup_valid_o,
+    input  logic  [NOutPorts-1:0]                       oup_ready_i,
+    /// Selections
+    input  logic [NOutPorts-1:0]                        inp_sel_valid_i,
+    input  logic [NOutPorts-1:0][LogNElements-1:0]      inp_sel_i,
+    /// Spyglass to all entries of the Buffer
+    output logic [NElements-1:0]                        spyglass_valid_o, 
+    output tag_t [NElements-1:0]                        spyglass_tag_o
+);
+
+/* All Typedef Vars */
+
+// a line of the buffer
+typedef struct packed {
+    data_mask_tag_t data;
+    logic f_valid;
+} buff_entry_t;
+
+/* Variable declaration */
+buff_entry_t [NElements-1:0] buffer_d, buffer_q; // Buffer to hold the data
+logic empty_field_found;
+logic [NElements-1:0] ready_sig_buf;
+
+/* Description */
+
+always_comb begin : partial_result_buffer
+    buffer_d = buffer_q;    // Init the buffer with the old data
+
+    // All Output signal
+    inp_ready_o = 1'b0;
+    oup_data_o = '0;
+    oup_valid_o = '0;
+    spyglass_tag_o = '0;
+    spyglass_valid_o = '0;
+
+    // Intermidiate signal
+    empty_field_found = 1'b0;
+    ready_sig_buf = '0;
+
+    // Store the Data into the Buffer
+    for(int i = 0; i < NElements; i++) begin
+        if((buffer_d[i].f_valid == 1'b0) && (empty_field_found == 1'b0) && (inp_valid_i == 1'b1)) begin
+            // Lock the Entry
+            empty_field_found = 1'b1;
+
+            // Ack the handshake
+            inp_ready_o = 1'b1;
+
+            // Copy the actual data
+            buffer_d[i].data = inp_data_i;
+            buffer_d[i].f_valid = 1'b1;
+        end
+    end
+
+    // Implement the Spyglass here!
+    for(int i = 0; i < NElements; i++) begin
+        spyglass_tag_o[i] = buffer_d[i].data.tag;
+        spyglass_valid_o[i] = buffer_d[i].f_valid;
+    end
+
+    // Assign the output for each defined port
+    for(int i = 0; i < NOutPorts;i++) begin
+        if(inp_sel_valid_i[i] == 1'b1) begin
+            oup_data_o[i] = buffer_d[inp_sel_i[i]].data;
+            oup_valid_o[i] = buffer_d[inp_sel_i[i]].f_valid;
+            ready_sig_buf[inp_sel_i[i]] = oup_ready_i[i];
+        end
+    end
+
+    // If we receive any valid handshake on any IF then reset the valid flag
+    for(int i = 0; i < NElements; i++) begin
+        if((ready_sig_buf[i] == 1'b1) && (buffer_d[i].f_valid == 1'b1)) begin
+            buffer_d[i].f_valid = 1'b0;
+        end
+    end
+
+    // Reset Buffer if flush is asserted & avoid piping data to the output
+    if(flush_i == 1'b1) begin
+        buffer_d = '0;
+        oup_valid_o = '0;
+    end
+end
+
+// Store the Buffer
+`FF(buffer_q, buffer_d, '0, clk_i, rst_ni)
+
+// We require at least a size of 2 for the partial result buffer (otherwise deadlock potential)
+`ASSERT_INIT(WrongNumberOfElements, !(NElements < 2))
+
+
+endmodule

--- a/hw/floo_offload_reduction_controller.sv
+++ b/hw/floo_offload_reduction_controller.sv
@@ -1,0 +1,827 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Raphael Roth <raroth@student.ethz.ch>
+
+// This module controls the hole reduction by setting all Mux / DeMus / Buff Select into its
+// appropriate position. To control the reduction(s) we have one buffer which stores all the
+// required metadata.
+//
+// We have three different configurations: Generic, Stalling & Simple
+//
+// Generic:     Most sufficicated option!
+//              Allows to have multiple reduction ongoing with the downside of requiring a TAG
+//              for each element. This mode can achieve a 100% FPU utilization (5 Stages) given
+//              enough data to reduce. To achieve 100% FPU utilization in all cases the partial
+//              buffer size should be as deep as the FPU pipeline.
+//
+// Stalling:    Good balance between area overhead & performence
+//              Allows only one ongoing reduction. It stalls all incoming element until the one
+//              it is currently working on is finished therefor no tag requirements. 
+//              Can not achieve a 100% FPU utilization if more than two inputs are involved in 
+//              the reduction. The partial buffer can be reduced to its minimum size of 2.
+//
+// Simple:      least hw overhead
+//              All incoming reduction can consits of only two elements therefor no partial buffer
+//              is required. However the user writing the software has to garantee that the only
+//              two elements are used in eac reduction. This requires that the sw guy is aware of
+//              the physical implementation of the NoC. No tag or mask is required as we can start
+//              the reduction as soon as we have two elements on the input.
+//
+// To garantee the ordering in the generic implementation this modul implements priority scheme 
+// e.g. the first buffer entry has the most priority, then the second, then the third etc.
+// It works only on elements from lower priority if the higher ones can not schedule
+// any operation.
+//
+// This module must be aware of the underlying communication protocol embedded in the FlooNoc.
+// Any header like information (e.g. AXI AW transmission) needs to be forwarded just once
+// without reducing anything. This is implmented by a bypass option.
+
+// Limits:
+// - We can not handle out-of-order
+// - We can not handle multiple reduction when they do not belong to the same subset of addresses
+//   (Due to the tag generation)
+
+// Open Points:
+// - AW flits stalls the hole process > We could potentially send the AW as soon as we receive
+//   the first  AW packet and then delet the others rather than waiting until all AW flits are
+//   available.
+
+// Disclaimer:
+// Sorry for the mess in the code ;) I had to add too much configuration option(s)!
+
+`include "common_cells/registers.svh"
+`include "common_cells/assertions.svh"
+`include "axi/typedef.svh"
+`include "floo_noc/typedef.svh"
+
+module floo_offload_reduction_controller #(
+    /// Number of Routes
+    parameter int unsigned  NumRoutes               = 1,
+    /// Partial buffer size for partial results
+    /// used in Generic / Stalling configuration
+    parameter int unsigned  RdPartialBufferSize     = 3,
+    /// Pipeline depth of the external reduction logic
+    parameter int unsigned  RdPipelineDepth         = 3,
+    /// Data payload size to extract from the floo flit
+    parameter type          RdData_t                = logic,
+    /// Possible reduction operation(s)
+    parameter type          RdOperation_t           = logic,
+    /// Various types used by floonoc / routing
+    parameter type          tag_t                   = logic,
+    parameter type          mask_t                  = logic,
+    parameter type          flit_t                  = logic,
+    parameter type          hdr_t                   = logic,
+    parameter type          data_tag_t              = logic,
+    parameter type          data_mask_tag_t         = logic,
+    parameter type          flit_mask_tag_t         = logic,
+    parameter type          flit_in_out_dir_tag_t   = logic,
+    /// Type to address the entries of the partial result buffer
+    parameter type          idx_part_res_t          = logic,
+    /// Controller configuration
+    parameter bit           GENERIC                 = 1'b1,
+    parameter bit           SIMPLE                  = 1'b0,
+    parameter bit           STALLING                = 1'b0,
+    /// Defines if the underlying protocol is AXI
+    parameter bit           RdSupportAxi            = 1'b1,
+    /// Axi Configuration
+    parameter floo_pkg::axi_cfg_t AxiCfg            = '0,
+    /// Define if we support a bypass or not (for AXI AW header)
+    parameter bit           RdEnableBypass          = 1'b1
+) (
+    /// Control Signals
+    input   logic                                   clk_i,
+    input   logic                                   rst_ni,
+    input   logic                                   flush_i,
+    /// Input from the fifos
+    input   flit_in_out_dir_tag_t [NumRoutes-1:0]   head_fifo_flit_i,
+    input   logic [NumRoutes-1:0]                   head_fifo_valid_i,
+    output  logic [NumRoutes-1:0]                   head_fifo_ready_o,
+    /// Output Operands (Support only 2 operands)
+    output  data_mask_tag_t [1:0]                   operand_data_o,
+    output  logic [1:0]                             operand_valid_o,
+    input   logic [1:0]                             operand_ready_i,
+    /// Metadata reduction req 
+    output  RdOperation_t                           reduction_req_operation_o,
+    input   logic                                   reduction_req_valid_i,
+    input   logic                                   reduction_req_ready_i,
+    /// Final Input from the reduction offload (fully reduced)
+    input   data_tag_t                              fully_red_data_i,
+    input   logic                                   fully_red_valid_i,
+    output  logic                                   fully_red_ready_o,
+    /// Metadata reduction resp
+    input   mask_t                                  reduction_resp_mask_i,
+    input   tag_t                                   reduction_resp_tag_i,
+    input   logic                                   reduction_resp_valid_i,
+    input   logic                                   reduction_resp_ready_i,
+    /// Flit provided to the output of the reduction logic
+    output  flit_mask_tag_t                         final_flit_o,
+    output  logic                                   final_valid_o,
+    input   logic                                   final_ready_i,
+    /// Spyglass from the partial result buffer
+    input   tag_t [RdPartialBufferSize-1:0]         buf_spyglass_tag_i,
+    input   logic [RdPartialBufferSize-1:0]         buf_spyglass_valid_i,
+    /// Contol Output for the index of the partial result buffer
+    output idx_part_res_t [1:0]                     select_partial_result_idx_o,
+    /// Control Signal for the Muxes / DeMuxes
+    output logic [1:0]                              ctrl_part_res_mux_o,
+    output logic                                    ctrl_output_demux_o
+);
+
+/* All local parameter */
+// Buffer Size to control all ongoing reduction
+// @ GENERIC: Use conservativ approach with (RdPipelineDepth+RdPartialBufferSize) // TODO: optimize size!
+// @ STALLING: We only have one reduction ongoing so 1 is enough
+// @ SIMPLE: We do not need any buffer so 1 to avoid questa panic (will be optimized away as never used)
+localparam int unsigned RdBufferSize = (GENERIC) ? (RdPipelineDepth+RdPartialBufferSize) : 1;
+
+localparam bit [NumRoutes-1:0] ONES = 1;
+
+/* All Typedef Vars */
+
+// Generate the axi / floo types to extract all relevant information
+// If we want to support another protocol rather AXI then add it here
+typedef logic [AxiCfg.AddrWidth-1:0] axi_addr_t;
+typedef logic [AxiCfg.InIdWidth-1:0] axi_in_id_t;
+typedef logic [AxiCfg.OutIdWidth-1:0] axi_out_id_t;
+typedef logic [AxiCfg.UserWidth-1:0] axi_user_t;
+typedef logic [AxiCfg.DataWidth-1:0] axi_data_t;
+typedef logic [AxiCfg.DataWidth/8-1:0] axi_strb_t;
+
+`AXI_TYPEDEF_ALL_CT(axi, axi_req_t, axi_rsp_t, axi_addr_t, axi_in_id_t, axi_data_t, axi_strb_t, axi_user_t)
+`AXI_TYPEDEF_AW_CHAN_T(axi_out_aw_chan_t, axi_addr_t, axi_out_id_t, axi_user_t)
+`FLOO_TYPEDEF_AXI_CHAN_ALL(axi, req, rsp, axi, AxiCfg, hdr_t)
+
+// Typedef to encompass an ongoing reduction in the buffer
+typedef struct packed {
+    // Copy (one) flit for all metadata in the package
+    flit_t                      header;
+    // Final reduction mask e.g. from which input i need to reduce input flits
+    mask_t                      final_mask;
+    // Assigned tag by the generator
+    tag_t                       tag;
+    // Output direction (N - E - S - W - L) of the flit
+    mask_t                      output_dir;
+    // Is the entry valid
+    logic                       f_valid;
+    // forward directly with the bypass
+    logic                       f_forwarding;
+} buffer_t;
+
+// Index for the input
+typedef logic [cf_math_pkg::idx_width(NumRoutes)-1:0] idx_input_t;
+
+/* Variable declaration */
+
+// Buffer to hold all reduction info's
+buffer_t [RdBufferSize-1:0]             buffer_q, buffer_d;
+
+// Stalled input signals
+flit_in_out_dir_tag_t [NumRoutes-1:0]   stalling_flit;
+logic [NumRoutes-1:0]                   stalling_valid;
+logic [NumRoutes-1:0]                   stalling_ready;
+
+// Signal to insert a new reduction in the buffer (serialzied approach to reduce required logic)
+// Iterates over all input and set to 1 if we found a tag that is not yet inside the buffer
+flit_in_out_dir_tag_t [NumRoutes-1:0]   unkown_incoming_flit;
+flit_in_out_dir_tag_t                   new_incoming_flit;
+logic [NumRoutes-1:0]                   unkown_incoming_valid;
+logic                                   new_incoming_valid;
+
+// Indicates if we have inserted the new data into the buffer or not
+logic f_insert_data_in_buffer;
+
+// Flags to find two valid operands for an reduction
+logic f_op1_found;
+logic f_op2_found;
+
+// Temporary signals for all selection(s)
+idx_input_t [1:0]       tmp_sel_input;
+idx_part_res_t [1:0]    tmp_sel_part_res_buf;
+logic [1:0]             tmp_part_res_mux;
+
+// Locked in signals to prevent changed during backpressure
+logic                   locked_d, locked_q;
+idx_input_t [1:0]       selected_input_d, selected_input_q;
+idx_part_res_t [1:0]    selected_partial_result_buffer_d, selected_partial_result_buffer_q;
+logic [1:0]             selected_partial_result_mux_d, selected_partial_result_mux_q;
+RdOperation_t           selected_op_d, selected_op_q;
+tag_t                   selected_tag_d, selected_tag_q;
+
+// Bypass Signal
+flit_mask_tag_t bypass_flit;
+logic           bypass_valid;
+logic           bypass_ready;
+
+// internal generated signals which holds the output mask for the current reduction response
+flit_t  fully_red_flit;
+mask_t  fully_red_mask;
+flit_t  metadata_out_flit;
+mask_t  metadata_out_mask;
+
+// Var used for the simple controller
+flit_t req_header;
+mask_t req_output_mask;
+logic simple_reduction_ongoing_n;
+
+/* Module Declaration */
+
+// If the stalling mode is enabled then we have to stall the inputs 
+// e.g. we deassert the valid without ackknowledge to the outside world
+// and only resets of the final flit leaves the reduction logic
+if(STALLING) begin : gen_stalling
+    for(genvar i = 0; i < NumRoutes;i++) begin
+        floo_offload_reduction_stalling #() i_stalling_module (
+            .clk_i          (clk_i),
+            .rst_ni         (rst_ni),
+            .flush_i        (flush_i),
+            .src_valid_i    (head_fifo_valid_i[i]),
+            .src_ready_o    (head_fifo_ready_o[i]),
+            .stalling_i     (final_valid_o & final_ready_i),
+            .dst_valid_o    (stalling_valid[i]),
+            .dst_ready_i    (stalling_ready[i])
+        );
+    end
+    assign stalling_flit = head_fifo_flit_i;
+end else begin : gen_no_stalling
+    assign stalling_flit = head_fifo_flit_i;
+    assign stalling_valid = head_fifo_valid_i;
+    assign head_fifo_ready_o = stalling_ready;
+end
+
+// Check if on any input we have new data are available. Each input is checked against
+// each buffer entry if the tag is available. However only one input will be forwarded
+// into the buffer.
+if(GENERIC || STALLING) begin : gen_filter_unkown_flit_tags
+    // Search if any element on the input can be inserted into the buffer
+    always_comb begin
+        // Init all Vars
+        unkown_incoming_flit = '0;
+        unkown_incoming_valid = 1'b0;
+
+        // Loop over all inputs
+        for(int k = 0; k < NumRoutes; k++) begin
+            // Is the incoming flit valid?
+            if(stalling_valid[k] == 1'b1) begin
+                // This input can be inserted if it is not already in the buffer
+                unkown_incoming_valid[k] = 1'b1;
+                // Assign the acutal data here
+                unkown_incoming_flit[k] = stalling_flit[k];
+                // Go through the hole buffer and check if the element is already inside or not
+                for(int j = 0; j < RdBufferSize; j++) begin
+                    if((stalling_flit[k].tag == buffer_q[j].tag) && (buffer_q[j].f_valid == 1'b1)) begin
+                        unkown_incoming_valid[k] = 1'b0;
+                    end
+                end
+            end
+        end
+    end
+end else begin
+    assign unkown_incoming_flit = '0;
+    assign unkown_incoming_valid = 1'b0;
+end
+
+// Select one of the unkown flits to be inserted in the buffer next. (Prio. lower indexes)
+// Both loop's could be combined but maybe there could be a better way to find the lsb 
+// indexes here
+if(GENERIC || STALLING) begin : gen_incoming_data
+    // Search if any element on the input can be inserted into the buffer
+    always_comb begin
+        // Init all Vars
+        new_incoming_flit = '0;
+        new_incoming_valid = 1'b0;
+
+        // Loop over unkown inputs
+        for(int k = 0; k < NumRoutes; k++) begin
+            // Is the incoming flit valid and is not already one selected?
+            if((unkown_incoming_valid[k] == 1'b1) && (new_incoming_valid == 1'b0)) begin
+                // If we find a valid one - selct our selection
+                new_incoming_valid = 1'b1;
+                new_incoming_flit = unkown_incoming_flit[k];
+            end
+        end
+    end
+end else begin
+    assign new_incoming_flit = '0;
+    assign new_incoming_valid = 1'b0;
+end
+
+// Dedect if the system does apply backpressure
+// The problem is that we want to fill the FPU pipeline. However if backpressure is applied we can
+// only insert an element if at least one element originates in the partial result buffer.
+// Otherwise we could deadlock thehole system.
+assign backpressure_fpu_resp = reduction_resp_valid_i & (~reduction_resp_ready_i);
+
+// The control part can be split into 4 distinctive stages (with additional substages)
+// 1. Stage: Populate the buffer with new data
+// 2. Stage: Schedule an reduction when possible
+// 3. Stage: Schedule an direct passthrough if possible (AXI AW)
+// 4. Stage: Retire an buffer entry if the corresponding tag leaves the reduction logic
+// 5. Stage: If one higher prio buffer entry is free then push the buffer by one position
+
+// The entries of the buffer are prioritized by the index. Operation from the first index
+// are priorited over the ones from the second, then from the third etc.
+// This only happens if we use the generic configuration as the stalling one has only
+// a single buffer entry (b.c. it works only on one reduction at the time).
+if(GENERIC || STALLING) begin : gen_controller_stalling_generic
+    always_comb begin
+        // Init all Vars
+        buffer_d = buffer_q;
+        locked_d = locked_q;
+        selected_input_d = selected_input_q;
+        selected_partial_result_buffer_d = selected_partial_result_buffer_q;
+        selected_partial_result_mux_d = selected_partial_result_mux_q;
+        selected_op_d = selected_op_q;
+        selected_tag_d = selected_tag_q;
+
+        // All ready signals for the input(s)
+        stalling_ready = '0;
+
+        // Output signal to the reduction
+        operand_data_o = '0;
+        operand_valid_o = '0;
+
+        // Init control signal for partial result / mux
+        select_partial_result_idx_o = '0;
+        ctrl_part_res_mux_o = '0;
+        reduction_req_operation_o = floo_pkg::F_Add;
+
+        // Flags
+        f_op1_found = 1'b0;
+        f_op2_found = 1'b0;
+        f_insert_data_in_buffer = 1'b0;
+
+        // Temporary selector signals
+        tmp_sel_input = '0;
+        tmp_sel_part_res_buf = '0;
+        tmp_part_res_mux = '0;
+
+        // Signal to directly bypass the reduction
+        bypass_flit = '0;
+        bypass_valid = 1'b0;
+
+        // Iterate over all buffer entries - handle by prio
+        for(int i = 0; i < RdBufferSize; i++) begin
+            // Reset Var for the loop
+            f_op1_found = 1'b0;
+            f_op2_found = 1'b0;
+            tmp_sel_input = '0;
+            tmp_sel_part_res_buf = '0;
+            tmp_part_res_mux = '0;
+
+            // 1. Stage: Accept new Data into the Buffer if we have free space and a valid entry
+            if(buffer_d[i].f_valid == 1'b0) begin
+
+                // Check if we can insert a new element
+                if((new_incoming_valid == 1'b1) && (f_insert_data_in_buffer == 1'b0)) begin
+                    // Lock in such a way that only one buffer entry can accept the data
+                    f_insert_data_in_buffer = 1'b1;
+                    // Insert the data into the selected entry
+                    buffer_d[i].header = new_incoming_flit.flit;
+                    buffer_d[i].final_mask = new_incoming_flit.input_exp;
+                    buffer_d[i].output_dir = new_incoming_flit.output_dir;
+                    buffer_d[i].tag = new_incoming_flit.tag;
+                    buffer_d[i].f_valid = 1'b1;
+                    // Check if we have to directly forward the flit
+                    buffer_d[i].f_forwarding = (new_incoming_flit.flit.hdr.reduction_op == floo_pkg::R_Select) ? 1'b1 : 1'b0;
+                    if((buffer_d[i].f_forwarding == 1'b1) && (RdEnableBypass == 1'b0)) begin
+                        $error($time, "Somehow an AW flit got to an reduction which does not support bypass - Why?");
+                    end
+                end
+            end
+            
+            // 2.1 Stage: Try to schedula an operation from the partial result buffer when:
+            //      - Entry in Buffer is valid
+            //      - No higher prioritized buffer already has scheduled an operation
+            //      - The reduction is not an AW transaction
+            if( (buffer_d[i].f_valid == 1'b1) && 
+                (locked_d == 1'b0) && 
+                (buffer_d[i].f_forwarding == 0)) begin
+
+                // First iterate over the partial result buffer
+                for(int j = 0; j < RdPartialBufferSize;j++) begin
+                    if((buf_spyglass_tag_i[j] == buffer_d[i].tag) && (buf_spyglass_valid_i[j] == 1'b1)) begin
+                        if(f_op1_found == 1'b0) begin
+                            // Select the appropriate entry in the partial result buffer
+                            tmp_sel_part_res_buf[0] = j;
+                            // Switch the Mux0 from the input to the partial result buffer
+                            tmp_part_res_mux[0] = 1'b1;
+                            // lock the first op
+                            f_op1_found = 1'b1;
+                        end else if(f_op2_found == 1'b0) begin
+                            // Select the appropriate entry in the partial result buffer
+                            tmp_sel_part_res_buf[1] = j;
+                            // Switch the Mux1 from the input to the partial result buffer
+                            tmp_part_res_mux[1] = 1'b1;
+                            // lock the second op
+                            f_op2_found = 1'b1;
+                        end
+                    end
+                end
+            end
+
+            // 2.2 Stage: Try to schedula an operation from the inputs when:
+            //      - Entry in Buffer is valid
+            //      - No higher prioritized buffer already has scheduled an operation
+            //      - The reduction is not an AW transaction
+            //      - No backpressure is applied to the FPU response or f_op1_found is 1
+            //        and f_op2_found is 0 (otherwise deadlock potential!)
+            if( (buffer_d[i].f_valid == 1'b1) && 
+                (locked_d == 1'b0) && 
+                (buffer_d[i].f_forwarding == 0) && 
+                ((backpressure_fpu_resp == 1'b0) || ((f_op1_found == 1'b1) && (f_op2_found == 1'b0)))) begin
+                    
+                // Iterate over all inputs
+                for(int j = 0; j < NumRoutes;j++) begin
+                    if((stalling_flit[j].tag == buffer_d[i].tag) && (stalling_valid[j] == 1'b1)) begin
+                        if(f_op1_found == 1'b0) begin
+                            // Select the appropriate input (Mux0 is per default input selection)
+                            tmp_sel_input[0] = j;
+                            // lock the first op
+                            f_op1_found = 1'b1;
+                        end else if(f_op2_found == 1'b0) begin
+                            // Select the appropriate input (Mux1 is per default input selection)
+                            tmp_sel_input[1] = j;
+                            // lock the second op
+                            f_op2_found = 1'b1;
+                        end
+                    end
+                end
+            end
+
+            // 2.3 Stage: Schedule an operation if:
+            //  - Both operands are found
+            //  - No locked in operation
+            if( (f_op1_found == 1'b1) && 
+                (f_op2_found == 1'b1) &&
+                (locked_d == 1'b0)) begin
+
+                // lock the output signals
+                locked_d = 1'b1;
+                // Copy the required signal
+                selected_input_d = tmp_sel_input;
+                selected_partial_result_buffer_d = tmp_sel_part_res_buf;
+                selected_partial_result_mux_d = tmp_part_res_mux;
+                selected_op_d = buffer_d[i].header.hdr.reduction_op;
+                selected_tag_d = buffer_d[i].tag;
+            end
+
+            // 3 Stage: Send an AW flit to the output if:
+            // - buffer entry 0 to ensure ordering
+            // - The reduction is an AW transaction
+            // - All required AW flits are aligned at the input
+            if( (buffer_d[i].f_valid == 1'b1) &&
+                (buffer_d[i].f_forwarding == 1) &&
+                ((stalling_valid & buffer_d[i].final_mask) == buffer_d[i].final_mask) &&
+                (i == 0) &&
+                (RdEnableBypass == 1'b1)) begin
+
+                // Assign valid & data signal to the output
+                bypass_valid = 1'b1;
+                bypass_flit.flit = buffer_d[i].header;
+                bypass_flit.mask = buffer_d[i].output_dir;
+                bypass_flit.tag = buffer_d[i].tag;
+                // Forward the bypass ready signal to the input's which requires the signal 
+                stalling_ready = (buffer_d[i].final_mask & {(NumRoutes){bypass_ready}});
+            end
+
+            // 4 Stage: Retire an element if:
+            // - Valid Buffer Element
+            // - Tag matches the one that leaves the reduction logic
+            // - Handshake on the output
+            //
+            // Note:
+            // To garantee ordering we only should retire from the 0'th entry! 
+            // However to avoid deadlocks with not retired instruction I allow 
+            // to retire from any position. TODO: Solve by introducing assertion
+            if( (buffer_d[i].f_valid == 1'b1) &&
+                (buffer_d[i].tag == final_flit_o.tag) &&
+                (final_valid_o == 1'b1) &&
+                (final_ready_i == 1'b1)) begin
+
+                // Reset the valid flag of the buffer
+                buffer_d[i].f_valid = 1'b0;
+                if(i > 0) begin
+                    $error($time, "We retired an element other from buffer entry 0. This should not happen. Why?");
+                end
+            end
+        end
+
+        // 5 Stage: Copy the data to a higher prio slot if it is free and we are valid
+        // (Stalling case already handled by having i only 0!)
+        for(int i = 0; i < RdBufferSize; i++) begin
+            if(i != 0) begin
+                if((buffer_d[i-1].f_valid == 1'b0) && (buffer_d[i].f_valid == 1'b1)) begin
+                    buffer_d[i-1] = buffer_d[i];    // copy the data (incl. valid bit)
+                    buffer_d[i] = '0;               // delet all old data
+                end
+            end
+        end
+
+        // Handle all locked in signals!
+        if(locked_d == 1'b1) begin
+            // Handle both operands
+            for(int i = 0; i < 2; i++) begin
+                // Use data provided by the partial result buffer
+                if(selected_partial_result_mux_d[i] == 1'b1) begin : fetch_result_from_partial_buffer
+                    select_partial_result_idx_o[i] = selected_partial_result_buffer_d[i];
+                // Use data provided by the input(s)
+                end else begin : fetch_result_from_input
+                    // data: extract the data from the AXI W channel in the selected input
+                    // mask: shift the 00001 according to the selected input
+                    // tag: just get it from the locked in version
+                    if(RdSupportAxi) begin
+                        operand_data_o[i] = {extractAXIWdata(stalling_flit[selected_input_d[i]].flit), ONES << selected_input_d[i], selected_tag_d};
+                    end
+                    // Set the valid bit
+                    operand_valid_o[i] = 1'b1;
+                    // Forward the ready bit without influencing already existing ready bits 
+                    // on other inputs. We can schedule an bypass and a operation in the same
+                    // cycle.
+                    // We either shift 00001 or 00000 to the left according to the selected input
+                    stalling_ready = stalling_ready | ((ONES & {(NumRoutes){operand_ready_i[i]}}) << selected_input_d[i]);
+                end
+            end
+            // Set the selected OP
+            reduction_req_operation_o = selected_op_d;
+            // Set the mux
+            ctrl_part_res_mux_o = selected_partial_result_mux_d;
+        end
+
+        // Release the lock if we recognize a valid handshake
+        if((reduction_req_valid_i == 1'b1) && (reduction_req_ready_i == 1'b1)) begin
+            locked_d = 1'b0;
+        end
+    end
+end else begin
+    // Set all not required vars to 0
+    assign select_partial_result_idx_o = '0;
+    assign ctrl_part_res_mux_o = '0;
+    assign selected_partial_result_buffer_d = '0;
+    assign selected_partial_result_mux_d = '0;
+    assign selected_tag_d = '0;
+    assign selected_op_d = '0;
+end
+
+// Simple controller which is only able to combine two flits
+// TODO: Add assertion to the decoded mask so that at most only two bits can be set!
+if(SIMPLE) begin : gen_simple_controller
+    always_comb begin
+
+        // Init all Vars
+        buffer_d = buffer_q;
+        locked_d = locked_q;
+        selected_input_d = selected_input_q;
+
+        // All ready signals for the input(s)
+        stalling_ready = '0;
+
+        // Output signal to the reduction
+        operand_data_o = '0;
+        operand_valid_o = '0;
+
+        // Init control signal for partial result / mux
+        reduction_req_operation_o = '0;
+
+        // Signal to directly bypass the reduction
+        bypass_flit = '0;
+        bypass_valid = 1'b0;
+
+        // Simple controller specific vars
+        req_header = '0;
+        req_output_mask = '0;
+
+        // Set intial value for the op found signal
+        tmp_sel_input = '0;
+        f_op1_found = 1'b0;
+        f_op2_found = 1'b0;
+
+        // 1.1 Stage: Search for schedulable operands when:
+        // - Input is valid
+        // - Currently no operation locked in
+        for(int i = 0; i < NumRoutes; i++) begin
+            // Find the first operand
+            if((stalling_valid[i] == 1'b1) && (f_op1_found == 1'b0) && (locked_d == 1'b0)) begin
+                // Select the appropriate input (No Mux in simple case)
+                tmp_sel_input[0] = i;
+                // lock the first op
+                f_op1_found = 1'b1;
+            // Find the second operand
+            end else if((stalling_valid[i] == 1'b1) && (f_op1_found == 1'b1) && (f_op2_found == 1'b0) && (locked_d == 1'b0)) begin
+                // Select the appropriate input (No Mux in simple case)
+                tmp_sel_input[1] = i;
+                // lock the second op
+                f_op2_found = 1'b1;
+            end
+        end
+
+        // 1.2 Stage: Schedule an operation if:
+        //  - Both operands are found
+        //  - No locked in operation
+        if( (f_op1_found == 1'b1) && 
+            (f_op2_found == 1'b1) &&
+            (locked_d == 1'b0)) begin
+
+            // lock the output matrix
+            locked_d = 1'b1;
+            // Copy the required signal
+            selected_input_d = tmp_sel_input;
+        end
+
+        // 1.3 Stage: Forward the data to the FPU or the bypass
+        if(locked_d == 1'b1) begin
+            // Handle the case for a bypassable flit
+            if(stalling_flit[selected_input_d[0]].flit.hdr.reduction_op == floo_pkg::R_Select) begin
+                // Stall sending the bypass until the pipeline is empty to avoid reordering
+                if(simple_reduction_ongoing_n) begin
+                    // AW flit found - direct forward to the output
+                    bypass_valid = 1'b1;
+                    // Forward the entire AW flit
+                    bypass_flit.flit = stalling_flit[selected_input_d[0]].flit;
+                    bypass_flit.mask = stalling_flit[selected_input_d[0]].output_dir;
+                    // Forward the ready signal to all involved inputs
+                    stalling_ready = (stalling_flit[selected_input_d[0]].input_exp & {(NumRoutes){bypass_ready}});
+                end
+            end else begin
+                // Iterate over all operands and prepare the data
+                stalling_ready = '0;
+                for(int i = 0; i < 2; i++) begin
+                    if(RdSupportAxi) begin
+                        operand_data_o[i].data = extractAXIWdata(stalling_flit[selected_input_d[i]].flit);
+                    end
+
+                    // Forward the handshaking
+                    stalling_ready = stalling_ready | ((ONES & {(NumRoutes){operand_ready_i[i]}}) << selected_input_d[i]);
+                    // Schedule the operation
+                    operand_valid_o[i] = 1'b1;
+                end
+                // Select the ongoing operand
+                reduction_req_operation_o = stalling_flit[selected_input_d[0]].flit.hdr.reduction_op;
+                // Forward the header of the flit
+                req_header = stalling_flit[selected_input_d[0]].flit;
+                // Forward the output selection mask
+                req_output_mask = stalling_flit[selected_input_d[0]].output_dir;
+            end
+        end
+
+        // 1.4 Stage: Release lock if operation was accepted
+        if((reduction_req_valid_i == 1'b1) && (reduction_req_ready_i == 1'b1)) begin
+            locked_d = 1'b0;
+        end
+
+        // 1.5 Stage: Release lock if bypass was accepted
+        if((bypass_valid == 1'b1) && (bypass_ready == 1'b1)) begin
+            locked_d = 1'b0;
+        end
+    end
+end else begin
+    assign req_header = '0;
+    assign req_output_mask = '0;
+end
+
+// If we want to support a bypass then use an arb-tree to include the bypass!
+if(RdEnableBypass == 1'b1) begin : gen_bypass_arb_tree
+    stream_arbiter_flushable  #(
+        .DATA_T                 (flit_mask_tag_t),
+        .N_INP                  (2)
+    ) i_output_arbiter (
+        .clk_i                  (clk_i),
+        .rst_ni                 (rst_ni),
+        .flush_i                (flush_i),
+        .inp_data_i             ({{fully_red_flit, fully_red_mask, fully_red_data_i.tag}, bypass_flit}),
+        .inp_valid_i            ({fully_red_valid_i, bypass_valid}),
+        .inp_ready_o            ({fully_red_ready_o, bypass_ready}),
+        .oup_data_o             (final_flit_o),
+        .oup_valid_o            (final_valid_o),
+        .oup_ready_i            (final_ready_i)
+    );
+end else begin
+    assign final_flit_o = {fully_red_flit, fully_red_mask, fully_red_data_i.tag};
+    assign final_valid_o = fully_red_valid_i;
+    assign fully_red_ready_o = final_ready_i;
+end
+
+// Generate the header and the output mask for the fully reduced data
+// @ Stalling / Generic: Iterate through the buffer and try to find a matching tag
+//                       then extract the header and the output mask
+// @ Simple:             Store the header / output dir directly inside a fifo when
+//                       the request is placed!
+if(GENERIC || STALLING) begin
+    always_comb begin
+        metadata_out_flit = '0;
+        metadata_out_mask = '0;
+
+        for(int i = 0; i < RdBufferSize; i++) begin
+            if(buffer_q[i].f_valid && (buffer_q[i].tag == fully_red_data_i.tag) && fully_red_valid_i) begin
+                metadata_out_flit = buffer_q[i].header;
+                metadata_out_mask = buffer_q[i].output_dir;
+            end
+        end
+    end
+end else begin
+    // Fifo to store the header of the element during the FPU reduction
+    fifo_v3 #(
+        .FALL_THROUGH     (1'b0),
+        .dtype            (flit_t),
+        .DEPTH            (RdPipelineDepth+2)
+    ) i_fifo_header (
+        .clk_i            (clk_i),
+        .rst_ni           (rst_ni),
+        .flush_i          (flush_i),
+        .testmode_i       (1'b0),
+        .full_o           (),
+        .empty_o          (simple_reduction_ongoing_n),
+        .usage_o          (),
+        .data_i           (req_header),
+        .push_i           (reduction_req_valid_i & reduction_req_ready_i),  // push mask on active fpu req hs
+        .data_o           (metadata_out_flit),
+        .pop_i            (reduction_resp_valid_i & reduction_resp_ready_i) // pop mask on active fpu resp hs
+    );
+
+    // Fifo to store the output direction of the element during the FPU reduction
+    fifo_v3 #(
+        .FALL_THROUGH     (1'b0),
+        .DATA_WIDTH       (NumRoutes),
+        .DEPTH            (RdPipelineDepth+2)
+    ) i_fifo_outdir (
+        .clk_i            (clk_i),
+        .rst_ni           (rst_ni),
+        .flush_i          (flush_i),
+        .testmode_i       (1'b0),
+        .full_o           (),
+        .empty_o          (),
+        .usage_o          (),
+        .data_i           (req_output_mask),
+        .push_i           (reduction_req_valid_i & reduction_req_ready_i),  // push mask on active fpu req hs
+        .data_o           (metadata_out_mask),
+        .pop_i            (reduction_resp_valid_i & reduction_resp_ready_i) // pop mask on active fpu resp hs
+    );
+end
+
+// Parse the mask
+//Combine the metadata flit together with the result from the reduction.
+always_comb begin
+    fully_red_flit = '0;
+    if(RdSupportAxi == 1'b1) begin
+        fully_red_flit = insertAXIWdata(metadata_out_flit, fully_red_data_i.data);
+    end
+    fully_red_mask = metadata_out_mask;
+end
+
+// Generate the signal for the demux which either forwards the reduction response
+// to the partial buffer or towards the output (if fully reduced)
+if(GENERIC || STALLING) begin : gen_response_demux
+    logic [RdBufferSize-1:0] temp_match;
+    for(genvar i = 0; i < RdBufferSize; i++) begin
+        // Only allow if we found a matching final mask and tag with a valid entry
+        assign temp_match[i] = (buffer_q[i].f_valid && (buffer_q[i].final_mask == reduction_resp_mask_i) && (buffer_q[i].tag == reduction_resp_tag_i)) ? 1'b1 : 1'b0; 
+    end
+    assign ctrl_output_demux_o = (|temp_match) & reduction_resp_valid_i;
+end else begin
+    // No buffering - always forward it
+    assign ctrl_output_demux_o = 1'b1;
+end
+
+// AXI Specific function!
+// Insert data into AXI specific W frame! 
+function automatic flit_t insertAXIWdata(flit_t metadata, RdData_t data);
+    floo_axi_w_flit_t w_flit;
+    // Parse the entire flit
+    w_flit = floo_axi_w_flit_t'(metadata);
+    // Copy the new data
+    w_flit.payload.data = data;
+    return flit_t'(w_flit);
+endfunction
+
+// Extract data from AXI specific W frame! 
+function automatic RdData_t extractAXIWdata(flit_t metadata);
+    floo_axi_w_flit_t w_flit;
+    // Parse the entire flit
+    w_flit = floo_axi_w_flit_t'(metadata);
+    // Return the W data
+    return w_flit.payload.data;
+endfunction
+
+// Store the data in the buffer
+`FF(buffer_q, buffer_d, '0, clk_i, rst_ni)
+
+// Store all locked in signals
+`FF(locked_q, locked_d, '0, clk_i, rst_ni)
+`FF(selected_input_q, selected_input_d, '0, clk_i, rst_ni)
+`FF(selected_partial_result_buffer_q, selected_partial_result_buffer_d, '0, clk_i, rst_ni)
+`FF(selected_partial_result_mux_q, selected_partial_result_mux_d, '0, clk_i, rst_ni)
+`FF(selected_op_q, selected_op_d, floo_pkg::F_Add, clk_i, rst_ni)
+`FF(selected_tag_q, selected_tag_d, '0, clk_i, rst_ni)
+
+/* ASSERTION Checks */
+// We can only run GENERIC or SIMPLE or STALLING
+`ASSERT_INIT(Invalid_Configuration_1, !(GENERIC & SIMPLE))
+`ASSERT_INIT(Invalid_Configuration_2, !(STALLING & SIMPLE))
+`ASSERT_INIT(Invalid_Configuration_3, !(GENERIC & STALLING))
+`ASSERT_INIT(Invalid_Configuration_4, (GENERIC | STALLING | SIMPLE))
+
+// Currently the AXI support must be enabled
+`ASSERT_INIT(Support_AXI, RdSupportAxi)
+
+endmodule

--- a/hw/floo_offload_reduction_controller.sv
+++ b/hw/floo_offload_reduction_controller.sv
@@ -131,10 +131,10 @@ module floo_offload_reduction_controller #(
 
 /* All local parameter */
 // Buffer Size to control all ongoing reduction
-// @ GENERIC: Use conservativ approach with (RdPipelineDepth+RdPartialBufferSize) // TODO: optimize size!
+// @ GENERIC: Needs to be at least to be RdPartialBufferSize which is RdPipelineDepth+1
 // @ STALLING: We only have one reduction ongoing so 1 is enough
 // @ SIMPLE: We do not need any buffer so 1 to avoid questa panic (will be optimized away as never used)
-localparam int unsigned RdBufferSize = (GENERIC) ? (RdPipelineDepth+RdPartialBufferSize) : 1;
+localparam int unsigned RdBufferSize = (GENERIC) ? (RdPartialBufferSize) : 1;
 
 localparam bit [NumRoutes-1:0] ONES = 1;
 

--- a/hw/floo_offload_reduction_stalling.sv
+++ b/hw/floo_offload_reduction_stalling.sv
@@ -1,0 +1,101 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Raphael Roth <raroth@student.ethz.ch>
+
+// This module allows to stall a valid / ready handshake by delaying the ready signal
+// to the source. Any valid signal acknowledged on the destination side will lead to
+// the deassertion of said valid signal. The handshake to the source can be controlled
+// by an external stalling signal.
+
+// The stalling signal is not preemtive e.g. it needs to be asserted in either the cycle where
+// the dst handshake occurs or after. A stalling signal befor will be ignored!
+
+`include "common_cells/registers.svh"
+
+module floo_offload_reduction_stalling #() (
+    /// Control Inputs
+    input  logic        clk_i,
+    input  logic        rst_ni,
+    input  logic        flush_i,
+    /// All Input Connections
+    input  logic        src_valid_i,
+    output logic        src_ready_o,
+    /// Stop stalling the valid signal
+    input logic         stalling_i,
+    /// All Output Connections
+    output logic        dst_valid_o,
+    input logic         dst_ready_i
+);
+
+/* All local parameter */
+
+/* All Typedef Vars */
+
+// Var to track the state of the handshake
+typedef enum logic [1:0] { 
+    s_idle = 2'd0,
+    s_forward = 2'd1,
+    s_stalling = 2'd2
+} state_t;
+
+/* Variable declaration */
+state_t sm_d, sm_q;
+
+/* Module Declaration */
+always_comb begin
+    // Init all Vars
+    sm_d = sm_q;
+
+    dst_valid_o = 1'b0;
+    src_ready_o = 1'b0;
+
+    // Small State Machine
+    case(sm_d)
+        s_idle: begin
+            dst_valid_o = src_valid_i;  // forward the valid signal
+
+            if((src_valid_i == 1'b1) && (dst_ready_i == 1'b0)) begin
+                sm_d = s_forward;
+            end else if((src_valid_i == 1'b1) && (dst_ready_i == 1'b1) && (stalling_i == 1'b0)) begin
+                sm_d = s_stalling;
+            end else if((src_valid_i == 1'b1) && (dst_ready_i == 1'b1) && (stalling_i == 1'b1)) begin
+                src_ready_o = 1'b1;
+                sm_d = s_idle;
+            end
+        end        
+        s_forward: begin
+            dst_valid_o = src_valid_i;  // forward the valid signal
+
+            if((src_valid_i == 1'b1) && (dst_ready_i == 1'b1) && (stalling_i == 1'b0)) begin
+                sm_d = s_stalling;
+            end else if((src_valid_i == 1'b1) && (dst_ready_i == 1'b1) && (stalling_i == 1'b1)) begin
+                src_ready_o = 1'b1;
+                sm_d = s_idle;
+            end
+        end
+        s_stalling: begin
+            dst_valid_o = 1'b0; // the valid signal was already acked
+
+            if(stalling_i == 1'b1) begin
+                src_ready_o = 1'b1;
+                sm_d = s_idle;
+            end
+        end
+    endcase
+
+    // Reset the state
+    if(flush_i == 1'b1) begin
+        sm_d = s_idle;
+        dst_valid_o = 1'b0;
+        src_ready_o = 1'b0;
+    end
+end
+
+
+// Buffer the locked in signal
+`FF(sm_q, sm_d, s_idle, clk_i, rst_ni)
+
+
+endmodule

--- a/hw/floo_offload_reduction_taggen.sv
+++ b/hw/floo_offload_reduction_taggen.sv
@@ -1,0 +1,246 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Raphael Roth <raroth@student.ethz.ch>
+
+// To be able to have multiple infligth reduction at the same time we need to track each element
+// belonging to an individal reduction. Only elements with equal tag will be reduced together.
+// This separation into a seperate module allows to reduce the tracking effort inside the rest
+// of the system. Depending on the system restriction we can have a more sophiticated tag 
+// generator implementation. In the most general case we would support reduction of 
+// out-of-order arriving elements (NOT SUPPORTED!)
+
+// Current Implementation:
+// We want to support the most general input pattern without the overhead of out-of-order 
+// tracking. The main problem is that the tag can never be out of sync in respect for all 
+// inputs. If one element is excpected from a certain input direction then it is only allowed 
+// to increment the Tag if the element actually arrives (and not sooner!) therefor we count
+// pending elements on each input. If no element is excpected from one direction then the Tag 
+// should be incremented immidiatly.
+
+// Example:
+// We have 3 different inputs (A,B & C) for two reductions:
+// - Reduction 1 with 2 (1.1 + 1.2) Flits from dir A & B
+// - Reduction 2 with 3 (2.1 + 2.2 + 2.3) Flits from dir B & C
+
+// Cycle 0  A > Flit 1.1A arrives --> gets Tag 1 --> internal Tag set to 2
+//          B > Flit expected but not here yet --> internal Tag remains 1 (pending counter = 1)
+//          C > No Flit expected --> internal Tag set to 2
+//
+// Cycle 1  A > Flit 1.2A arrives --> gets Tag 2 --> internal Tag set to 3
+//          B > Flit 1.1B arrives --> gets Tag 1 --> internal Tag set to 2 (pending counter = 1)
+//          C > No Flit expected --> internal Tag set to 3
+//
+// Cycle 2  None
+//
+// Cycle 3  A > No Flit --> internal Tag remains 3
+//          B > Flit 1.2B arrives --> gets Tag 2 --> internal Tag set to 3 (pending counter = 0)
+//          C > No Flit --> internal Tag remains 3
+//
+// Cycle 4  None
+//
+// Cycle 5  A > No Flit expected --> internal Tag set to 4
+//          B > Flit 2.1B arrives --> gets Tag 3 --> internal Tag set to 4
+//          C > Flit 2.1C arrives --> gets Tag 3 --> internal Tag set to 4 
+//
+// Cycle 6  None*
+//
+// Cycle 7  A > No Flit expected --> internal Tag set to 5
+//          B > Flit 2.2B arrives --> gets Tag 4 --> internal Tag set to 5
+//          C > Flit expected but not here yet --> internal Tag remains 4 (pending counter = 1)
+//
+// Cycle 8  A > No Flit expected --> internal Tag set to 6
+//          B > Flit 2.3B arrives --> gets Tag 5 --> internal Tag set to 6
+//          C > Flit expected but not here yet --> internal Tag remains 4 (pending counter = 2)
+//
+// Cycle 9  A > No Flit --> internal Tag remains 6
+//          B > No Flit --> internal Tag remains 6
+//          C > Flit 2.2C arrives --> gets Tag 4 --> internal Tag set to 5 (pending counter = 1)
+//
+// Cycle 10 A > No Flit --> internal Tag remains 6
+//          B > No Flit --> internal Tag remains 6
+//          C > Flit 2.3C arrives --> gets Tag 5 --> internal Tag set to 6 (pending counter = 0)
+//
+// * At this point we have finished reduction threfor all internal tag are required to be on the
+//   same internal level because we do not know from where the next flits will arrive from.
+
+// Restriction:
+// - With the current implementation it is impossible to handle two different incoming reduction
+//   (different target address) request in the same cycle. However it should work if a pending 
+//   elements incomes together with an new reduction request (Not tested!).
+// - All inputs needs to be strictly in order.
+
+// Open Points:
+// - Check if the module works with backpressure or not. Maybe necessary to introduce output 
+//   stage if valid is asserted but not accepted by ready yet.
+// - Evaluate the target adress to allow for more than one incoming reduction at the same time
+
+`include "common_cells/registers.svh"
+
+module floo_offload_reduction_taggen #(
+    /// Number of input routes
+    parameter int unsigned NumRoutes                    = 1,
+    /// Typedef for the Tag
+    parameter type TAG_T                                = logic,
+    /// Bit-Width of the TAG_T
+    parameter int unsigned RdTagBits                    = 1
+) (
+    /// Control Inputs
+    input  logic                                clk_i,
+    input  logic                                rst_ni,
+    input  logic                                flush_i,
+    /// All Input directions
+    input logic [NumRoutes-1:0][NumRoutes-1:0]  mask_i,
+    input logic [NumRoutes-1:0]                 valid_i,
+    input logic [NumRoutes-1:0]                 ready_i,
+    /// Generated Tag for each output
+    output TAG_T [NumRoutes-1:0]                tag_o
+);
+
+/* All local parameter */
+localparam int unsigned  MaxNumberofOutstandingRed = 1 << RdTagBits;
+
+/* All Typedef Vars */
+
+/* Variable declaration */
+logic [NumRoutes-1:0] inc_pending;
+logic [NumRoutes-1:0] dec_pending;
+logic [NumRoutes-1:0] outstanding_pending;
+
+logic [NumRoutes-1:0][NumRoutes-1:0] gen_mask_with_pending;
+
+logic [NumRoutes-1:0] inc_tag;
+logic [NumRoutes-1:0] inc_tag_pending_src;
+logic [NumRoutes-1:0] general_mask;
+
+TAG_T [NumRoutes-1:0] tag_q, tag_d;
+
+logic [NumRoutes-1:0] handshake;
+
+logic new_reduction_incoming;
+
+/* Module Declaration */
+
+// determint if we have a active valid handshake
+assign handshake = valid_i & ready_i;
+
+// Generate Credit Counter once per input
+for (genvar i = 0; i < NumRoutes; i++) begin : gen_pending_tracker
+    credit_counter #(
+        .NumCredits         (MaxNumberofOutstandingRed),
+        .InitCreditEmpty    (1'b1)
+    ) i_credit_counter (
+        .clk_i              (clk_i),
+        .rst_ni             (rst_ni),
+        .credit_o           (),
+        .credit_give_i      (inc_pending[i]),
+        .credit_take_i      (dec_pending[i]),
+        .credit_init_i      (1'b0),
+        .credit_left_o      (outstanding_pending[i]),   // == 1'b1 if credits are available
+        .credit_crit_o      (),  // Giving one more credit will fill the credits
+        .credit_full_o      ()
+    );
+end
+
+// Generat the mask - if no pending incoming req then forward the mask, otherwise set to 0!
+for (genvar i = 0; i < NumRoutes; i++) begin
+    for (genvar j = 0; j < NumRoutes; j++) begin
+        assign gen_mask_with_pending[j][i] = 
+                ((outstanding_pending[i] == 1'b0) && (handshake[i] == 1'b1)) ? mask_i[i][j] : 1'b0;
+    end
+end
+
+// The general mask indicates if the router excpect an element on this input. The or-connection 
+// between all inputs is to receive the first handshake on any interface availble.
+// The mask is only taken into consideration in the general mask if no pending element exists on
+// the input as the strict in-order-requiremnt determines that the next incoming element
+// belongs to an "old" reduction.
+
+// Here is also the problematic part when two different reductions arrive at the same time:
+// the generated mask would be the combination of the two and the tag would be mixed up!
+
+// Generate the General Mask (OR-Connect all 1 bit / 2 bit etc.)
+for (genvar i = 0; i < NumRoutes; i++) begin : gen_reduce_bitwise_outer
+    assign general_mask[i] = |gen_mask_with_pending[i];
+end
+
+// Generate the Signal where we indicate if a new reduction is incoming
+assign new_reduction_incoming = (|handshake) & (|general_mask);
+
+always_comb begin
+    // Init all Vars
+    inc_pending = '0;
+    dec_pending = '0;
+    inc_tag = '0;
+    inc_tag_pending_src = '0;
+
+    // Iterate over all inputs
+    for (int i = 0; i < NumRoutes;i++) begin
+        // Increment the Tag if we have a valid handshake and the bit in the general mask is set
+        // (Element expected from this input and element is actually there)
+        if((general_mask[i] == 1'b1) && (handshake[i] == 1'b1) && (new_reduction_incoming == 1'b1)) begin
+            // Edge case: On another input we have new incoming request but we have also a pending one 
+            // with the same mask on this input therefore the received entry is the pending one 
+            // (handled further down) and not the "new" one - so increment the pending one
+            if(outstanding_pending[i] == 1'b1) begin
+                inc_pending[i] = 1'b1;
+            end else begin
+                inc_tag[i] = 1'b1;
+            end
+        end
+
+        // Increment the Pending for this Input when the general mask bit is set but we do not have a hs
+        // (Element expected from this input but element is not there)
+        if((general_mask[i] == 1'b1) && (handshake[i] == 1'b0) && (new_reduction_incoming == 1'b1)) begin
+            inc_pending[i] = 1'b1;
+        end
+
+        // Increment the Tag if the general mask bit is clear but somewhere exists a hs
+        // (No Element expected from this input - make sure to only increment by 1)
+        // However if this entry is backpressured then add a pending
+        if((general_mask[i] == 1'b0) && (new_reduction_incoming == 1'b1)) begin
+            if(valid_i[i] == 1'b0) begin
+                inc_tag[i] = 1'b1;
+            end else begin
+                inc_pending[i] = 1'b1;
+            end
+        end
+
+        // Decrement the Pending for this Input if we have a pending incoming element and a valid hs
+        // (Element arrives from a erlier handled request but was pending)
+        if((outstanding_pending[i] == 1'b1) && (handshake[i] == 1'b1)) begin
+            dec_pending[i] = 1'b1;
+            inc_tag_pending_src[i] = 1'b1;
+        end
+    end
+end
+
+// Generate the Tag's here!
+always_comb begin
+    // Init all Vars
+    tag_d = tag_q;
+
+    // Iterate over all inputs
+    for (int i = 0; i < NumRoutes;i++) begin
+
+        // Increment the Tag
+        if(inc_tag[i] == 1'b1) begin
+            tag_d[i] = tag_d[i] + 1;
+        end
+
+        // Increment the Tag again if we have a second HS
+        if(inc_tag_pending_src[i] == 1'b1) begin
+            tag_d[i] = tag_d[i] + 1;
+        end
+    end
+end
+
+// Assign the output tag
+assign tag_o = tag_q;
+
+// buffer the tag
+`FF(tag_q, tag_d, '0, clk_i, rst_ni)
+
+/* ASSERTION Checks */
+endmodule

--- a/hw/floo_output_arbiter.sv
+++ b/hw/floo_output_arbiter.sv
@@ -2,7 +2,12 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 //
-// Chen Wu <chenwu@student.ethz.ch>
+// Author: Chen Wu <chenwu@student.ethz.ch>
+//         Raphael Roth <raroth@student.ethz.ch>
+
+// The purpose of the slave ports is to merge data from port's which are not mapped in the "normal" way.
+// An example would be the output of the reduction logic!
+// These ports cannot be reduced!
 
 `include "common_cells/assertions.svh"
 
@@ -10,43 +15,60 @@ module floo_output_arbiter import floo_pkg::*;
 #(
   /// Number of input ports
   parameter int unsigned NumRoutes  = 1,
+  /// Number of additional input ports to merge (MSB Part of the array contains the slave ports)
+  parameter int unsigned NumSlaveRoutes = 0,
+  /// Enable parallel reduction feature
+  parameter bit          EnParallelReduction  = 1'b0,
   /// Type definitions
-  parameter type         flit_t     = logic,
-  parameter type         payload_t  = logic,
-  parameter payload_t    NarrowRspMask = '0,
-  parameter payload_t    WideRspMask = '0,
-  parameter type         id_t       = logic
+  parameter type         flit_t               = logic,
+  parameter type         hdr_t                = logic,
+  parameter type         payload_t            = logic,
+  parameter payload_t    NarrowRspMask        = '0,
+  parameter payload_t    WideRspMask          = '0,
+  parameter type         id_t                 = logic,
+  /// Do we support local loopback e.g. should the logic expect the local flit or not
+  parameter bit          RdSupportLoopback    = 1'b0,
+  /// AXI dependent parameter
+  parameter bit          RdSupportAxi         = 1'b1,
+  parameter axi_cfg_t    AxiCfg               = '0,
+  /// FIXED PARAM'S - DO NOT OVERWRITE!
+  parameter int unsigned localRoutes          = (NumRoutes + NumSlaveRoutes)
 ) (
-  input  logic                   clk_i,
-  input  logic                   rst_ni,
+  input  logic                      clk_i,
+  input  logic                      rst_ni,
   /// Current XY-coordinate of the router
-  input  id_t                    xy_id_i,
+  input  id_t                       xy_id_i,
   /// Input ports
-  input  logic  [NumRoutes-1:0]  valid_i,
-  output logic  [NumRoutes-1:0]  ready_o,
-  input  flit_t [NumRoutes-1:0]  data_i,
+  input  logic  [localRoutes-1:0]   valid_i,
+  output logic  [localRoutes-1:0]   ready_o,
+  input  flit_t [localRoutes-1:0]   data_i,
   /// Output port
-  output logic                   valid_o,
-  input  logic                   ready_i,
-  output flit_t                  data_o
+  output logic                      valid_o,
+  input  logic                      ready_i,
+  output flit_t                     data_o
 );
 
-  flit_t                 reduce_data_out, unicast_data_out;
-  logic [NumRoutes-1:0]  reduce_valid_in, unicast_valid_in, reduce_ready_out, unicast_ready_out;
-  logic                  reduce_valid_out, unicast_valid_out, reduce_ready_in, unicast_ready_in;
+  flit_t                    reduce_data_out, unicast_data_out;
+  logic [localRoutes-1:0]   reduce_valid_in, unicast_valid_in, reduce_ready_out, unicast_ready_out;
+  logic                     reduce_valid_out, unicast_valid_out, reduce_ready_in, unicast_ready_in;
 
-  logic [NumRoutes-1:0]  reduce_mask;
+  logic [localRoutes-1:0]   reduce_mask;
+
+  // Var to sparate Non-Slave ports if they have to go to the reduction arbiter!
+  flit_t [NumRoutes-1:0]    full_port_data;
+  logic [NumRoutes-1:0]     full_port_valid;
+  logic [NumRoutes-1:0]     full_port_ready;
 
   // Determine which input ports are to be reduced
-  for (genvar i = 0; i < NumRoutes; i++) begin : gen_reduce_mask
-    assign reduce_mask[i] = (data_i[i].hdr.commtype == ParallelReduction);
+  for (genvar i = 0; i < localRoutes; i++) begin : gen_reduce_mask
+    assign reduce_mask[i] = (i < NumRoutes) ? (data_i[i].hdr.commtype == ParallelReduction) : 1'b0;
   end
 
   // Arbitrate unicasts
   assign unicast_valid_in = valid_i & ~reduce_mask;
 
   floo_wormhole_arbiter #(
-    .NumRoutes  ( NumRoutes ),
+    .NumRoutes  ( localRoutes ),
     .flit_t     ( flit_t    )
   ) i_wormhole_arbiter (
     .clk_i,
@@ -62,18 +84,32 @@ module floo_output_arbiter import floo_pkg::*;
   // Arbitrate reductions
   assign reduce_valid_in = valid_i & reduce_mask;
 
+  // The reduction supportonly the "original" configuration of NumRoutes!
+  // Therefor we have to mask all slave ports here!
+  assign full_port_data = data_i[NumRoutes-1:0];
+  assign full_port_valid = reduce_valid_in[NumRoutes-1:0];
+  assign reduce_ready_out[NumRoutes-1:0] = full_port_ready;
+  if(NumSlaveRoutes > 0) begin
+    assign reduce_ready_out[NumSlaveRoutes+NumRoutes-1:NumRoutes] = '0;
+  end
+
   floo_reduction_arbiter #(
-    .NumRoutes      ( NumRoutes     ),
-    .flit_t         ( flit_t        ),
-    .payload_t      ( payload_t     ),
-    .id_t           ( id_t          ),
-    .NarrowRspMask  ( NarrowRspMask ),
-    .WideRspMask    ( WideRspMask   )
+    .NumRoutes            ( NumRoutes           ),
+    .EnParallelReduction  ( EnParallelReduction ),
+    .flit_t               ( flit_t              ),
+    .hdr_t                ( hdr_t               ),
+    .payload_t            ( payload_t           ),
+    .id_t                 ( id_t                ),
+    .NarrowRspMask        ( NarrowRspMask       ),
+    .WideRspMask          ( WideRspMask         ),
+    .RdSupportLoopback    ( RdSupportLoopback   ),
+    .RdSupportAxi         ( RdSupportAxi        ),
+    .AxiCfg               ( AxiCfg              )
   ) i_reduction_arbiter (
     .xy_id_i,
-    .data_i,
-    .valid_i   ( reduce_valid_in  ),
-    .ready_o   ( reduce_ready_out ),
+    .data_i    ( full_port_data   ),
+    .valid_i   ( full_port_valid  ),
+    .ready_o   ( full_port_ready  ),
     .valid_o   ( reduce_valid_out ),
     .ready_i   ( reduce_ready_in  ),
     .data_o    ( reduce_data_out  )

--- a/hw/floo_pkg.sv
+++ b/hw/floo_pkg.sv
@@ -234,6 +234,51 @@ package floo_pkg;
     bit CutRsp;
   } chimney_cfg_t;
 
+  /// Controller configuration
+  typedef enum logic [1:0] {
+    /// Simple configuration
+    ControllerSimple = 2'd0,
+    /// Stalling configuration
+    ControllerStalling = 2'd1,
+    /// Generic configuration
+    ControllerGeneric = 2'd2
+  } floo_red_controller_e;
+
+  /// Configuration for the offload reduction logic
+  typedef struct packed {
+    /// configuration for the controller
+    floo_red_controller_e RdControllConf;
+    /// input fifo configuration
+    bit RdFifoFallThrough;
+    int unsigned RdFifoDepth;
+    /// pipeline depth of the offload unit
+    int unsigned RdPipelineDepth;
+    /// partial buffer size
+    int unsigned RdPartialBufferSize;
+    /// required tag bit if generic controller is used
+    int unsigned RdTagBits;
+    /// is the underlying protocl AXI
+    bit RdSupportAxi;
+    /// enable the bypass (required for AXI-AW)
+    bit RdEnableBypass;
+    /// support loopback for the local link - collective will
+    /// be forwarded to the local port too.
+    bit RdSupportLoopback;
+  } reduction_cfg_t;
+
+  /// The default configuration for the reduction
+  localparam reduction_cfg_t ReductionDefaultCfg = '{
+    RdControllConf: ControllerGeneric,
+    RdFifoFallThrough: 1'b1,
+    RdFifoDepth: 2,
+    RdPipelineDepth: 5,
+    RdPartialBufferSize: 3,
+    RdTagBits: 5,
+    RdSupportAxi: 1'b1,
+    RdEnableBypass: 1'b1,
+    RdSupportLoopback: 1'b1
+  };
+
   /// The default configuration for the network interface
   localparam chimney_cfg_t ChimneyDefaultCfg = '{
     EnSbrPort: 1'b1,

--- a/hw/floo_reduction_arbiter.sv
+++ b/hw/floo_reduction_arbiter.sv
@@ -3,19 +3,31 @@
 // SPDX-License-Identifier: SHL-0.51
 //
 // Author: Chen Wu <chenwu@student.ethz.ch>
+//         Raphael Roth <raroth@student.ethz.ch>
+
+`include "axi/typedef.svh"
+`include "floo_noc/typedef.svh"
 
 module floo_reduction_arbiter import floo_pkg::*;
 #(
   /// Number of input ports
-  parameter int unsigned NumRoutes  = 1,
+  parameter int unsigned NumRoutes            = 1,
+  /// Enable Parallel Reduction
+  parameter bit          EnParallelReduction  = 1'b0,
   /// Type definitions
-  parameter type         flit_t     = logic,
-  parameter type         payload_t  = logic,
+  parameter type         flit_t               = logic,
+  parameter type         hdr_t                = logic,
+  parameter type         payload_t            = logic,
   // Masks used to select which bits of the payload are part of the response,
   // allowing extraction of relevant bits and detection of any participant errors.
-  parameter payload_t    NarrowRspMask = '0,
-  parameter payload_t    WideRspMask = '0,
-  parameter type         id_t       = logic
+  parameter payload_t    NarrowRspMask        = '0,
+  parameter payload_t    WideRspMask          = '0,
+  parameter type         id_t                 = logic,
+  /// Do we support local loopback e.g. should the logic expect the local flit or not
+  parameter bit          RdSupportLoopback    = 1'b0,
+  /// AXI dependent parameter
+  parameter bit          RdSupportAxi         = 1'b1,
+  parameter axi_cfg_t    AxiCfg               = '0
 ) (
   /// Current XY-coordinate of the router
   input  id_t                    xy_id_i,
@@ -28,6 +40,30 @@ module floo_reduction_arbiter import floo_pkg::*;
   input  logic                   ready_i,
   output flit_t                  data_o
 );
+
+  // Generate the AXI specific types
+  typedef logic [AxiCfg.AddrWidth-1:0] axi_addr_t;
+  typedef logic [AxiCfg.InIdWidth-1:0] axi_in_id_t;
+  typedef logic [AxiCfg.OutIdWidth-1:0] axi_out_id_t;
+  typedef logic [AxiCfg.UserWidth-1:0] axi_user_t;
+  typedef logic [AxiCfg.DataWidth-1:0] axi_data_t;
+  typedef logic [AxiCfg.DataWidth/8-1:0] axi_strb_t;
+
+  `AXI_TYPEDEF_ALL_CT(axi, axi_req_t, axi_rsp_t, axi_addr_t, axi_in_id_t, axi_data_t, axi_strb_t, axi_user_t)
+  `AXI_TYPEDEF_AW_CHAN_T(axi_out_aw_chan_t, axi_addr_t, axi_out_id_t, axi_user_t)
+  `FLOO_TYPEDEF_AXI_CHAN_ALL(axi, req, rsp, axi, AxiCfg, hdr_t)
+
+  // We calculte the different reduction in parallel and select the result at the output
+  flit_t data_forward_flit;   
+  flit_t data_collectB;
+  flit_t data_LSBAnd;
+
+  // Logic bit to connect all LSB together
+  logic lsb;
+  logic [1:0] resp;
+
+  // Reduction mask for either the narrow or wide link
+  payload_t ReduceMask;
 
   // calculated expected input source lists for each input flit
   logic [NumRoutes-1:0]  in_route_mask;
@@ -45,10 +81,11 @@ module floo_reduction_arbiter import floo_pkg::*;
   );
 
   floo_reduction_sync #(
-    .NumRoutes ( NumRoutes ),
-    .arb_idx_t ( arb_idx_t ),
-    .flit_t    ( flit_t    ),
-    .id_t      ( id_t      )
+    .NumRoutes          ( NumRoutes ),
+    .RdSupportLoopback  ( RdSupportLoopback ),
+    .arb_idx_t          ( arb_idx_t ),
+    .flit_t             ( flit_t    ),
+    .id_t               ( id_t      )
   ) i_reduction_sync (
     .sel_i            ( input_sel     ),
     .data_i           ( data_i        ),
@@ -58,14 +95,12 @@ module floo_reduction_arbiter import floo_pkg::*;
     .in_route_mask_o  ( in_route_mask )
   );
 
-  payload_t ReduceMask;
+  // Set the eduction mask for either the narrow or the wide link
   assign ReduceMask = data_i[input_sel].hdr.axi_ch==NarrowB? NarrowRspMask : WideRspMask;
 
-  logic [1:0] resp;
-
-  // Reduction operation
+  // Collect B response operation
   always_comb begin : gen_reduced_B
-    data_o = data_i[input_sel];
+    data_collectB = data_i[input_sel];
     // We check every input port from which we expect a response
     for (int i = 0; i < NumRoutes; i++) begin
       if(in_route_mask[i]) begin
@@ -81,13 +116,80 @@ module floo_reduction_arbiter import floo_pkg::*;
         // If one of the responses is an error, we return an error
         // otherwise we return the first response
         if(resp == axi_pkg::RESP_SLVERR) begin
-          data_o = data_i[i];
+          data_collectB = data_i[i];
           break;
         end
       end
     end
   end
 
+  // Forward flits directly - Just choose to forward the selected one
+  always_comb begin : gen_forward
+    data_forward_flit = data_i[input_sel];
+  end
+
+  // And all the LSB
+  always_comb begin : gen_and_lsb
+    data_LSBAnd = data_i[input_sel];
+    lsb = 1'b1;
+    
+    // We check every input port from which we expect a response
+    for (int i = 0; i < NumRoutes; i++) begin
+      if(in_route_mask[i]) begin
+        // Extract the last bit from the data
+        if(RdSupportAxi) begin
+          lsb = lsb & extractAXIWlsb(data_i[i]);
+        end
+      end
+    end
+
+    // Assign the bit again
+    if(RdSupportAxi) begin
+      data_LSBAnd = insertAXIWlsb(data_LSBAnd, lsb);
+    end
+  end
+
+  // If we support more than the inital parallel reduction
+  if(EnParallelReduction) begin
+    always_comb begin
+      // Assign inital value
+      data_o = '0;
+      if(data_i[input_sel].hdr.reduction_op == SelectAW) begin
+        // AW flit dedected
+        data_o = data_forward_flit;
+      end else if(data_i[input_sel].hdr.reduction_op == CollectB) begin
+        // Collect B flit dedected
+        data_o = data_collectB;
+      end else if(data_i[input_sel].hdr.reduction_op == LSBAnd) begin
+        // LSB And flit dedected
+        data_o = data_LSBAnd;
+      end
+    end
+  end else begin
+    assign data_o = data_collectB;
+  end
+
+  // Connect the ready signal
   assign ready_o = (ready_i & valid_o)? valid_i & in_route_mask : '0;
+
+  // AXI Specific function!
+  // Insert data into AXI specific W frame! 
+  function automatic flit_t insertAXIWlsb(flit_t metadata, logic data);
+      floo_axi_w_flit_t w_flit;
+      // Parse the entire flit
+      w_flit = floo_axi_w_flit_t'(metadata);
+      // Copy the new data
+      w_flit.payload.data[0] = data;
+      return flit_t'(w_flit);
+  endfunction
+
+  // Extract data from AXI specific W frame! 
+  function automatic logic extractAXIWlsb(flit_t metadata);
+      floo_axi_w_flit_t w_flit;
+      // Parse the entire flit
+      w_flit = floo_axi_w_flit_t'(metadata);
+      // Return the W data
+      return w_flit.payload.data[0];
+  endfunction
 
 endmodule

--- a/hw/floo_reduction_sync.sv
+++ b/hw/floo_reduction_sync.sv
@@ -3,11 +3,14 @@
 // SPDX-License-Identifier: SHL-0.51
 //
 // Author: Chen Wu <chenwu@student.ethz.ch>
+//         Raphael Roth <raroth@student.ethz.ch>
 
 module floo_reduction_sync import floo_pkg::*;
 #(
   /// Number of input ports
   parameter int unsigned NumRoutes  = 1,
+  /// Do we support local loopback e.g. should the logic expect the local flit or not
+  parameter bit          RdSupportLoopback    = 1'b0,
   /// Type definitions
   parameter type         arb_idx_t  = logic,
   parameter type         flit_t     = logic,
@@ -43,9 +46,8 @@ module floo_reduction_sync import floo_pkg::*;
                                (data_i[in].hdr.dst_id == data_i[sel_i].hdr.dst_id));
 
     // Determine if this input should be considered valid for the reduction:
-    // If we are at the dst node and the port is the local one, we don’t wait for a
-    // response/reduction since it will stay locally [NoLoopBack].
-    assign same_and_valid[in] = (data_i[sel_i].hdr.dst_id == xy_id_i && in == Eject) ||
+    assign same_and_valid[in] = RdSupportLoopback ? (compare_same[in] & valid_i[in]) :
+                                (data_i[sel_i].hdr.dst_id == xy_id_i && in == Eject) ||
                                 (compare_same[in] & valid_i[in]);
   end
 

--- a/hw/floo_route_select.sv
+++ b/hw/floo_route_select.sv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: SHL-0.51
 //
 // Michael Rogenmoser <michaero@iis.ee.ethz.ch>
+// Raphael Roth <raroth@student.ethz.ch>
 
 `include "common_cells/registers.svh"
 
@@ -27,7 +28,9 @@ module floo_route_select
   /// Various types used in the routing algorithm
   parameter type         flit_t           = logic,
   parameter type         addr_rule_t      = logic,
-  parameter type         id_t             = logic[IdWidth-1:0]
+  parameter type         id_t             = logic[IdWidth-1:0],
+  /// Inversed SRC / DST if we want to support Multicast on the B response
+  parameter bit          InversedSrcDst       = 1'b0
 ) (
   input  logic                          clk_i,
   input  logic                          rst_ni,
@@ -44,8 +47,14 @@ module floo_route_select
   output logic [RouteSelWidth-1:0]      route_sel_id_o
 );
 
+  // Selected route defined by th alg.
   logic [NumRoutes-1:0] route_sel;
   logic [RouteSelWidth-1:0] route_sel_id;
+
+  // We need to calc the multicast and the unicast route in parallel
+  // and mux them depending on the flit header!
+  logic [NumRoutes-1:0] route_sel_multicast; 
+  logic [NumRoutes-1:0] route_sel_unicast;
 
   if (RouteAlgo == IdTable) begin : gen_id_table
     // Routing based on an ID table passed into the router (TBD parameter or signal)
@@ -102,43 +111,54 @@ module floo_route_select
 
     // One-hot encoding of the decoded route
 
+    // If we enable multicast then generate the output routes here seperatly
     if (EnMultiCast) begin : gen_mcast_route_sel
       floo_route_xymask #(
-        .NumRoutes     ( NumRoutes ),
-        .flit_t        ( flit_t    ),
-        .id_t          ( id_t      ),
-        .FwdMode       ( 1         )
+        .NumRoutes     ( NumRoutes        ),
+        .flit_t        ( flit_t           ),
+        .id_t          ( id_t             ),
+        .FwdMode       ( 1'b1             )
       ) i_route_xymask (
         .channel_i   ( channel_i ),
         .xy_id_i     ( xy_id_i   ),
-        .route_sel_o ( route_sel )
+        .route_sel_o ( route_sel_multicast )
       );
-      assign route_sel_id = '0; // Not defined in multicast
-    end else begin : gen_route_sel
-      id_t id_in;
-      assign id_in = id_t'(channel_i.hdr.dst_id);
-      always_comb begin
-        route_sel_id = East;
-        if (id_in.x == xy_id_i.x && id_in.y == xy_id_i.y) begin
-          route_sel_id = Eject + channel_i.hdr.dst_id.port_id;
-        end else if (id_in.x == xy_id_i.x) begin
-          if (id_in.y < xy_id_i.y) begin
-            route_sel_id = South;
-          end else begin
-            route_sel_id = North;
-          end
+    end else begin : gen_no_mcast
+      assign route_sel_multicast = '0;  // No MCast supported
+    end
+    
+    // Calculate here the unicast output mask
+    id_t id_in;
+    assign id_in = id_t'(channel_i.hdr.dst_id);
+    always_comb begin
+      route_sel_id = East;
+      if (id_in.x == xy_id_i.x && id_in.y == xy_id_i.y) begin
+        route_sel_id = Eject + channel_i.hdr.dst_id.port_id;
+      end else if (id_in.x == xy_id_i.x) begin
+        if (id_in.y < xy_id_i.y) begin
+          route_sel_id = South;
         end else begin
-          if (id_in.x < xy_id_i.x) begin
-            route_sel_id = West;
-          end else begin
-            route_sel_id = East;
-          end
+          route_sel_id = North;
         end
-        route_sel = '0;
-        route_sel[route_sel_id] = 1'b1;
+      end else begin
+        if (id_in.x < xy_id_i.x) begin
+          route_sel_id = West;
+        end else begin
+          route_sel_id = East;
+        end
       end
+      route_sel_unicast = '0;
+      route_sel_unicast[route_sel_id] = 1'b1;
     end
 
+    // Depending on the flit header choose the correct route
+    if(EnMultiCast) begin
+      assign route_sel = (channel_i.hdr.commtype == Multicast) ? route_sel_multicast : route_sel_unicast;
+    end else begin
+      assign route_sel = route_sel_unicast;
+    end
+
+    // Assign the data directly to the output
     assign channel_o = channel_i;
 
   end else begin : gen_err

--- a/hw/floo_route_xymask.sv
+++ b/hw/floo_route_xymask.sv
@@ -2,20 +2,32 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 //
-// Author: Chen Wu <chenwu@student.ethz.ch>
+// Author: 
+// - Chen Wu <chenwu@student.ethz.ch>
+// - Raphael Roth <raroth@student.ethz.ch>
 
-module floo_route_xymask
-  import floo_pkg::*;
-#(
-  /// Number of output ports
-  parameter int unsigned NumRoutes     = 0,
+// This module is the heartpiece for collectiv operation in the FlooNoC. When running an 
+// multicast / reduction it either determines the output direction of the filt 
+// (e.g. in which direction a copy of the filt has to be sent) or the expected
+// input direction (e.g. which input provides a flit).
+
+// Limitations:
+// - It only supports xy routing
+// - It only supports 5 in/out routes
+
+`include "common_cells/assertions.svh"
+
+module floo_route_xymask import floo_pkg::*; #(
+  /// Number of input / output ports
+  parameter int unsigned    NumRoutes   = 0,
   /// The type of mask to be computed
   /// 1: Determine output directions of the forward path in Multicast
   /// 0: Determine input directions of the backward path in Multicast i.e the reduction
-  parameter bit       FwdMode          = 1'b1,
-  /// Various types
-  parameter type         flit_t        = logic,
-  parameter type         id_t          = logic
+  parameter bit             FwdMode     = 1'b1,
+  /// type for data flit
+  parameter type            flit_t      = logic,
+  /// type for local id (router id)
+  parameter type            id_t        = logic
 ) (
   // The input flit (only the header is used)
   input  flit_t                         channel_i,
@@ -25,40 +37,98 @@ module floo_route_xymask
   output logic [NumRoutes-1:0]          route_sel_o
 );
 
-  logic [NumRoutes-1:0] route_sel;
+  // General Concept: In XY-Routing all flits travel first in X - direction until they arrive at the columne of the destination
+  //                  and then travel in Y direction until they reach the destination. In the Multicast case we have to forward
+  //                  them until the "most far away" x/y position (dst_id_max) determint by the mask!
 
-  id_t dst_id, mask_in, src_id;
+  // We need to handle 4 different cases in this module:
+  // ---------------------------------------------------
+  // @ Multicast
+  //
+  // Multicast            - src (Single)
+  //                      - dst (Multiple)
+  //                      --> generate destination mask
+  //
+  // Collect B            - src (Multiple)
+  //                      - dst (Single)
+  //                      --> generate expected input mask
+  // ---------------------------------------------------
+  // @ Reduction
+  //
+  // Reduction            - src (Multiple)
+  //                      - dst (Single)
+  //                      --> generate expected input mask
+  //
+  // distribute B resp    - src (Single)
+  //                      - dst (Multiple)
+  //                      --> generate destination mask
+  // ---------------------------------------------------
+
+  // Two cases overlap themself e.g. when we want to have an expected input mask
+  // we go from multiple sources to one destination (reduction). With the output mask it is
+  // the opposite with single source to multiple destinations (multicast).
+
+  // To improve readability of the code we generate both mask in parallel and only
+  // mux them at the output.
+
+/* Variable declaration */
+  // generated routes
+  logic [NumRoutes-1:0] route_ouput;
+  logic [NumRoutes-1:0] route_expected_input;
+
+  // Var for easier signal assignments
+  id_t dst_id;
+  id_t src_id;
+  id_t mask;
+
+  // Var to hold the maxium distribution distance for both source and destination
   id_t dst_id_max, dst_id_min;
-  logic x_matched, y_matched;
+  id_t src_id_max, src_id_min;
 
-  // In the forward path, we use the normal `dst_id` to compute the mask.
-  // In the backward path, we use the `src_id` which was the original
-  // `dst_id` in from the forward path.
-  assign dst_id = (FwdMode)? channel_i.hdr.dst_id : channel_i.hdr.src_id;
-  assign src_id = (FwdMode)? channel_i.hdr.src_id : channel_i.hdr.dst_id;
-  // TODO(fischeti): Clarify with Chen why `ParallelReduction` are excluded
-  assign mask_in = (FwdMode && channel_i.hdr.commtype==ParallelReduction)?
-                    '0 : channel_i.hdr.mask;
+  // Var indicates if the current router lies in the same x/y axis as the source / destination
+  logic x_matched_output;
+  logic y_matched_output;
+  logic x_matched_expected_input;
+  logic y_matched_expected_input;
+
+  // Signal assigments
+  assign dst_id = channel_i.hdr.dst_id;
+  assign src_id = channel_i.hdr.src_id;
+  assign mask = channel_i.hdr.mask;
 
   // We compute minimum and maximum destination IDs, to decide whether
   // we need to send left and/or right resp. up and/or down.
-  assign dst_id_max.x = dst_id.x | mask_in.x;
-  assign dst_id_max.y = dst_id.y | mask_in.y;
-  assign dst_id_min.x = dst_id.x & (~mask_in.x);
-  assign dst_id_min.y = dst_id.y & (~mask_in.y);
+  assign dst_id_max.x = dst_id.x | mask.x;
+  assign dst_id_max.y = dst_id.y | mask.y;
+  assign dst_id_min.x = dst_id.x & (~mask.x);
+  assign dst_id_min.y = dst_id.y & (~mask.y);
 
-  // `x/y_matched` means whether the current coordinate is a
-  // receiver of the the multicast.
-  assign x_matched = &(mask_in.x | ~(xy_id_i.x ^ dst_id.x));
-  assign y_matched = &(mask_in.y | ~(xy_id_i.y ^ dst_id.y));
+  // We compute minimum and maximum source IDs, to decide whether
+  // we need to send left and/or right resp. up and/or down.
+  assign src_id_max.x = src_id.x | mask.x;
+  assign src_id_max.y = src_id.y | mask.y;
+  assign src_id_min.x = src_id.x & (~mask.x);
+  assign src_id_min.y = src_id.y & (~mask.y);
 
-  always_comb begin
-    route_sel = '0;
-    if (FwdMode) begin : gen_out_mask
-      // If both x and y are matched, we eject the flit
-      if (x_matched && y_matched) begin
-        route_sel[Eject] = 1;
+  // `x/y_matched_output` means whether the current coordinate is a receiver of the the multicast.
+  assign x_matched_output = &(mask.x | ~(xy_id_i.x ^ dst_id.x));
+  assign y_matched_output = &(mask.y | ~(xy_id_i.y ^ dst_id.y));
+
+  // `x/y_matched_expected_input` means the current coordinate provides one element to the reduction.
+  assign x_matched_expected_input = &(mask.x | ~(xy_id_i.x ^ src_id.x));
+  assign y_matched_expected_input = &(mask.y | ~(xy_id_i.y ^ src_id.y));
+
+
+  // Generate the output mask
+  if(FwdMode) begin : gen_output_mask
+    always_comb begin
+      route_ouput = '0;
+
+      // If both direction match then the local port is member of the distribution
+      if(x_matched_output && y_matched_output) begin
+        route_ouput[Eject] = 1'b1;
       end
+
       // If the multicast was issued from an endpoint in the same row
       // i.e. the same Y-coordinate, we forward it to `East` if:
       // 1. The request is incoming from `West` or `Eject` and
@@ -66,53 +136,72 @@ module floo_route_xymask
       // The same applies to the `West` direction.
       if (xy_id_i.y == src_id.y) begin
         if (xy_id_i.x >= src_id.x && xy_id_i.x < dst_id_max.x) begin
-          route_sel[East] = 1;
+          route_ouput[East] = 1;
         end
         if (xy_id_i.x <= src_id.x && xy_id_i.x > dst_id_min.x) begin
-          route_sel[West] = 1;
+          route_ouput[West] = 1;
         end
       end
+
       // If there are multicast destinations in the current column,
       // We inject it to `North` if:
       // 1. The request is incoming from `South` or `Eject` and
       // 2. There are more multicast destinations in the `North` direction
       // The same applies to the `South` direction.
-      if (x_matched) begin
+      if (x_matched_output) begin
         if (xy_id_i.y >= src_id.y && xy_id_i.y < dst_id_max.y) begin
-          route_sel[North] = 1;
+          route_ouput[North] = 1;
         end
         if (xy_id_i.y <= src_id.y && xy_id_i.y > dst_id_min.y) begin
-          route_sel[South] = 1;
-        end
-      end
-    end
-
-    // TODO(fischeti): Clarify with Chen why `YXRouting` is used
-    // for the backward path
-    else begin : gen_in_mask
-      // If we previously ejected the flit, we expect one again
-      if (x_matched && y_matched) begin
-        route_sel[Eject] = 1;
-      end
-      // This is the same as the forward path, but we use the
-      // `YXRouting` algorithm to compute the mask.
-      if (xy_id_i.x == src_id.x) begin
-        if (xy_id_i.y >= src_id.y && xy_id_i.y < dst_id_max.y) begin
-          route_sel[North] = 1;
-        end
-        if (xy_id_i.y <= src_id.y && xy_id_i.y > dst_id_min.y) begin
-          route_sel[South] = 1;
-        end
-      end
-      if (y_matched) begin
-        if (xy_id_i.x >= src_id.x && xy_id_i.x < dst_id_max.x) begin
-          route_sel[East] = 1;
-        end
-        if (xy_id_i.x <= src_id.x && xy_id_i.x > dst_id_min.x) begin
-          route_sel[West] = 1;
+          route_ouput[South] = 1;
         end
       end
     end
   end
-  assign route_sel_o = route_sel;
+
+  // Generate the expected input mask
+  if(!FwdMode) begin : gen_expected_input_mask
+    always_comb begin
+      route_expected_input = '0;
+
+      // If both direction match then the local port is a member of the distribution
+      if(x_matched_expected_input && y_matched_expected_input) begin
+        route_expected_input[Eject] = 1'b1;
+      end
+
+      // In the case of an reduction we want to collect the source responses first in the x direction.
+      // e.g. the North / South can only be selected if we are in the correct dst columne.
+      // We expect a packet from the north if the current y id is higher/equal as the destination but still
+      // inside the expected maximum range of the source reduction. Same for the South!
+      if(xy_id_i.x == dst_id.x) begin
+        if((xy_id_i.y >= dst_id.y) && (xy_id_i.y < src_id_max.y)) begin
+          route_expected_input[North] = 1'b1;
+        end
+        if((xy_id_i.y <= dst_id.y) && (xy_id_i.y > src_id_min.y)) begin
+          route_expected_input[South] = 1'b1;
+        end
+      end
+
+      // If we have multiple sources in the same row we first have to collect them in x direction
+      // therefor expecting inputs from either the east or west direction.
+      // For all members of a rows involved in the reduction the flag y_matched_expected_input is set!
+      // We expect a packet from the east if the current x id is higher/equal as the destination but still
+      // inside the expected maximum range of the source reduction. Same for the West!
+      if(y_matched_expected_input) begin
+        if((xy_id_i.x >= dst_id.x) && (xy_id_i.x < src_id_max.x)) begin
+          route_expected_input[East] = 1'b1;
+        end
+        if((xy_id_i.x <= dst_id.x) && (xy_id_i.x > src_id_min.x)) begin
+          route_expected_input[West] = 1'b1;
+        end
+      end
+    end
+  end
+
+  // Eiter assign the expected input or the output depending on the Mode
+  assign route_sel_o = (FwdMode) ? route_ouput : route_expected_input;
+
+  // We only support five input/output routes
+  `ASSERT_INIT(NoMultiCastSupport, NumRoutes == 5)
+
 endmodule

--- a/hw/test/floo_reduction_offloads.sv
+++ b/hw/test/floo_reduction_offloads.sv
@@ -1,0 +1,338 @@
+// Copyright 2022 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Raphael Roth <raroth@student.ethz.ch>
+
+// This module allows to implement a reduction HW to simulate a reduction operation.
+// Simple Testbench implementation!
+
+// Open Points:
+
+`include "common_cells/assertions.svh"
+
+// This Wrapper allows to wrap 8x 64 Bit (512 Bits) in parallel
+module floo_reduction_wrapper import floo_pkg::*; #(
+  parameter type         RdData_t               = logic,
+  parameter int unsigned RdElements             = 8,
+  parameter bit          FPU_ACTIVE             = 1'b0,
+  parameter bit          ALU_ACTIVE             = 1'b0,
+  parameter bit          DEBUG_PRINT_TRACE      = 1'b0
+) (
+  input  logic                          clk_i,
+  input  logic                          rst_ni,
+  input  logic                          flush_i,
+  /// IF towards external FPU
+  input  RdData_t                       reduction_req_op1_i,
+  input  RdData_t                       reduction_req_op2_i,
+  input  reduction_op_t                 reduction_req_type_i,
+  input  logic                          reduction_req_valid_i,
+  output logic                          reduction_req_ready_o,
+  /// IF from external FPU
+  output RdData_t                       reduction_resp_data_o,
+  output logic                          reduction_resp_valid_o,
+  input  logic                          reduction_resp_ready_i
+);
+
+  // Parameter
+  localparam int unsigned FLEN = 64;
+
+  // Variable
+  logic [RdElements] comp_req_valid;
+  logic [RdElements] comp_req_ready;
+  logic [RdElements] comp_resp_valid;
+  logic [RdElements] comp_resp_ready;
+
+  // Fork the hadshaking
+  stream_fork #(
+    .N_OUP         (RdElements)
+  ) i_dca_fork_fpu (
+    .clk_i         (clk_i),
+    .rst_ni        (rst_ni),
+    .valid_i       (reduction_req_valid_i),
+    .ready_o       (reduction_req_ready_o),
+    .valid_o       (comp_req_valid),
+    .ready_i       (comp_req_ready)
+  );
+
+  // Implement FPU(s)
+  for (genvar i = 0; i < RdElements; i++) begin : gen_fpu_metadata
+
+    // Generate the FPU
+    if(FPU_ACTIVE == 1'b1) begin
+      floo_reduction_fpu #(
+        .ID                   (i),
+        .DEBUG_PRINT_TRACE    (DEBUG_PRINT_TRACE)
+      ) i_fpu (
+        .clk_i                (clk_i),
+        .rst_ni               (rst_ni),
+        .flush_i              (flush_i),
+        .fpu_req_op1_i        (reduction_req_op1_i[(FLEN*(i+1))-1:FLEN*i]),
+        .fpu_req_op2_i        (reduction_req_op2_i[(FLEN*(i+1))-1:FLEN*i]),
+        .fpu_req_type_i       (reduction_req_type_i),
+        .fpu_req_valid_i      (comp_req_valid[i]),
+        .fpu_req_ready_o      (comp_req_ready[i]),
+        .fpu_resp_data_o      (reduction_resp_data_o[(FLEN*(i+1)-1):FLEN*i]),
+        .fpu_resp_valid_o     (comp_resp_valid[i]),
+        .fpu_resp_ready_i     (comp_resp_ready[i])
+      );
+    end
+
+    // Generate the ALU
+    if(ALU_ACTIVE == 1'b1) begin
+      floo_reduction_alu #(
+        .ID                   (i),
+        .DEBUG_PRINT_TRACE    (DEBUG_PRINT_TRACE)
+      ) i_alu (
+        .clk_i                (clk_i),
+        .rst_ni               (rst_ni),
+        .flush_i              (flush_i),
+        .alu_req_op1_i        (reduction_req_op1_i[(FLEN*(i+1))-1:FLEN*i]),
+        .alu_req_op2_i        (reduction_req_op2_i[(FLEN*(i+1))-1:FLEN*i]),
+        .alu_req_type_i       (reduction_req_type_i),
+        .alu_req_valid_i      (comp_req_valid[i]),
+        .alu_req_ready_o      (comp_req_ready[i]),
+        .alu_resp_data_o      (reduction_resp_data_o[(FLEN*(i+1)-1):FLEN*i]),
+        .alu_resp_valid_o     (comp_resp_valid[i]),
+        .alu_resp_ready_i     (comp_resp_ready[i])
+      );
+    end
+
+  end
+
+  // Join all the signal together
+  stream_join #(
+    .N_INP           (RdElements)
+  ) i_dca_join_fpu (
+    .inp_valid_i     (comp_resp_valid),
+    .inp_ready_o     (comp_resp_ready),
+    .oup_valid_o     (reduction_resp_valid_o),
+    .oup_ready_i     (reduction_resp_ready_i)
+  );
+
+  // Sanity Check
+  `ASSERT_INIT(Invalid_ALU_or_FPU, !((FPU_ACTIVE ^ ALU_ACTIVE) == 1'b0))
+  `ASSERT_INIT(Invalid_Config, !($bits(RdData_t) != (RdElements*FLEN)))
+
+endmodule
+
+// Floating Point Reduction
+module floo_reduction_fpu import floo_pkg::*; #(
+  parameter int unsigned ID = 0,
+  parameter bit          DEBUG_PRINT_TRACE      = 1'b0
+) (
+  input  logic              clk_i,
+  input  logic              rst_ni,
+  input  logic              flush_i,
+  /// IF towards external FPU
+  input  logic[63:0]        fpu_req_op1_i,
+  input  logic[63:0]        fpu_req_op2_i,
+  input  reduction_op_t     fpu_req_type_i,
+  input  logic              fpu_req_valid_i,
+  output logic              fpu_req_ready_o,
+  /// IF from external FPU
+  output logic[63:0]        fpu_resp_data_o,
+  output logic              fpu_resp_valid_o,
+  input  logic              fpu_resp_ready_i
+);
+
+  /* All local parameter */
+
+  // FPU Configuration
+  localparam fpnew_pkg::fpu_features_t FPUFeatures = '{
+    Width:             64,
+    EnableVectors:     1'b1,
+    EnableNanBox:      1'b1,
+    FpFmtMask:         {1'b1, 1'b1, 1'b1, 1'b1, 1'b1, 1'b1}, //{RVF, RVD, XF16, XF8, XF16ALT, XF8ALT},
+    IntFmtMask:        {1'b1, 1'b1, 1'b1, 1'b1} //{XFVEC && (XF8 || XF8ALT), XFVEC && (XF16 || XF16ALT), 1'b1, 1'b0}
+  };
+
+  // FPU Implementation copied from the generated code (messy as fuck)
+  localparam fpnew_pkg::fpu_implementation_t FPUImplementation [1] = '{
+      '{
+          PipeRegs: 
+                    '{'{2, 3, 1, 1, 1, 1},   // FMA Block
+                      '{1, 1, 1, 1, 1, 1},   // DIVSQRT
+                      '{1, 1, 1, 1, 1, 1},   // NONCOMP
+                      '{2, 2, 2, 2, 2, 2},   // CONV
+                      '{3, 3, 3, 3, 3, 3}    // DOTP
+                      },
+          UnitTypes: '{'{fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED},  // FMA
+                      '{fpnew_pkg::DISABLED, fpnew_pkg::DISABLED, fpnew_pkg::DISABLED, fpnew_pkg::DISABLED, fpnew_pkg::DISABLED, fpnew_pkg::DISABLED}, // DIVSQRT
+                      '{fpnew_pkg::PARALLEL, fpnew_pkg::PARALLEL, fpnew_pkg::PARALLEL, fpnew_pkg::PARALLEL, fpnew_pkg::PARALLEL, fpnew_pkg::PARALLEL}, // NONCOMP
+                      '{fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED},   // CONV
+                      '{fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED, fpnew_pkg::MERGED}},  // DOTP
+          PipeConfig: fpnew_pkg::BEFORE
+      }
+    };
+
+  /* All Typedef Vars */
+  typedef struct packed {
+    logic [2:0][63:0]        operands;
+    fpnew_pkg::roundmode_e   rnd_mode;
+    fpnew_pkg::operation_e   op;
+    logic                    op_mod;
+    fpnew_pkg::fp_format_e   src_fmt;
+    fpnew_pkg::fp_format_e   dst_fmt;
+    fpnew_pkg::int_format_e  int_fmt;
+    logic                    vectorial_op;
+  } fpu_in_t;
+
+  typedef struct packed {
+    logic [63:0] result;
+    logic [4:0]      status;
+  } fpu_out_t;
+
+  /* Variable declaration */
+  fpu_in_t fpu_in;
+  fpu_out_t fpu_out;
+
+  /* Module Declaration */
+
+  // Parse the FPU Request
+  always_comb begin
+    // Init default values
+    fpu_in = '0;
+
+    // Set default Values
+    fpu_in.src_fmt = fpnew_pkg::FP64;
+    fpu_in.dst_fmt = fpnew_pkg::FP64;
+    fpu_in.int_fmt = fpnew_pkg::INT64;
+    fpu_in.vectorial_op = 1'b0;
+    fpu_in.op_mod = 1'b0;
+    fpu_in.rnd_mode = fpnew_pkg::RNE;
+    fpu_in.op = fpnew_pkg::ADD;
+
+    // Define the operation we want to execute on the FPU
+    unique casez (fpu_req_type_i)
+      (floo_pkg::F_Add) : begin
+        fpu_in.op = fpnew_pkg::ADD;
+        fpu_in.operands[0] = '0;
+        fpu_in.operands[1] = fpu_req_op1_i;
+        fpu_in.operands[2] = fpu_req_op2_i;
+      end
+      (floo_pkg::F_Mul) : begin
+        fpu_in.op = fpnew_pkg::MUL;
+        fpu_in.operands[0] = fpu_req_op1_i;
+        fpu_in.operands[1] = fpu_req_op2_i;
+        fpu_in.operands[2] = '0;
+      end                
+      (floo_pkg::F_Max) : begin
+        fpu_in.op = fpnew_pkg::MINMAX;
+        fpu_in.rnd_mode = fpnew_pkg::RNE;
+        fpu_in.operands[0] = fpu_req_op1_i;
+        fpu_in.operands[1] = fpu_req_op2_i;
+        fpu_in.operands[2] = '0;
+      end
+      (floo_pkg::F_Min) : begin
+        fpu_in.op = fpnew_pkg::MINMAX;
+        fpu_in.rnd_mode = fpnew_pkg::RTZ;
+        fpu_in.operands[0] = fpu_req_op1_i;
+        fpu_in.operands[1] = fpu_req_op2_i;
+        fpu_in.operands[2] = '0;
+      end
+      default : begin
+        fpu_in.op = fpnew_pkg::ADD;
+        fpu_in.operands[0] = '0;
+        fpu_in.operands[1] = '0;
+        fpu_in.operands[2] = '0;
+      end
+    endcase
+  end
+
+  // Instanciate the FPU as single element
+  fpnew_top #(
+    // FPU configuration
+    .Features                    (FPUFeatures),
+    .Implementation              (FPUImplementation[0]),
+    .TagType                     (logic),
+    .CompressedVecCmpResult      (1),
+    .StochasticRndImplementation (fpnew_pkg::DEFAULT_RSR)
+  ) i_fpu (
+    .clk_i            (clk_i),
+    .rst_ni           (rst_ni),
+    .hart_id_i        ('0),
+    .operands_i       (fpu_in.operands),
+    .rnd_mode_i       (fpu_in.rnd_mode),
+    .op_i             (fpu_in.op),
+    .op_mod_i         (fpu_in.op_mod),
+    .src_fmt_i        (fpu_in.src_fmt),
+    .dst_fmt_i        (fpu_in.dst_fmt),
+    .int_fmt_i        (fpu_in.int_fmt),
+    .vectorial_op_i   (fpu_in.vectorial_op),
+    .tag_i            ('0),
+    .simd_mask_i      ('1),
+    .in_valid_i       (fpu_req_valid_i),
+    .in_ready_o       (fpu_req_ready_o),
+    .flush_i          (flush_i),
+    .result_o         (fpu_out.result),
+    .status_o         (fpu_out.status),
+    .tag_o            (),
+    .out_valid_o      (fpu_resp_valid_o),
+    .out_ready_i      (fpu_resp_ready_i),
+    .busy_o           ()
+  );
+
+  // Provide the data to the output
+  assign fpu_resp_data_o = fpu_out.result;
+
+  // Print the Status info
+  if(DEBUG_PRINT_TRACE) begin
+    int cnt_in;
+    int cnt_out;
+    initial begin
+      cnt_in = 0;
+      cnt_out = 0;
+      while(1) begin
+        @(posedge clk_i);
+        // Print the incoming operation
+        if((fpu_req_valid_i == 1'b1) && (fpu_req_ready_o == 1'b1)) begin
+          $display($time, " [FPU %1d - Itr %1d] > FPU Ops: [%f, %f] FPU Op: %s", ID, cnt_in, fpu_req_op1_i, fpu_req_op2_i, genOp(fpu_req_type_i));
+          cnt_in = cnt_in + 1;
+        end
+
+        // Print Result / Status of FPU
+        if((fpu_resp_valid_o == 1'b1) && (fpu_resp_ready_i == 1'b1)) begin
+          $display($time, " [FPU %1d - Itr %1d] > FPU Result: %f FPU Status: %s", ID, cnt_out, fpu_out.result, genBitRep(fpu_out.status));
+          cnt_out = cnt_out + 1;
+        end
+      end
+    end
+
+    // Helper Function to generate Bitstring
+    function string genBitRep (logic [4:0] in);
+      string retVal;
+      retVal = "B";
+      for(int i = 0; i < 5; i++) begin
+          if(in[4-i] == 1'b1) begin
+              retVal = {retVal, "1"};
+          end else begin
+              retVal = {retVal, "0"};
+          end
+      end
+      return retVal;
+    endfunction
+
+    function string genOp (reduction_op_t type_reduction);
+      string retVal;
+      retVal = "";
+      unique casez (type_reduction)
+        (floo_pkg::F_Add) : begin
+          retVal = "FAdd";
+        end
+        (floo_pkg::F_Mul) : begin
+          retVal = "FMul";
+        end                
+        (floo_pkg::F_Max) : begin
+          retVal = "FMax";
+        end
+        (floo_pkg::F_Min) : begin
+          retVal = "FMin";
+        end
+      endcase
+      return retVal;
+    endfunction
+  end
+
+endmodule
+


### PR DESCRIPTION
This PR aims to further enhance FlooNoC by implementing offload reductions.

* hw: add sequential reduction controller to FlooNoC

* hw: add generic offload port to all routers

* hw: added small parametrisable ALU to FlooNoC which can be used to run simple Integer operation (Add / Mul / Min / Max)

* misc: reduction controller supports multiple configuration depending on area / performance requirements.

* dataflow: any offload collective flit is brunch off at the input of the router and forwarded to the reduction logic. The final reduced flit will be merged into the normal data-stream with an additional slave port on the reduction arbiter / wormhole arbiter.

(merged from commit hash: 4a7f9a12e58575a1dee59e705454cdbb6f1bdad5 by raroth)