### PR TITLE
Bug-Fix: Fix the calculation of the NumSamRules

### DIFF
--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -569,6 +569,8 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
         """Wrapper function to generate all the routing info for the network,
         for a specific routing algorithm."""
         self.routing.num_endpoints = len(self.graph.get_ni_nodes())
+        self.routing.num_cols = self.routers[0].array[0]
+        self.routing.num_nums = self.routers[0].array[1]
         if self.routing.num_endpoints == 0:
             raise ValueError(
                 "No endpoints found in the network. Use the `only_pkg` flag for package generation."

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -496,6 +496,10 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
                 "addr_range": [rng.model_copy() for rng in ep_desc.addr_range],
                 "id": self.graph.get_node_id(node_name=ni_name).model_copy(),
                 "uid": self.graph.get_node_uid(node_name=ni_name).model_copy(),
+                "en_default_idx": self.routing.en_default_idx,
+                "default_idx": Coord(x=self.routing.default_idx[0], y=self.routing.default_idx[1]),
+                "num_cols": self.routers[0].array[0],
+                "num_rows": self.routers[0].array[1]
             }
 
             assert ep_desc
@@ -797,3 +801,4 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
             plt.savefig(filename)
         else:
             plt.show()
+            

--- a/floogen/model/network_interface.py
+++ b/floogen/model/network_interface.py
@@ -30,6 +30,8 @@ class NetworkInterface(BaseModel):
     uid: Optional[SimpleId] = None
     arr_idx: Optional[Id] = None
     addr_range: Optional[List[AddrRange]] = None
+    en_default_idx: Optional[bool] = False
+    default_idx: Optional[Id] = Coord(x=0, y=0)
 
     def is_sbr(self) -> bool:
         """Return true if the network interface is a subordinate."""
@@ -92,3 +94,4 @@ class NarrowWideAxiNI(NetworkInterface):
     def render(self, **kwargs) -> str:
         """Render the network interface."""
         return self.tpl.render(ni=self, **kwargs)
+    

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -352,6 +352,7 @@ class RouteMap(BaseModel):
 
     name: str
     rules: List[RouteMapRule]
+    en_default_idx: Optional[bool] = False
 
     def __str__(self):
         return f"{self.rules}"
@@ -481,6 +482,10 @@ class Routing(BaseModel):
 
     route_algo: RouteAlgo
     use_id_table: bool = True
+    en_default_idx: Optional[bool] = False
+    default_idx: Optional[List[int]] = [0, 0]
+    num_rows: Optional[int] = 2
+    num_cols: Optional[int] = 2
     sam: Optional[RouteMap] = None
     table: Optional[RouteMap] = None
     addr_offset_bits: Optional[int] = None
@@ -576,7 +581,8 @@ class Routing(BaseModel):
                                 self.route_algo == RouteAlgo.XY else 0,
             "IdAddrOffset": self.addr_offset_bits if
                                 self.route_algo == RouteAlgo.ID and not self.use_id_table else 0,
-            "NumSamRules": len(self.sam),
+            "NumSamRules": len(self.sam) if not self.en_default_idx else len(self.sam)- self.num_rows,
             "NumRoutes": self.num_endpoints if self.route_algo == RouteAlgo.SRC else 0,
         }
         return sv_param_decl(name, sv_struct_render(fields), dtype="route_cfg_t")
+    

--- a/floogen/templates/floo_nw_chimney.sv.mako
+++ b/floogen/templates/floo_nw_chimney.sv.mako
@@ -25,7 +25,6 @@ floo_nw_chimney  #(
 % endif
   .hdr_t  (hdr_t),
   .sam_rule_t(sam_rule_t),
-  .Sam(Sam),
   .axi_narrow_in_req_t(${narrow_in_prot.type_name()}_req_t),
   .axi_narrow_in_rsp_t(${narrow_in_prot.type_name()}_rsp_t),
   .axi_narrow_out_req_t(${narrow_out_prot.type_name()}_req_t),
@@ -76,6 +75,9 @@ floo_nw_chimney  #(
 % else:
   .route_table_i    ( '0                          ),
 % endif
+  .en_default_idx_i ( en_default_idx_i            ),
+  .default_idx_i    ( default_idx_i               ),
+  .Sam_i            ( Sam_i                       ),
   .floo_req_o       ( ${ni.mgr_link.req_name()}   ),
   .floo_rsp_i       ( ${ni.mgr_link.rsp_name()}   ),
   .floo_wide_o      ( ${ni.mgr_link.wide_name()}  ),

--- a/floogen/templates/floo_top_noc.sv.mako
+++ b/floogen/templates/floo_top_noc.sv.mako
@@ -14,7 +14,7 @@ module floo_${noc.name}_noc
   input logic clk_i,
   input logic rst_ni,
   input logic test_enable_i,
-  %if noc.chip_id_width and noc.routing.en_default_idx:
+  %if noc.routing.en_default_idx:
   input sam_rule_t [RouteCfg.NumSamRules-1:0] Sam_i,
   input logic en_default_idx_i,
   input id_t  default_idx_i,

--- a/floogen/templates/floo_top_noc.sv.mako
+++ b/floogen/templates/floo_top_noc.sv.mako
@@ -14,6 +14,11 @@ module floo_${noc.name}_noc
   input logic clk_i,
   input logic rst_ni,
   input logic test_enable_i,
+  %if noc.chip_id_width and noc.routing.en_default_idx:
+  input sam_rule_t [RouteCfg.NumSamRules-1:0] Sam_i,
+  input logic en_default_idx_i,
+  input id_t  default_idx_i,
+  %endif
   ${noc.render_ports()}
 );
 

--- a/hw/floo_nw_chimney.sv
+++ b/hw/floo_nw_chimney.sv
@@ -49,7 +49,7 @@ module floo_nw_chimney #(
   parameter type sam_rule_t                             = logic,
   /// The System Address Map (SAM) rules
   /// (only used if `RouteCfg.UseIdTable == 1'b1`)
-  parameter sam_rule_t [RouteCfg.NumSamRules-1:0] Sam   = '0,
+  // parameter sam_rule_t [RouteCfg.NumSamRules-1:0] Sam   = '0,
   /// Narrow AXI manager request channel type
   parameter type axi_narrow_in_req_t                    = logic,
   /// Narrow AXI manager response channel type
@@ -95,6 +95,11 @@ module floo_nw_chimney #(
   input  id_t id_i,
   /// Routing table for the current tile
   input  route_t [RouteCfg.NumRoutes-1:0] route_table_i,
+  /// Default ID
+  input  logic        en_default_idx_i,
+  input  id_t         default_idx_i,
+  /// SAM as input
+  input  sam_rule_t   [RouteCfg.NumSamRules-1:0] Sam_i,
   /// Output links to NoC
   output floo_req_t   floo_req_o,
   output floo_rsp_t   floo_rsp_o,
@@ -718,11 +723,13 @@ module floo_nw_chimney #(
         .clk_i,
         .rst_ni,
         .route_table_i,
-        .addr_map_i ( Sam               ),
-        .id_i       ( id_t'('0)         ),
-        .addr_i     ( axi_req_addr[ch]  ),
-        .route_o    ( route_out[ch]     ),
-        .id_o       ( id_out[ch]        )
+        .addr_map_i       ( Sam_i             ),
+        .id_i             ( id_t'('0)         ),
+        .addr_i           ( axi_req_addr[ch]  ),
+        .en_default_idx_i ( en_default_idx_i  ),
+        .default_idx_i    ( default_idx_i     ),
+        .route_o          ( route_out[ch]     ),
+        .id_o             ( id_out[ch]        )
       );
     end else if (RouteCfg.RouteAlgo == floo_pkg::SourceRouting &&
                  (Ch == NarrowB || Ch == NarrowR ||
@@ -741,11 +748,13 @@ module floo_nw_chimney #(
         .clk_i,
         .rst_ni,
         .route_table_i,
-        .addr_i     ( '0                  ),
-        .addr_map_i ( '0                  ),
-        .id_i       ( axi_rsp_src_id[ch]  ),
-        .route_o    ( route_out[ch]       ),
-        .id_o       ( id_out[ch]          )
+        .addr_i           ( '0                  ),
+        .addr_map_i       ( '0                  ),
+        .id_i             ( axi_rsp_src_id[ch]  ),
+        .en_default_idx_i ( en_default_idx_i    ),
+        .default_idx_i    ( default_idx_i       ),
+        .route_o          ( route_out[ch]       ),
+        .id_o             ( id_out[ch]          )
       );
     end
   end

--- a/hw/floo_route_comp.sv
+++ b/hw/floo_route_comp.sv
@@ -20,14 +20,16 @@ module floo_route_comp
   /// The type of the address rules
   parameter type addr_rule_t = logic
 ) (
-  input  logic  clk_i,
-  input  logic  rst_ni,
-  input  id_t   id_i,
-  input  addr_t addr_i,
+  input  logic                                  clk_i,
+  input  logic                                  rst_ni,
+  input  id_t                                   id_i,
+  input  addr_t                                 addr_i,
   input  addr_rule_t [RouteCfg.NumSamRules-1:0] addr_map_i,
-  input  route_t [RouteCfg.NumRoutes-1:0] route_table_i,
-  output route_t route_o,
-  output id_t id_o
+  input  route_t     [RouteCfg.NumRoutes-1:0]   route_table_i,
+  input  logic                                  en_default_idx_i,
+  input  id_t                                   default_idx_i,
+  output route_t                                route_o,
+  output id_t                                   id_o
 );
 
   // Use an address decoder to map the address to a destination ID.
@@ -54,13 +56,13 @@ module floo_route_comp
       .rule_t     ( addr_rule_t          ),
       .idx_t      ( id_t                 )
     ) i_addr_dst_decode (
-      .addr_i           ( addr_i      ),
-      .addr_map_i       ( addr_map_i  ),
-      .idx_o            ( id_o        ),
-      .dec_valid_o      (             ),
-      .dec_error_o      ( dec_error   ),
-      .en_default_idx_i ( 1'b0        ),
-      .default_idx_i    ( '0          )
+      .addr_i           ( addr_i           ),
+      .addr_map_i       ( addr_map_i       ),
+      .idx_o            ( id_o             ),
+      .dec_valid_o      (                  ),
+      .dec_error_o      ( dec_error        ),
+      .en_default_idx_i ( en_default_idx_i ),
+      .default_idx_i    ( default_idx_i    )
     );
 
     `ASSERT(DecodeError, !dec_error)


### PR DESCRIPTION
This PR fixes the bug of the compuation of the NumSamRules from the num_of_row

In `floogen/model/routing.py` line 584

The NumSamRules is calculated as len(self.sam)- self.num_rows

However the num_rows are not correctly setted in previous verison. This PR sets the correct number from the configuration file.