### PR TITLE
floogen: Add exclusion of endpoints from rdl generation

### DIFF
--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -386,6 +386,7 @@ class AddrRange(BaseModel):
     arr_idx: Optional[Tuple[int, ...]] = None
     arr_dim: Optional[Tuple[int, ...]] = None
     rdl_name: Optional[str] = None
+    rdl_as_mem: Optional[bool] = None
     en_collective: bool = False
     desc: Optional[str] = None
 
@@ -430,6 +431,10 @@ class AddrRange(BaseModel):
         """Validate the address range."""
         if self.start >= self.end:
             raise ValueError("Address range start must be less than end")
+        if self.rdl_name is not None and self.rdl_as_mem is True:
+            raise ValueError(
+                "AddrRange: 'rdl_name' and 'rdl_as_mem' are mutually exclusive"
+            )
         return self
 
     def set_arr(self, arr_idx, arr_dim):
@@ -501,7 +506,8 @@ class RouteMapRule(BaseModel):
                     "arr_dim": self.addr_range.arr_dim,
                 }
             ]
-        if rdl_as_mem:
+        effective_as_mem = rdl_as_mem if self.addr_range.rdl_as_mem is None else self.addr_range.rdl_as_mem
+        if effective_as_mem:
             mementries = (self.addr_range.end - self.addr_range.start) // rdl_memwidth * 8
             mem_string = (
                 f"external mem {{ mementries = 0x{mementries:X}; memwidth = {rdl_memwidth}; }}"

--- a/floogen/tests/address_test.py
+++ b/floogen/tests/address_test.py
@@ -76,6 +76,54 @@ def test_invalid_addr_range():
         addr_range = AddrRange(start=0, end=100, size=100)
         addr_range.set_arr(2, 5)
 
+
+def test_rdl_name_and_rdl_as_mem_mutually_exclusive():
+    """Test that setting both rdl_name and rdl_as_mem raises a validation error."""
+    with pytest.raises(ValueError):
+        AddrRange(start=0, end=0x1000, rdl_name="foo", rdl_as_mem=True)
+
+
+def test_get_rdl_per_endpoint_as_mem():
+    """Test that rdl_as_mem=True in AddrRange enables memory block regardless of global flag."""
+    rule = RouteMapRule(
+        addr_range=AddrRange(start=0, end=0x1000, rdl_as_mem=True),
+        dest=SimpleId(id=1),
+    )
+    result = rule.get_rdl("inst", rdl_as_mem=False, rdl_memwidth=8)
+    assert len(result) == 1
+    assert "external mem" in result[0]["rdl_name"]
+
+
+def test_get_rdl_per_endpoint_opt_out():
+    """Test that rdl_as_mem=False excludes the endpoint even when --as-mem is passed."""
+    rule = RouteMapRule(
+        addr_range=AddrRange(start=0, end=0x1000, rdl_as_mem=False),
+        dest=SimpleId(id=1),
+    )
+    assert rule.get_rdl("inst", rdl_as_mem=True, rdl_memwidth=8) == []
+
+
+def test_get_rdl_global_fallback():
+    """Test that the global --as-mem CLI flag still works when rdl_as_mem is not set."""
+    rule = RouteMapRule(
+        addr_range=AddrRange(start=0, end=0x1000),
+        dest=SimpleId(id=1),
+    )
+    assert rule.get_rdl("inst", rdl_as_mem=False) == []
+    result = rule.get_rdl("inst", rdl_as_mem=True, rdl_memwidth=32)
+    assert len(result) == 1
+    assert "memwidth = 32" in result[0]["rdl_name"]
+
+
+def test_get_rdl_rdl_name_takes_priority():
+    """Test that rdl_name still takes priority over rdl_as_mem."""
+    rule = RouteMapRule(
+        addr_range=AddrRange(start=0, end=0x1000, rdl_name="my_block"),
+        dest=SimpleId(id=1),
+    )
+    result = rule.get_rdl("inst", rdl_as_mem=True)
+    assert result[0]["rdl_name"] == "my_block"
+
 def test_routing_table_len():
     """Test the length of a RoutingTable object."""
     rule1 = RouteMapRule(addr_range=AddrRange(start=0, end=10), dest=SimpleId(id=1))


### PR DESCRIPTION
# Floogen RDL as-mem
 The previous `--as-mem` feature automatically generated the RDL of all endpoints with no `rdl_name` specified.
 
 Now the user can specify in the YAML file the endpoint as `rdl_as_mem: true/false`. Setting the value to false will avoid dumping the endpoint in the generated RDL address map. 

The user can still make use of `--as-mem` and tag as `rdl_as_mem: false` only the endpoints to be excluded. 