### PR TITLE
hw: Add parallel reduction capabilities to FlooNoC

### DIFF
--- a/hw/floo_mask_decode.sv
+++ b/hw/floo_mask_decode.sv
@@ -1,0 +1,32 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Chen Wu <chenwu@student.ethz.ch>
+
+/// This module is similar to addr decoder
+module floo_mask_decode #(
+    parameter int unsigned NumSamRules = '0,
+    parameter type         id_t        = logic,
+    /// The type of the address rules
+    parameter type         addr_rule_t = logic,
+    parameter type         mask_sel_t  = logic
+) (
+    input  id_t                          id_i,
+    input  addr_rule_t [NumSamRules-1:0] addr_map_i,
+    output mask_sel_t                    mask_x_mask_o,
+    output mask_sel_t                    mask_y_mask_o,
+    output logic                         dec_error_o
+);
+
+  always_comb begin
+    dec_error_o = 1;
+    for (int unsigned i = 0; i < NumSamRules; i++) begin
+      if (addr_map_i[i].id == id_i) begin
+        mask_x_mask_o = addr_map_i[i].mask_x;
+        mask_y_mask_o = addr_map_i[i].mask_y;
+        dec_error_o   = 0;
+      end
+    end
+  end
+endmodule

--- a/hw/floo_mask_extract.sv
+++ b/hw/floo_mask_extract.sv
@@ -1,0 +1,40 @@
+// Copyright 2025 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Author: Tim Fischer <fischeti@iis.ee.ethz.ch>
+
+`include "common_cells/assertions.svh"
+
+/// This module returns the bits of the input data that are set in the mask.
+/// For instance, if the mask is `4'b1010` and the input data is `4'b1101`, the output
+/// will be `2'b10` (the first and third bits of the input data).
+module floo_mask_extract #(
+  /// The width of the mask and the input data
+  parameter int unsigned MaskWidth = 1,
+  /// The mask/input type
+  parameter type in_t = logic [MaskWidth-1:0],
+  /// The resulting output type, typically `logic[$countones(Mask)-1:0]`
+  parameter type out_t = logic,
+  /// The mask to select the bits that should be extracted
+  parameter in_t Mask = '0
+) (
+  input in_t data_i,
+  output out_t data_o
+);
+
+  always_comb begin : gen_mask_extract
+    automatic int incr = 0;
+    for (int i = 0; i < MaskWidth; i++) begin
+      if (Mask[i]) begin
+        data_o[incr] = data_i[i];
+        incr++;
+      end
+    end
+  end
+
+  // Assert that the output width is equal to the number of bits set in the mask
+  // `ASSERT_INIT(CountOnes, $countones(Mask) == $bits(out_t),
+  //     "Number of bits set in the mask and output width don't match")
+
+endmodule

--- a/hw/floo_nw_chimney.sv
+++ b/hw/floo_nw_chimney.sv
@@ -32,6 +32,20 @@ module floo_nw_chimney #(
   /// Every atomic transactions needs to have a unique ID
   /// and one ID is reserved for non-atomic transactions
   parameter int unsigned MaxAtomicTxns           = 1,
+  /// Enable collective operation (subfiel type and operation)
+  parameter bit EnWideCollectiveOperation               = 1'b0,
+  /// Enable narrow collective operation (subfiel type and operation required)
+  parameter bit EnNarrowCollectiveOperation             = 1'b0,
+  /// Enable the b-response for wide collectiv operation 
+  /// Chimney can be the destination but not a source! e.g. it reacts only with
+  /// the approbriate B-Response
+  parameter bit EnBRespWideCollectiveOperation          = EnWideCollectiveOperation,
+  /// Enable the b-response for narrow collectiv operation 
+  parameter bit EnBRespNarrowCollectiveOperation        = EnNarrowCollectiveOperation,
+  /// Mask incoming wide collectiv operation when sending the user field to the axi port!
+  parameter bit EnMaskingWideCollectivOperation         = 1'b0,
+  /// Mask incoming narrow collectiv operation when sending the user field to the axi port!
+  parameter bit EnMaskingNarrowCollectivOperation       = 1'b0,
   /// Node ID type for routing
   parameter type id_t                                   = logic,
   /// RoB index type for reordering.
@@ -83,9 +97,12 @@ module floo_nw_chimney #(
   /// SRAM configuration type `tc_sram_impl` in RoB
   /// Only used if technology-dependent SRAM is used
   parameter type sram_cfg_t                             = logic,
-  /// Struct for user field in AXI
+  /// Struct for the narrow user field in AXI
   /// currently only used if EnMultiCast
-  parameter type user_struct_t                          = logic
+  parameter type user_narrow_struct_t                   = logic,
+  /// Struct for the wide user field in AXI
+  /// currently only used if EnMultiCast
+  parameter type user_wide_struct_t                     = logic
 ) (
   input  logic clk_i,
   input  logic rst_ni,
@@ -142,7 +159,7 @@ module floo_nw_chimney #(
 
   // Type of the mask encoded in the user field.
   // It's always equal to the address field.
-  // For future extension, add an extra opcode in the user_struct_t
+  // For future extension, add an extra opcode in the user_narrow_struct_t
   typedef axi_addr_t user_mask_t ;
 
   // Duplicate AXI port signals to degenerate ports
@@ -152,6 +169,10 @@ module floo_nw_chimney #(
   axi_wide_req_t axi_wide_req_in;
   axi_wide_rsp_t axi_wide_rsp_out;
   user_mask_t axi_narrow_req_in_mask, axi_wide_req_in_mask;
+  floo_pkg::collect_comm_e axi_narrow_req_in_red_comm_type;
+  floo_pkg::collect_comm_e axi_wide_req_in_red_comm_type;
+  floo_pkg::reduction_op_t axi_narrow_req_in_red_op;
+  floo_pkg::reduction_op_t axi_wide_req_in_red_op;
 
   // AX queue
   axi_narrow_aw_chan_t axi_narrow_aw_queue;
@@ -163,6 +184,10 @@ module floo_nw_chimney #(
   logic axi_wide_aw_queue_valid_out, axi_wide_aw_queue_ready_in;
   logic axi_wide_ar_queue_valid_out, axi_wide_ar_queue_ready_in;
   user_mask_t axi_narrow_mask_queue, axi_wide_mask_queue;
+  floo_pkg::collect_comm_e axi_narrow_red_comm_type_queue;
+  floo_pkg::collect_comm_e axi_wide_red_comm_type_queue;
+  floo_pkg::reduction_op_t axi_narrow_red_op_queue;
+  floo_pkg::reduction_op_t axi_wide_red_op_queue;
 
   // AXI req/rsp arbiter
   floo_req_chan_t [WideAr:NarrowAw] floo_req_arb_in;
@@ -259,12 +284,23 @@ module floo_nw_chimney #(
 
     // Extract the multicast mask bits from the AXI user bits
     if (RouteCfg.EnMultiCast) begin : gen_mask
-      user_struct_t user;
+      user_narrow_struct_t user;
       assign user = axi_narrow_in_req_i.aw.user;
       // TODO(lleone): Check subfield name is `mcast_mask`
       assign axi_narrow_req_in_mask = user.mcast_mask;
     end else begin : gen_no_mask
       assign axi_narrow_req_in_mask = '0;
+    end
+
+    // Extract the reduction information if from the narrow AXI user bits
+    if(EnNarrowCollectiveOperation) begin : gen_narrow_collectiv_operation
+      user_narrow_struct_t user;
+      assign user = axi_narrow_in_req_i.aw.user;
+      assign axi_narrow_req_in_red_comm_type = user.coll_type;
+      assign axi_narrow_req_in_red_op = user.coll_op;
+    end else begin : gen_no_collectiv_operation
+      assign axi_narrow_req_in_red_comm_type = '0;
+      assign axi_narrow_req_in_red_op = '0;
     end
 
     if (ChimneyCfgN.CutAx) begin : gen_ax_cuts
@@ -311,6 +347,36 @@ module floo_nw_chimney #(
         assign axi_narrow_mask_queue = '0;
       end
 
+      // Cut all signals used for the collectiv operations (type of operation and operation)
+      if(EnNarrowCollectiveOperation) begin : gen_collectiv_operation_cuts
+        spill_register #(
+          .T (floo_pkg::collect_comm_e)
+        ) i_coll_type_queue (
+          .clk_i,
+          .rst_ni,
+          .data_i   ( axi_narrow_req_in_red_comm_type ),
+          .valid_i  ( axi_narrow_req_in.aw_valid ),
+          .ready_o  (  ),
+          .data_o   ( axi_narrow_red_comm_type_queue ),
+          .valid_o  (  ),
+          .ready_i  ( axi_narrow_aw_queue_ready_in )
+        );
+        spill_register #(
+          .T (floo_pkg::reduction_op_t)
+        ) i_coll_operation_queue (
+          .clk_i,
+          .rst_ni,
+          .data_i   ( axi_narrow_req_in_red_op ),
+          .valid_i  ( axi_narrow_req_in.aw_valid ),
+          .ready_o  (  ),
+          .data_o   ( axi_narrow_red_op_queue ),
+          .valid_o  (  ),
+          .ready_i  ( axi_narrow_aw_queue_ready_in )
+        );
+      end else begin : gen_no_collectiv_operation_cuts
+        assign axi_narrow_red_comm_type_queue = '0;
+        assign axi_narrow_red_op_queue = '0;
+      end
 
     end else begin : gen_ax_no_cuts
       assign axi_narrow_aw_queue = axi_narrow_req_in.aw;
@@ -320,6 +386,8 @@ module floo_nw_chimney #(
       assign axi_narrow_ar_queue_valid_out = axi_narrow_req_in.ar_valid;
       assign axi_narrow_rsp_out.ar_ready = axi_narrow_ar_queue_ready_in;
       assign axi_narrow_mask_queue = axi_narrow_req_in_mask;
+      assign axi_narrow_red_comm_type_queue = axi_narrow_req_in_red_comm_type;
+      assign axi_narrow_red_op_queue = axi_narrow_req_in_red_op;
     end
 
   end else begin : gen_narrow_err_slv_port
@@ -341,6 +409,8 @@ module floo_nw_chimney #(
     assign axi_narrow_aw_queue_valid_out = 1'b0;
     assign axi_narrow_ar_queue_valid_out = 1'b0;
     assign axi_narrow_mask_queue = '0;
+    assign axi_narrow_red_comm_type_queue = '0;
+    assign axi_narrow_red_op_queue = '0;
   end
 
   if (ChimneyCfgW.EnMgrPort) begin : gen_wide_sbr_port
@@ -350,9 +420,22 @@ module floo_nw_chimney #(
     `AXI_ASSIGN_RESP_STRUCT(axi_wide_in_rsp_o, axi_wide_rsp_out)
 
     if (RouteCfg.EnMultiCast) begin : gen_mask
-      assign axi_wide_req_in_mask = axi_wide_in_req_i.aw.user;
+      user_wide_struct_t user;
+      assign user = axi_wide_in_req_i.aw.user;
+      assign axi_wide_req_in_mask = user.mcast_mask;
     end else begin : gen_no_mask
       assign axi_wide_req_in_mask = '0;
+    end
+
+    // Extract the reduction information if from the narrow AXI user bits
+    if(EnWideCollectiveOperation) begin : gen_narrow_collectiv_operation
+      user_wide_struct_t user;
+      assign user = axi_wide_in_req_i.aw.user;
+      assign axi_wide_req_in_red_comm_type = user.coll_type;
+      assign axi_wide_req_in_red_op = user.coll_op;
+    end else begin : gen_no_collectiv_operation
+      assign axi_wide_req_in_red_comm_type = '0;
+      assign axi_wide_req_in_red_op = '0;
     end
 
     if (ChimneyCfgW.CutAx) begin : gen_ax_cuts
@@ -399,6 +482,37 @@ module floo_nw_chimney #(
         assign axi_wide_mask_queue = '0;
       end
 
+      // Cut all signals used for the collectiv operations (type of operation and operation)
+      if(EnWideCollectiveOperation) begin : gen_collectiv_operation_cuts
+        spill_register #(
+          .T (floo_pkg::collect_comm_e)
+        ) i_coll_type_queue (
+          .clk_i,
+          .rst_ni,
+          .data_i   ( axi_wide_req_in_red_comm_type ),
+          .valid_i  ( axi_wide_req_in.aw_valid ),
+          .ready_o  (  ),
+          .data_o   ( axi_wide_red_comm_type_queue ),
+          .valid_o  (  ),
+          .ready_i  ( axi_wide_aw_queue_ready_in )
+        );
+        spill_register #(
+          .T (floo_pkg::reduction_op_t)
+        ) i_coll_operation_queue (
+          .clk_i,
+          .rst_ni,
+          .data_i   ( axi_wide_req_in_red_op ),
+          .valid_i  ( axi_wide_req_in.aw_valid ),
+          .ready_o  (  ),
+          .data_o   ( axi_wide_red_op_queue ),
+          .valid_o  (  ),
+          .ready_i  ( axi_wide_aw_queue_ready_in )
+        );
+      end else begin : gen_no_collectiv_operation_cuts
+        assign axi_wide_red_comm_type_queue = '0;
+        assign axi_wide_red_op_queue = '0;
+      end
+
     end else begin : gen_ax_no_cuts
       assign axi_wide_aw_queue = axi_wide_req_in.aw;
       assign axi_wide_aw_queue_valid_out = axi_wide_req_in.aw_valid;
@@ -407,6 +521,8 @@ module floo_nw_chimney #(
       assign axi_wide_ar_queue_valid_out = axi_wide_req_in.ar_valid;
       assign axi_wide_rsp_out.ar_ready = axi_wide_ar_queue_ready_in;
       assign axi_wide_mask_queue = axi_wide_req_in_mask;
+      assign axi_wide_red_comm_type_queue = axi_wide_req_in_red_comm_type;
+      assign axi_wide_red_op_queue = axi_wide_req_in_red_op;
     end
 
   end else begin : gen_wide_err_slv_port
@@ -428,6 +544,8 @@ module floo_nw_chimney #(
     assign axi_wide_aw_queue_valid_out = 1'b0;
     assign axi_wide_ar_queue_valid_out = 1'b0;
     assign axi_wide_mask_queue = '0;
+    assign axi_wide_red_comm_type_queue = '0;
+    assign axi_wide_red_op_queue = '0;
   end
 
   if (ChimneyCfgN.CutRsp && ChimneyCfgW.CutRsp) begin : gen_rsp_cuts
@@ -530,6 +648,41 @@ module floo_nw_chimney #(
     `AXI_SET_AW_STRUCT(axi_wide_out_req_o.aw, axi_wide_aw_queue_out);
     axi_wide_meta_buf_rsp_in = axi_wide_out_rsp_i;
     axi_wide_meta_buf_rsp_in.aw_ready = wide_aw_out_queue_ready;
+    // If the option is enabled: mask the collective operation bits here
+    // Do it in this way so potential future fields are passed without any problems
+    if(EnMaskingWideCollectivOperation) begin
+      user_wide_struct_t user_aw;
+      user_wide_struct_t user_w;
+      // Mask the AW Channel
+      user_aw = axi_wide_out_req_o.aw.user;
+      user_aw.mcast_mask = '0;
+      user_aw.coll_type = Unicast;
+      user_aw.coll_op = '0;
+      axi_wide_out_req_o.aw.user = user_aw;
+      // Mask the W Channel
+      user_w = axi_wide_out_req_o.w.user;
+      user_w.mcast_mask = '0;
+      user_w.coll_type = Unicast;
+      user_w.coll_op = '0;
+      axi_wide_out_req_o.w.user = user_w;
+    end
+    
+    if(EnMaskingNarrowCollectivOperation) begin
+      user_narrow_struct_t user_aw;
+      user_narrow_struct_t user_w;
+      // Mask the AW Channel
+      user_aw = axi_narrow_out_req_o.aw.user;
+      user_aw.mcast_mask = '0;
+      user_aw.coll_type = Unicast;
+      user_aw.coll_op = '0;
+      axi_narrow_out_req_o.aw.user = user_aw;
+      // Mask the W Channel
+      user_w = axi_narrow_out_req_o.w.user;
+      user_w.mcast_mask = '0;
+      user_w.coll_type = Unicast;
+      user_w.coll_op = '0;
+      axi_narrow_out_req_o.w.user = user_w;
+    end
   end
 
   ///////////////////////
@@ -775,6 +928,13 @@ module floo_nw_chimney #(
   id_t [NumNWAxiChannels-1:0] axi_rsp_src_id;
   mask_sel_t [NumNWAxiChannels-1:0] x_mask_sel, y_mask_sel;
 
+  floo_pkg::collect_comm_e [NumNWAxiChannels-1:0] red_coll_type;
+  floo_pkg::collect_comm_e red_narrow_coll_type_q;
+  floo_pkg::collect_comm_e red_wide_coll_type_q;
+  floo_pkg::reduction_op_t [NumNWAxiChannels-1:0] red_coll_operation;
+  floo_pkg::reduction_op_t red_narrow_coll_operation_q;
+  floo_pkg::reduction_op_t red_wide_coll_operation_q;
+
   assign axi_req_addr[NarrowAw] = axi_narrow_aw_queue.addr;
   assign axi_req_addr[NarrowAr] = axi_narrow_ar_queue.addr;
   assign axi_req_addr[WideAw]   = axi_wide_aw_queue.addr;
@@ -890,6 +1050,51 @@ module floo_nw_chimney #(
     assign mcast_mask = '0;
   end
 
+  // Because the W doesn't have a user field it is required to store the AW user field
+  // for all following W beats! For the collectiv operations this encompass the type and the
+  // operation we want to apply to the data!
+
+  // Currently any reduction have to either be on the AW/W channel
+  // If the chimney receives an Multicast / Reduction it will automatically update the resonse
+  // to the appropriate type (Multicast => Paralle Reduction with CollectB / Reduction => Multicast B Response)
+  if(EnNarrowCollectiveOperation) begin : gen_cache_collectiv_operation_data
+    // Assign all collective type
+    assign red_coll_type[NarrowAw] = axi_narrow_red_comm_type_queue;
+    assign red_coll_type[NarrowAr] = '0;
+    assign red_coll_type[WideAw]   = axi_wide_red_comm_type_queue;
+    assign red_coll_type[WideAr]   = '0;
+    assign red_coll_type[NarrowW]  = red_narrow_coll_type_q;
+    assign red_coll_type[WideW]    = red_wide_coll_type_q;
+    assign red_coll_type[NarrowR]  = '0;
+    assign red_coll_type[NarrowB]  = '0;
+    assign red_coll_type[WideR]    = '0;
+    assign red_coll_type[WideB]    = '0;
+
+    // Store the coll type!
+    `FFL(red_narrow_coll_type_q, axi_narrow_red_comm_type_queue, axi_narrow_aw_queue_valid_out && axi_narrow_aw_queue_ready_in, '0)
+    `FFL(red_wide_coll_type_q, axi_wide_red_comm_type_queue, axi_wide_aw_queue_valid_out && axi_wide_aw_queue_ready_in, '0)
+
+    // Assign all collective operation
+    assign red_coll_operation[NarrowAw] = axi_narrow_red_op_queue;
+    assign red_coll_operation[NarrowAr] = '0;
+    assign red_coll_operation[WideAw]   = axi_wide_red_op_queue;
+    assign red_coll_operation[WideAr]   = '0;
+    assign red_coll_operation[NarrowW]  = red_narrow_coll_operation_q;
+    assign red_coll_operation[WideW]    = red_wide_coll_operation_q;
+    assign red_coll_operation[NarrowR]  = '0;
+    assign red_coll_operation[NarrowB]  = '0;
+    assign red_coll_operation[WideR]    = '0;
+    assign red_coll_operation[WideB]    = '0;
+
+    // Store the coll operation!
+    `FFL(red_narrow_coll_operation_q, axi_narrow_red_op_queue, axi_narrow_aw_queue_valid_out && axi_narrow_aw_queue_ready_in, '0)
+    `FFL(red_wide_coll_operation_q, axi_wide_red_op_queue, axi_wide_aw_queue_valid_out && axi_wide_aw_queue_ready_in, '0)
+
+  end else begin : gen_no_collectiv_operation_data
+    assign red_coll_type = '0;
+    assign red_coll_operation = '0;
+  end
+
   ///////////////////
   // FLIT PACKING  //
   ///////////////////
@@ -905,7 +1110,17 @@ module floo_nw_chimney #(
     floo_narrow_aw.hdr.axi_ch   = NarrowAw;
     floo_narrow_aw.hdr.atop     = axi_narrow_aw_queue.atop != axi_pkg::ATOP_NONE;
     floo_narrow_aw.payload      = axi_narrow_aw_queue;
-    floo_narrow_aw.hdr.commtype = (mcast_mask[NarrowAw] != '0)? Multicast : Unicast;
+    // Assign the commtype and operation to the narrow AW flit
+    if(EnNarrowCollectiveOperation) begin
+      floo_narrow_aw.hdr.commtype = red_coll_type[NarrowAw];
+      if(red_coll_type[NarrowAw] == OffloadReduction) begin
+        floo_narrow_aw.hdr.reduction_op = R_Select;
+      end else if(red_coll_type[NarrowAw] == ParallelReduction) begin
+        floo_narrow_aw.hdr.reduction_op = SelectAW;
+      end
+    end else begin
+      floo_narrow_aw.hdr.commtype = (mcast_mask[NarrowAw] != '0)? Multicast : Unicast;
+    end
   end
 
   always_comb begin
@@ -918,7 +1133,13 @@ module floo_nw_chimney #(
     floo_narrow_w.hdr.last      = axi_narrow_req_in.w.last;
     floo_narrow_w.hdr.axi_ch    = NarrowW;
     floo_narrow_w.payload       = axi_narrow_req_in.w;
-    floo_narrow_w.hdr.commtype  = (mcast_mask[NarrowW] != '0)? Multicast : Unicast;
+    // Assign the commtype and operation to the narrow W flit
+    if(EnNarrowCollectiveOperation) begin
+      floo_narrow_w.hdr.commtype = red_coll_type[NarrowW];
+      floo_narrow_w.hdr.reduction_op = red_coll_operation[NarrowW];
+    end else begin
+      floo_narrow_w.hdr.commtype  = (mcast_mask[NarrowW] != '0)? Multicast : Unicast;
+    end
   end
 
   always_comb begin
@@ -946,8 +1167,22 @@ module floo_nw_chimney #(
     floo_narrow_b.hdr.atop     = narrow_aw_buf_hdr_out.hdr.atop;
     floo_narrow_b.payload      = axi_narrow_meta_buf_rsp_out.b;
     floo_narrow_b.payload.id   = narrow_aw_buf_hdr_out.id;
-    floo_narrow_b.hdr.commtype = (narrow_aw_buf_hdr_out.hdr.commtype == Multicast)?
-                                 ParallelReduction : Unicast;
+    // We need to adapt the B Response according to the incoming AW Request earlier
+    // The AXI member on the chimney should not be aware of a reduction / multicast!
+    // Multicast --> Collect the B responses in a parallel reduction
+    // Reduction --> Multicast the B response to all members
+    if(EnBRespNarrowCollectiveOperation) begin
+      if(narrow_aw_buf_hdr_out.hdr.commtype == Multicast) begin
+        floo_narrow_b.hdr.commtype = ParallelReduction;
+        floo_narrow_b.hdr.reduction_op = CollectB;
+      end else if((narrow_aw_buf_hdr_out.hdr.commtype == OffloadReduction) || (narrow_aw_buf_hdr_out.hdr.commtype == ParallelReduction)) begin
+        floo_narrow_b.hdr.commtype = Multicast;
+      end else begin
+        floo_narrow_b.hdr.commtype = Unicast;
+      end
+    end else begin
+      floo_narrow_b.hdr.commtype = (narrow_aw_buf_hdr_out.hdr.commtype == Multicast)? ParallelReduction : Unicast;
+    end
   end
 
   always_comb begin
@@ -975,7 +1210,16 @@ module floo_nw_chimney #(
     floo_wide_aw.hdr.last     = 1'b0;  // AW and W need to be sent together
     floo_wide_aw.hdr.axi_ch   = WideAw;
     floo_wide_aw.payload      = axi_wide_aw_queue;
-    floo_wide_aw.hdr.commtype = (mcast_mask[WideAw] != '0)? Multicast : Unicast;
+    // Assign the commtype and operation to the wide AW flit
+    if(EnWideCollectiveOperation) begin
+      floo_wide_aw.hdr.commtype = red_coll_type[WideAw];
+      if(red_coll_type[WideAw] == OffloadReduction) begin
+        floo_wide_aw.hdr.reduction_op = R_Select;
+      end else if(red_coll_type[WideAw] == ParallelReduction) begin
+        floo_wide_aw.hdr.reduction_op = SelectAW;
+      end    end else begin
+      floo_wide_aw.hdr.commtype = (mcast_mask[WideAw] != '0)? Multicast : Unicast;
+    end
   end
 
   always_comb begin
@@ -988,7 +1232,13 @@ module floo_nw_chimney #(
     floo_wide_w.hdr.last    = axi_wide_req_in.w.last;
     floo_wide_w.hdr.axi_ch  = WideW;
     floo_wide_w.payload     = axi_wide_req_in.w;
-    floo_wide_w.hdr.commtype = (mcast_mask[WideW] != '0)? Multicast : Unicast;
+    // Assign the commtype and operation to the wide W flit
+    if(EnWideCollectiveOperation) begin
+      floo_wide_w.hdr.commtype = red_coll_type[WideW];
+      floo_wide_w.hdr.reduction_op = red_coll_operation[WideW];
+    end else begin
+      floo_wide_w.hdr.commtype  = (mcast_mask[WideW] != '0)? Multicast : Unicast;
+    end
   end
 
   always_comb begin
@@ -1015,8 +1265,23 @@ module floo_nw_chimney #(
     floo_wide_b.hdr.axi_ch  = WideB;
     floo_wide_b.payload     = axi_wide_meta_buf_rsp_out.b;
     floo_wide_b.payload.id  = wide_aw_buf_hdr_out.id;
-    floo_wide_b.hdr.commtype = (wide_aw_buf_hdr_out.hdr.commtype == Multicast)?
-                               ParallelReduction : Unicast;
+
+    // We need to adapt the B Response according to the incoming AW Request earlier
+    // The AXI member on the chimney should not be aware of a reduction / multicast!
+    // Multicast --> Collect the B responses in a parallel reduction
+    // Reduction --> Multicast the B response to all members
+    if(EnBRespWideCollectiveOperation == 1'b1) begin
+      if(wide_aw_buf_hdr_out.hdr.commtype == Multicast) begin
+        floo_wide_b.hdr.commtype = ParallelReduction;
+        floo_wide_b.hdr.reduction_op = CollectB;
+      end else if((wide_aw_buf_hdr_out.hdr.commtype == OffloadReduction) || (wide_aw_buf_hdr_out.hdr.commtype == ParallelReduction)) begin
+        floo_wide_b.hdr.commtype = Multicast;
+      end else begin
+        floo_wide_b.hdr.commtype = Unicast;
+      end
+    end else begin
+      floo_wide_b.hdr.commtype = (wide_aw_buf_hdr_out.hdr.commtype == Multicast)? ParallelReduction : Unicast;
+    end
   end
 
   always_comb begin
@@ -1451,5 +1716,15 @@ module floo_nw_chimney #(
                            (floo_req_unpack_generic.hdr.axi_ch == WideAr)))
   `ASSERT(NoWideSbrPortWRequest,  ChimneyCfgW.EnSbrPort || !(floo_wide_in_valid &&
                            (floo_wide_unpack_generic.hdr.axi_ch == WideW)))
+
+  // We do not support reduction with ROB Buffer
+  `ASSERT_INIT(NoRobReduction, !(EnWideCollectiveOperation | EnNarrowCollectiveOperation) || 
+                          (ChimneyCfgN.BRoBType == NoRoB && 
+                           ChimneyCfgN.RRoBType == NoRoB &&
+                           ChimneyCfgW.BRoBType == NoRoB &&
+                           ChimneyCfgW.RRoBType == NoRoB))
+
+  // We do not support reduction without multicast
+  `ASSERT_INIT(NoWideReductionWithoutMulticast, (RouteCfg.EnMultiCast || !(EnWideCollectiveOperation | EnNarrowCollectiveOperation)))
 
 endmodule

--- a/hw/floo_output_arbiter.sv
+++ b/hw/floo_output_arbiter.sv
@@ -2,7 +2,12 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 //
-// Chen Wu <chenwu@student.ethz.ch>
+// Author: Chen Wu <chenwu@student.ethz.ch>
+//         Raphael Roth <raroth@student.ethz.ch>
+
+// The purpose of the slave ports is to merge data from port's which are not mapped in the "normal" way.
+// An example would be the output of the reduction logic!
+// These ports cannot be reduced!
 
 `include "common_cells/assertions.svh"
 
@@ -10,43 +15,60 @@ module floo_output_arbiter import floo_pkg::*;
 #(
   /// Number of input ports
   parameter int unsigned NumRoutes  = 1,
+  /// Number of additional input ports to merge (MSB Part of the array contains the slave ports)
+  parameter int unsigned NumSlaveRoutes = 0,
+  /// Enable parallel reduction feature
+  parameter bit          EnParallelReduction  = 1'b0,
   /// Type definitions
-  parameter type         flit_t     = logic,
-  parameter type         payload_t  = logic,
-  parameter payload_t    NarrowRspMask = '0,
-  parameter payload_t    WideRspMask = '0,
-  parameter type         id_t       = logic
+  parameter type         flit_t               = logic,
+  parameter type         hdr_t                = logic,
+  parameter type         payload_t            = logic,
+  parameter payload_t    NarrowRspMask        = '0,
+  parameter payload_t    WideRspMask          = '0,
+  parameter type         id_t                 = logic,
+  /// Do we support local loopback e.g. should the logic expect the local flit or not
+  parameter bit          RdSupportLoopback    = 1'b0,
+  /// AXI dependent parameter
+  parameter bit          RdSupportAxi         = 1'b1,
+  parameter axi_cfg_t    AxiCfg               = '0,
+  /// FIXED PARAM'S - DO NOT OVERWRITE!
+  parameter int unsigned localRoutes          = (NumRoutes + NumSlaveRoutes)
 ) (
-  input  logic                   clk_i,
-  input  logic                   rst_ni,
+  input  logic                      clk_i,
+  input  logic                      rst_ni,
   /// Current XY-coordinate of the router
-  input  id_t                    xy_id_i,
+  input  id_t                       xy_id_i,
   /// Input ports
-  input  logic  [NumRoutes-1:0]  valid_i,
-  output logic  [NumRoutes-1:0]  ready_o,
-  input  flit_t [NumRoutes-1:0]  data_i,
+  input  logic  [localRoutes-1:0]   valid_i,
+  output logic  [localRoutes-1:0]   ready_o,
+  input  flit_t [localRoutes-1:0]   data_i,
   /// Output port
-  output logic                   valid_o,
-  input  logic                   ready_i,
-  output flit_t                  data_o
+  output logic                      valid_o,
+  input  logic                      ready_i,
+  output flit_t                     data_o
 );
 
-  flit_t                 reduce_data_out, unicast_data_out;
-  logic [NumRoutes-1:0]  reduce_valid_in, unicast_valid_in, reduce_ready_out, unicast_ready_out;
-  logic                  reduce_valid_out, unicast_valid_out, reduce_ready_in, unicast_ready_in;
+  flit_t                    reduce_data_out, unicast_data_out;
+  logic [localRoutes-1:0]   reduce_valid_in, unicast_valid_in, reduce_ready_out, unicast_ready_out;
+  logic                     reduce_valid_out, unicast_valid_out, reduce_ready_in, unicast_ready_in;
 
-  logic [NumRoutes-1:0]  reduce_mask;
+  logic [localRoutes-1:0]   reduce_mask;
+
+  // Var to sparate Non-Slave ports if they have to go to the reduction arbiter!
+  flit_t [NumRoutes-1:0]    full_port_data;
+  logic [NumRoutes-1:0]     full_port_valid;
+  logic [NumRoutes-1:0]     full_port_ready;
 
   // Determine which input ports are to be reduced
-  for (genvar i = 0; i < NumRoutes; i++) begin : gen_reduce_mask
-    assign reduce_mask[i] = (data_i[i].hdr.commtype == ParallelReduction);
+  for (genvar i = 0; i < localRoutes; i++) begin : gen_reduce_mask
+    assign reduce_mask[i] = (i < NumRoutes) ? (data_i[i].hdr.commtype == ParallelReduction) : 1'b0;
   end
 
   // Arbitrate unicasts
   assign unicast_valid_in = valid_i & ~reduce_mask;
 
   floo_wormhole_arbiter #(
-    .NumRoutes  ( NumRoutes ),
+    .NumRoutes  ( localRoutes ),
     .flit_t     ( flit_t    )
   ) i_wormhole_arbiter (
     .clk_i,
@@ -62,18 +84,32 @@ module floo_output_arbiter import floo_pkg::*;
   // Arbitrate reductions
   assign reduce_valid_in = valid_i & reduce_mask;
 
+  // The reduction supportonly the "original" configuration of NumRoutes!
+  // Therefor we have to mask all slave ports here!
+  assign full_port_data = data_i[NumRoutes-1:0];
+  assign full_port_valid = reduce_valid_in[NumRoutes-1:0];
+  assign reduce_ready_out[NumRoutes-1:0] = full_port_ready;
+  if(NumSlaveRoutes > 0) begin
+    assign reduce_ready_out[NumSlaveRoutes+NumRoutes-1:NumRoutes] = '0;
+  end
+
   floo_reduction_arbiter #(
-    .NumRoutes      ( NumRoutes     ),
-    .flit_t         ( flit_t        ),
-    .payload_t      ( payload_t     ),
-    .id_t           ( id_t          ),
-    .NarrowRspMask  ( NarrowRspMask ),
-    .WideRspMask    ( WideRspMask   )
+    .NumRoutes            ( NumRoutes           ),
+    .EnParallelReduction  ( EnParallelReduction ),
+    .flit_t               ( flit_t              ),
+    .hdr_t                ( hdr_t               ),
+    .payload_t            ( payload_t           ),
+    .id_t                 ( id_t                ),
+    .NarrowRspMask        ( NarrowRspMask       ),
+    .WideRspMask          ( WideRspMask         ),
+    .RdSupportLoopback    ( RdSupportLoopback   ),
+    .RdSupportAxi         ( RdSupportAxi        ),
+    .AxiCfg               ( AxiCfg              )
   ) i_reduction_arbiter (
     .xy_id_i,
-    .data_i,
-    .valid_i   ( reduce_valid_in  ),
-    .ready_o   ( reduce_ready_out ),
+    .data_i    ( full_port_data   ),
+    .valid_i   ( full_port_valid  ),
+    .ready_o   ( full_port_ready  ),
     .valid_o   ( reduce_valid_out ),
     .ready_i   ( reduce_ready_in  ),
     .data_o    ( reduce_data_out  )

--- a/hw/floo_pkg.sv
+++ b/hw/floo_pkg.sv
@@ -234,6 +234,51 @@ package floo_pkg;
     bit CutRsp;
   } chimney_cfg_t;
 
+  /// Controller configuration
+  typedef enum logic [1:0] {
+    /// Simple configuration
+    ControllerSimple = 2'd0,
+    /// Stalling configuration
+    ControllerStalling = 2'd1,
+    /// Generic configuration
+    ControllerGeneric = 2'd2
+  } floo_red_controller_e;
+
+  /// Configuration for the offload reduction logic
+  typedef struct packed {
+    /// configuration for the controller
+    floo_red_controller_e RdControllConf;
+    /// input fifo configuration
+    bit RdFifoFallThrough;
+    int unsigned RdFifoDepth;
+    /// pipeline depth of the offload unit
+    int unsigned RdPipelineDepth;
+    /// partial buffer size
+    int unsigned RdPartialBufferSize;
+    /// required tag bit if generic controller is used
+    int unsigned RdTagBits;
+    /// is the underlying protocl AXI
+    bit RdSupportAxi;
+    /// enable the bypass (required for AXI-AW)
+    bit RdEnableBypass;
+    /// support loopback for the local link - collective will
+    /// be forwarded to the local port too.
+    bit RdSupportLoopback;
+  } reduction_cfg_t;
+
+  /// The default configuration for the reduction
+  localparam reduction_cfg_t ReductionDefaultCfg = '{
+    RdControllConf: ControllerGeneric,
+    RdFifoFallThrough: 1'b1,
+    RdFifoDepth: 2,
+    RdPipelineDepth: 5,
+    RdPartialBufferSize: 3,
+    RdTagBits: 5,
+    RdSupportAxi: 1'b1,
+    RdEnableBypass: 1'b1,
+    RdSupportLoopback: 1'b1
+  };
+
   /// The default configuration for the network interface
   localparam chimney_cfg_t ChimneyDefaultCfg = '{
     EnSbrPort: 1'b1,

--- a/hw/floo_reduction_arbiter.sv
+++ b/hw/floo_reduction_arbiter.sv
@@ -3,19 +3,31 @@
 // SPDX-License-Identifier: SHL-0.51
 //
 // Author: Chen Wu <chenwu@student.ethz.ch>
+//         Raphael Roth <raroth@student.ethz.ch>
+
+`include "axi/typedef.svh"
+`include "floo_noc/typedef.svh"
 
 module floo_reduction_arbiter import floo_pkg::*;
 #(
   /// Number of input ports
-  parameter int unsigned NumRoutes  = 1,
+  parameter int unsigned NumRoutes            = 1,
+  /// Enable Parallel Reduction
+  parameter bit          EnParallelReduction  = 1'b0,
   /// Type definitions
-  parameter type         flit_t     = logic,
-  parameter type         payload_t  = logic,
+  parameter type         flit_t               = logic,
+  parameter type         hdr_t                = logic,
+  parameter type         payload_t            = logic,
   // Masks used to select which bits of the payload are part of the response,
   // allowing extraction of relevant bits and detection of any participant errors.
-  parameter payload_t    NarrowRspMask = '0,
-  parameter payload_t    WideRspMask = '0,
-  parameter type         id_t       = logic
+  parameter payload_t    NarrowRspMask        = '0,
+  parameter payload_t    WideRspMask          = '0,
+  parameter type         id_t                 = logic,
+  /// Do we support local loopback e.g. should the logic expect the local flit or not
+  parameter bit          RdSupportLoopback    = 1'b0,
+  /// AXI dependent parameter
+  parameter bit          RdSupportAxi         = 1'b1,
+  parameter axi_cfg_t    AxiCfg               = '0
 ) (
   /// Current XY-coordinate of the router
   input  id_t                    xy_id_i,
@@ -28,6 +40,30 @@ module floo_reduction_arbiter import floo_pkg::*;
   input  logic                   ready_i,
   output flit_t                  data_o
 );
+
+  // Generate the AXI specific types
+  typedef logic [AxiCfg.AddrWidth-1:0] axi_addr_t;
+  typedef logic [AxiCfg.InIdWidth-1:0] axi_in_id_t;
+  typedef logic [AxiCfg.OutIdWidth-1:0] axi_out_id_t;
+  typedef logic [AxiCfg.UserWidth-1:0] axi_user_t;
+  typedef logic [AxiCfg.DataWidth-1:0] axi_data_t;
+  typedef logic [AxiCfg.DataWidth/8-1:0] axi_strb_t;
+
+  `AXI_TYPEDEF_ALL_CT(axi, axi_req_t, axi_rsp_t, axi_addr_t, axi_in_id_t, axi_data_t, axi_strb_t, axi_user_t)
+  `AXI_TYPEDEF_AW_CHAN_T(axi_out_aw_chan_t, axi_addr_t, axi_out_id_t, axi_user_t)
+  `FLOO_TYPEDEF_AXI_CHAN_ALL(axi, req, rsp, axi, AxiCfg, hdr_t)
+
+  // We calculte the different reduction in parallel and select the result at the output
+  flit_t data_forward_flit;   
+  flit_t data_collectB;
+  flit_t data_LSBAnd;
+
+  // Logic bit to connect all LSB together
+  logic lsb;
+  logic [1:0] resp;
+
+  // Reduction mask for either the narrow or wide link
+  payload_t ReduceMask;
 
   // calculated expected input source lists for each input flit
   logic [NumRoutes-1:0]  in_route_mask;
@@ -45,10 +81,11 @@ module floo_reduction_arbiter import floo_pkg::*;
   );
 
   floo_reduction_sync #(
-    .NumRoutes ( NumRoutes ),
-    .arb_idx_t ( arb_idx_t ),
-    .flit_t    ( flit_t    ),
-    .id_t      ( id_t      )
+    .NumRoutes          ( NumRoutes ),
+    .RdSupportLoopback  ( RdSupportLoopback ),
+    .arb_idx_t          ( arb_idx_t ),
+    .flit_t             ( flit_t    ),
+    .id_t               ( id_t      )
   ) i_reduction_sync (
     .sel_i            ( input_sel     ),
     .data_i           ( data_i        ),
@@ -58,14 +95,12 @@ module floo_reduction_arbiter import floo_pkg::*;
     .in_route_mask_o  ( in_route_mask )
   );
 
-  payload_t ReduceMask;
+  // Set the eduction mask for either the narrow or the wide link
   assign ReduceMask = data_i[input_sel].hdr.axi_ch==NarrowB? NarrowRspMask : WideRspMask;
 
-  logic [1:0] resp;
-
-  // Reduction operation
+  // Collect B response operation
   always_comb begin : gen_reduced_B
-    data_o = data_i[input_sel];
+    data_collectB = data_i[input_sel];
     // We check every input port from which we expect a response
     for (int i = 0; i < NumRoutes; i++) begin
       if(in_route_mask[i]) begin
@@ -81,13 +116,80 @@ module floo_reduction_arbiter import floo_pkg::*;
         // If one of the responses is an error, we return an error
         // otherwise we return the first response
         if(resp == axi_pkg::RESP_SLVERR) begin
-          data_o = data_i[i];
+          data_collectB = data_i[i];
           break;
         end
       end
     end
   end
 
+  // Forward flits directly - Just choose to forward the selected one
+  always_comb begin : gen_forward
+    data_forward_flit = data_i[input_sel];
+  end
+
+  // And all the LSB
+  always_comb begin : gen_and_lsb
+    data_LSBAnd = data_i[input_sel];
+    lsb = 1'b1;
+    
+    // We check every input port from which we expect a response
+    for (int i = 0; i < NumRoutes; i++) begin
+      if(in_route_mask[i]) begin
+        // Extract the last bit from the data
+        if(RdSupportAxi) begin
+          lsb = lsb & extractAXIWlsb(data_i[i]);
+        end
+      end
+    end
+
+    // Assign the bit again
+    if(RdSupportAxi) begin
+      data_LSBAnd = insertAXIWlsb(data_LSBAnd, lsb);
+    end
+  end
+
+  // If we support more than the inital parallel reduction
+  if(EnParallelReduction) begin
+    always_comb begin
+      // Assign inital value
+      data_o = '0;
+      if(data_i[input_sel].hdr.reduction_op == SelectAW) begin
+        // AW flit dedected
+        data_o = data_forward_flit;
+      end else if(data_i[input_sel].hdr.reduction_op == CollectB) begin
+        // Collect B flit dedected
+        data_o = data_collectB;
+      end else if(data_i[input_sel].hdr.reduction_op == LSBAnd) begin
+        // LSB And flit dedected
+        data_o = data_LSBAnd;
+      end
+    end
+  end else begin
+    assign data_o = data_collectB;
+  end
+
+  // Connect the ready signal
   assign ready_o = (ready_i & valid_o)? valid_i & in_route_mask : '0;
+
+  // AXI Specific function!
+  // Insert data into AXI specific W frame! 
+  function automatic flit_t insertAXIWlsb(flit_t metadata, logic data);
+      floo_axi_w_flit_t w_flit;
+      // Parse the entire flit
+      w_flit = floo_axi_w_flit_t'(metadata);
+      // Copy the new data
+      w_flit.payload.data[0] = data;
+      return flit_t'(w_flit);
+  endfunction
+
+  // Extract data from AXI specific W frame! 
+  function automatic logic extractAXIWlsb(flit_t metadata);
+      floo_axi_w_flit_t w_flit;
+      // Parse the entire flit
+      w_flit = floo_axi_w_flit_t'(metadata);
+      // Return the W data
+      return w_flit.payload.data[0];
+  endfunction
 
 endmodule

--- a/hw/floo_reduction_sync.sv
+++ b/hw/floo_reduction_sync.sv
@@ -3,11 +3,14 @@
 // SPDX-License-Identifier: SHL-0.51
 //
 // Author: Chen Wu <chenwu@student.ethz.ch>
+//         Raphael Roth <raroth@student.ethz.ch>
 
 module floo_reduction_sync import floo_pkg::*;
 #(
   /// Number of input ports
   parameter int unsigned NumRoutes  = 1,
+  /// Do we support local loopback e.g. should the logic expect the local flit or not
+  parameter bit          RdSupportLoopback    = 1'b0,
   /// Type definitions
   parameter type         arb_idx_t  = logic,
   parameter type         flit_t     = logic,
@@ -43,9 +46,8 @@ module floo_reduction_sync import floo_pkg::*;
                                (data_i[in].hdr.dst_id == data_i[sel_i].hdr.dst_id));
 
     // Determine if this input should be considered valid for the reduction:
-    // If we are at the dst node and the port is the local one, we don’t wait for a
-    // response/reduction since it will stay locally [NoLoopBack].
-    assign same_and_valid[in] = (data_i[sel_i].hdr.dst_id == xy_id_i && in == Eject) ||
+    assign same_and_valid[in] = RdSupportLoopback ? (compare_same[in] & valid_i[in]) :
+                                (data_i[sel_i].hdr.dst_id == xy_id_i && in == Eject) ||
                                 (compare_same[in] & valid_i[in]);
   end
 

--- a/hw/floo_route_select.sv
+++ b/hw/floo_route_select.sv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: SHL-0.51
 //
 // Michael Rogenmoser <michaero@iis.ee.ethz.ch>
+// Raphael Roth <raroth@student.ethz.ch>
 
 `include "common_cells/registers.svh"
 
@@ -27,7 +28,9 @@ module floo_route_select
   /// Various types used in the routing algorithm
   parameter type         flit_t           = logic,
   parameter type         addr_rule_t      = logic,
-  parameter type         id_t             = logic[IdWidth-1:0]
+  parameter type         id_t             = logic[IdWidth-1:0],
+  /// Inversed SRC / DST if we want to support Multicast on the B response
+  parameter bit          InversedSrcDst       = 1'b0
 ) (
   input  logic                          clk_i,
   input  logic                          rst_ni,
@@ -44,8 +47,14 @@ module floo_route_select
   output logic [RouteSelWidth-1:0]      route_sel_id_o
 );
 
+  // Selected route defined by th alg.
   logic [NumRoutes-1:0] route_sel;
   logic [RouteSelWidth-1:0] route_sel_id;
+
+  // We need to calc the multicast and the unicast route in parallel
+  // and mux them depending on the flit header!
+  logic [NumRoutes-1:0] route_sel_multicast; 
+  logic [NumRoutes-1:0] route_sel_unicast;
 
   if (RouteAlgo == IdTable) begin : gen_id_table
     // Routing based on an ID table passed into the router (TBD parameter or signal)
@@ -102,43 +111,54 @@ module floo_route_select
 
     // One-hot encoding of the decoded route
 
+    // If we enable multicast then generate the output routes here seperatly
     if (EnMultiCast) begin : gen_mcast_route_sel
       floo_route_xymask #(
-        .NumRoutes     ( NumRoutes ),
-        .flit_t        ( flit_t    ),
-        .id_t          ( id_t      ),
-        .FwdMode       ( 1         )
+        .NumRoutes     ( NumRoutes        ),
+        .flit_t        ( flit_t           ),
+        .id_t          ( id_t             ),
+        .FwdMode       ( 1'b1             )
       ) i_route_xymask (
         .channel_i   ( channel_i ),
         .xy_id_i     ( xy_id_i   ),
-        .route_sel_o ( route_sel )
+        .route_sel_o ( route_sel_multicast )
       );
-      assign route_sel_id = '0; // Not defined in multicast
-    end else begin : gen_route_sel
-      id_t id_in;
-      assign id_in = id_t'(channel_i.hdr.dst_id);
-      always_comb begin
-        route_sel_id = East;
-        if (id_in.x == xy_id_i.x && id_in.y == xy_id_i.y) begin
-          route_sel_id = Eject + channel_i.hdr.dst_id.port_id;
-        end else if (id_in.x == xy_id_i.x) begin
-          if (id_in.y < xy_id_i.y) begin
-            route_sel_id = South;
-          end else begin
-            route_sel_id = North;
-          end
+    end else begin : gen_no_mcast
+      assign route_sel_multicast = '0;  // No MCast supported
+    end
+    
+    // Calculate here the unicast output mask
+    id_t id_in;
+    assign id_in = id_t'(channel_i.hdr.dst_id);
+    always_comb begin
+      route_sel_id = East;
+      if (id_in.x == xy_id_i.x && id_in.y == xy_id_i.y) begin
+        route_sel_id = Eject + channel_i.hdr.dst_id.port_id;
+      end else if (id_in.x == xy_id_i.x) begin
+        if (id_in.y < xy_id_i.y) begin
+          route_sel_id = South;
         end else begin
-          if (id_in.x < xy_id_i.x) begin
-            route_sel_id = West;
-          end else begin
-            route_sel_id = East;
-          end
+          route_sel_id = North;
         end
-        route_sel = '0;
-        route_sel[route_sel_id] = 1'b1;
+      end else begin
+        if (id_in.x < xy_id_i.x) begin
+          route_sel_id = West;
+        end else begin
+          route_sel_id = East;
+        end
       end
+      route_sel_unicast = '0;
+      route_sel_unicast[route_sel_id] = 1'b1;
     end
 
+    // Depending on the flit header choose the correct route
+    if(EnMultiCast) begin
+      assign route_sel = (channel_i.hdr.commtype == Multicast) ? route_sel_multicast : route_sel_unicast;
+    end else begin
+      assign route_sel = route_sel_unicast;
+    end
+
+    // Assign the data directly to the output
     assign channel_o = channel_i;
 
   end else begin : gen_err

--- a/hw/floo_route_xymask.sv
+++ b/hw/floo_route_xymask.sv
@@ -2,20 +2,32 @@
 // Solderpad Hardware License, Version 0.51, see LICENSE for details.
 // SPDX-License-Identifier: SHL-0.51
 //
-// Author: Chen Wu <chenwu@student.ethz.ch>
+// Author: 
+// - Chen Wu <chenwu@student.ethz.ch>
+// - Raphael Roth <raroth@student.ethz.ch>
 
-module floo_route_xymask
-  import floo_pkg::*;
-#(
-  /// Number of output ports
-  parameter int unsigned NumRoutes     = 0,
+// This module is the heartpiece for collectiv operation in the FlooNoC. When running an 
+// multicast / reduction it either determines the output direction of the filt 
+// (e.g. in which direction a copy of the filt has to be sent) or the expected
+// input direction (e.g. which input provides a flit).
+
+// Limitations:
+// - It only supports xy routing
+// - It only supports 5 in/out routes
+
+`include "common_cells/assertions.svh"
+
+module floo_route_xymask import floo_pkg::*; #(
+  /// Number of input / output ports
+  parameter int unsigned    NumRoutes   = 0,
   /// The type of mask to be computed
   /// 1: Determine output directions of the forward path in Multicast
   /// 0: Determine input directions of the backward path in Multicast i.e the reduction
-  parameter bit       FwdMode          = 1'b1,
-  /// Various types
-  parameter type         flit_t        = logic,
-  parameter type         id_t          = logic
+  parameter bit             FwdMode     = 1'b1,
+  /// type for data flit
+  parameter type            flit_t      = logic,
+  /// type for local id (router id)
+  parameter type            id_t        = logic
 ) (
   // The input flit (only the header is used)
   input  flit_t                         channel_i,
@@ -25,40 +37,98 @@ module floo_route_xymask
   output logic [NumRoutes-1:0]          route_sel_o
 );
 
-  logic [NumRoutes-1:0] route_sel;
+  // General Concept: In XY-Routing all flits travel first in X - direction until they arrive at the columne of the destination
+  //                  and then travel in Y direction until they reach the destination. In the Multicast case we have to forward
+  //                  them until the "most far away" x/y position (dst_id_max) determint by the mask!
 
-  id_t dst_id, mask_in, src_id;
+  // We need to handle 4 different cases in this module:
+  // ---------------------------------------------------
+  // @ Multicast
+  //
+  // Multicast            - src (Single)
+  //                      - dst (Multiple)
+  //                      --> generate destination mask
+  //
+  // Collect B            - src (Multiple)
+  //                      - dst (Single)
+  //                      --> generate expected input mask
+  // ---------------------------------------------------
+  // @ Reduction
+  //
+  // Reduction            - src (Multiple)
+  //                      - dst (Single)
+  //                      --> generate expected input mask
+  //
+  // distribute B resp    - src (Single)
+  //                      - dst (Multiple)
+  //                      --> generate destination mask
+  // ---------------------------------------------------
+
+  // Two cases overlap themself e.g. when we want to have an expected input mask
+  // we go from multiple sources to one destination (reduction). With the output mask it is
+  // the opposite with single source to multiple destinations (multicast).
+
+  // To improve readability of the code we generate both mask in parallel and only
+  // mux them at the output.
+
+/* Variable declaration */
+  // generated routes
+  logic [NumRoutes-1:0] route_ouput;
+  logic [NumRoutes-1:0] route_expected_input;
+
+  // Var for easier signal assignments
+  id_t dst_id;
+  id_t src_id;
+  id_t mask;
+
+  // Var to hold the maxium distribution distance for both source and destination
   id_t dst_id_max, dst_id_min;
-  logic x_matched, y_matched;
+  id_t src_id_max, src_id_min;
 
-  // In the forward path, we use the normal `dst_id` to compute the mask.
-  // In the backward path, we use the `src_id` which was the original
-  // `dst_id` in from the forward path.
-  assign dst_id = (FwdMode)? channel_i.hdr.dst_id : channel_i.hdr.src_id;
-  assign src_id = (FwdMode)? channel_i.hdr.src_id : channel_i.hdr.dst_id;
-  // TODO(fischeti): Clarify with Chen why `ParallelReduction` are excluded
-  assign mask_in = (FwdMode && channel_i.hdr.commtype==ParallelReduction)?
-                    '0 : channel_i.hdr.mask;
+  // Var indicates if the current router lies in the same x/y axis as the source / destination
+  logic x_matched_output;
+  logic y_matched_output;
+  logic x_matched_expected_input;
+  logic y_matched_expected_input;
+
+  // Signal assigments
+  assign dst_id = channel_i.hdr.dst_id;
+  assign src_id = channel_i.hdr.src_id;
+  assign mask = channel_i.hdr.mask;
 
   // We compute minimum and maximum destination IDs, to decide whether
   // we need to send left and/or right resp. up and/or down.
-  assign dst_id_max.x = dst_id.x | mask_in.x;
-  assign dst_id_max.y = dst_id.y | mask_in.y;
-  assign dst_id_min.x = dst_id.x & (~mask_in.x);
-  assign dst_id_min.y = dst_id.y & (~mask_in.y);
+  assign dst_id_max.x = dst_id.x | mask.x;
+  assign dst_id_max.y = dst_id.y | mask.y;
+  assign dst_id_min.x = dst_id.x & (~mask.x);
+  assign dst_id_min.y = dst_id.y & (~mask.y);
 
-  // `x/y_matched` means whether the current coordinate is a
-  // receiver of the the multicast.
-  assign x_matched = &(mask_in.x | ~(xy_id_i.x ^ dst_id.x));
-  assign y_matched = &(mask_in.y | ~(xy_id_i.y ^ dst_id.y));
+  // We compute minimum and maximum source IDs, to decide whether
+  // we need to send left and/or right resp. up and/or down.
+  assign src_id_max.x = src_id.x | mask.x;
+  assign src_id_max.y = src_id.y | mask.y;
+  assign src_id_min.x = src_id.x & (~mask.x);
+  assign src_id_min.y = src_id.y & (~mask.y);
 
-  always_comb begin
-    route_sel = '0;
-    if (FwdMode) begin : gen_out_mask
-      // If both x and y are matched, we eject the flit
-      if (x_matched && y_matched) begin
-        route_sel[Eject] = 1;
+  // `x/y_matched_output` means whether the current coordinate is a receiver of the the multicast.
+  assign x_matched_output = &(mask.x | ~(xy_id_i.x ^ dst_id.x));
+  assign y_matched_output = &(mask.y | ~(xy_id_i.y ^ dst_id.y));
+
+  // `x/y_matched_expected_input` means the current coordinate provides one element to the reduction.
+  assign x_matched_expected_input = &(mask.x | ~(xy_id_i.x ^ src_id.x));
+  assign y_matched_expected_input = &(mask.y | ~(xy_id_i.y ^ src_id.y));
+
+
+  // Generate the output mask
+  if(FwdMode) begin : gen_output_mask
+    always_comb begin
+      route_ouput = '0;
+
+      // If both direction match then the local port is member of the distribution
+      if(x_matched_output && y_matched_output) begin
+        route_ouput[Eject] = 1'b1;
       end
+
       // If the multicast was issued from an endpoint in the same row
       // i.e. the same Y-coordinate, we forward it to `East` if:
       // 1. The request is incoming from `West` or `Eject` and
@@ -66,53 +136,72 @@ module floo_route_xymask
       // The same applies to the `West` direction.
       if (xy_id_i.y == src_id.y) begin
         if (xy_id_i.x >= src_id.x && xy_id_i.x < dst_id_max.x) begin
-          route_sel[East] = 1;
+          route_ouput[East] = 1;
         end
         if (xy_id_i.x <= src_id.x && xy_id_i.x > dst_id_min.x) begin
-          route_sel[West] = 1;
+          route_ouput[West] = 1;
         end
       end
+
       // If there are multicast destinations in the current column,
       // We inject it to `North` if:
       // 1. The request is incoming from `South` or `Eject` and
       // 2. There are more multicast destinations in the `North` direction
       // The same applies to the `South` direction.
-      if (x_matched) begin
+      if (x_matched_output) begin
         if (xy_id_i.y >= src_id.y && xy_id_i.y < dst_id_max.y) begin
-          route_sel[North] = 1;
+          route_ouput[North] = 1;
         end
         if (xy_id_i.y <= src_id.y && xy_id_i.y > dst_id_min.y) begin
-          route_sel[South] = 1;
-        end
-      end
-    end
-
-    // TODO(fischeti): Clarify with Chen why `YXRouting` is used
-    // for the backward path
-    else begin : gen_in_mask
-      // If we previously ejected the flit, we expect one again
-      if (x_matched && y_matched) begin
-        route_sel[Eject] = 1;
-      end
-      // This is the same as the forward path, but we use the
-      // `YXRouting` algorithm to compute the mask.
-      if (xy_id_i.x == src_id.x) begin
-        if (xy_id_i.y >= src_id.y && xy_id_i.y < dst_id_max.y) begin
-          route_sel[North] = 1;
-        end
-        if (xy_id_i.y <= src_id.y && xy_id_i.y > dst_id_min.y) begin
-          route_sel[South] = 1;
-        end
-      end
-      if (y_matched) begin
-        if (xy_id_i.x >= src_id.x && xy_id_i.x < dst_id_max.x) begin
-          route_sel[East] = 1;
-        end
-        if (xy_id_i.x <= src_id.x && xy_id_i.x > dst_id_min.x) begin
-          route_sel[West] = 1;
+          route_ouput[South] = 1;
         end
       end
     end
   end
-  assign route_sel_o = route_sel;
+
+  // Generate the expected input mask
+  if(!FwdMode) begin : gen_expected_input_mask
+    always_comb begin
+      route_expected_input = '0;
+
+      // If both direction match then the local port is a member of the distribution
+      if(x_matched_expected_input && y_matched_expected_input) begin
+        route_expected_input[Eject] = 1'b1;
+      end
+
+      // In the case of an reduction we want to collect the source responses first in the x direction.
+      // e.g. the North / South can only be selected if we are in the correct dst columne.
+      // We expect a packet from the north if the current y id is higher/equal as the destination but still
+      // inside the expected maximum range of the source reduction. Same for the South!
+      if(xy_id_i.x == dst_id.x) begin
+        if((xy_id_i.y >= dst_id.y) && (xy_id_i.y < src_id_max.y)) begin
+          route_expected_input[North] = 1'b1;
+        end
+        if((xy_id_i.y <= dst_id.y) && (xy_id_i.y > src_id_min.y)) begin
+          route_expected_input[South] = 1'b1;
+        end
+      end
+
+      // If we have multiple sources in the same row we first have to collect them in x direction
+      // therefor expecting inputs from either the east or west direction.
+      // For all members of a rows involved in the reduction the flag y_matched_expected_input is set!
+      // We expect a packet from the east if the current x id is higher/equal as the destination but still
+      // inside the expected maximum range of the source reduction. Same for the West!
+      if(y_matched_expected_input) begin
+        if((xy_id_i.x >= dst_id.x) && (xy_id_i.x < src_id_max.x)) begin
+          route_expected_input[East] = 1'b1;
+        end
+        if((xy_id_i.x <= dst_id.x) && (xy_id_i.x > src_id_min.x)) begin
+          route_expected_input[West] = 1'b1;
+        end
+      end
+    end
+  end
+
+  // Eiter assign the expected input or the output depending on the Mode
+  assign route_sel_o = (FwdMode) ? route_ouput : route_expected_input;
+
+  // We only support five input/output routes
+  `ASSERT_INIT(NoMultiCastSupport, NumRoutes == 5)
+
 endmodule


### PR DESCRIPTION
This PR aims to extend the parallel reduction capabilities of FlooNoC to allow for barrier operation. 

* pkg: Extend package with configuration for parallel and offload reduction

* hw: Introduce LSB-And operation in ```floo_reduction_arbiter.sv```

* hw: Add parallel reduction support to ```floo_router.sv```

* hw: Add all parameters relevant for the parallel and offload reduction to the ```floo_nw_router.sv``` / ```floo_router.sv``` without changing the port-list

* hw: Add support to the ```floo_nw_chimney.sv```

Due to the interleave between parallel reduction and offload reduction ( #134 ) some required changes for the offload reduction are already implemented in this PR. The split PR aims to reduce review time.

(merged from commit hash: 4a7f9a12e58575a1dee59e705454cdbb6f1bdad5 by raroth)