### PR TITLE
hw: fix non zero width mismatch for VCS simulation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,14 +187,15 @@ clean-spyglass:
 ###################
 
 PD_REMOTE ?= git@iis-git.ee.ethz.ch:axi-noc/floo_noc_pd.git
-PD_BRANCH ?= master
+PD_BRANCH ?= 85eaa6f8dcf8142457668b4e6aa9b7e20ee90339
 PD_DIR = $(FLOO_ROOT)/pd
 
 .PHONY: init-pd
 
 init-pd:
 	rm -rf $(PD_DIR)
-	git clone $(PD_REMOTE) $(PD_DIR) -b $(PD_BRANCH)
+	git clone $(PD_REMOTE) $(PD_DIR) 
+	cd $(PD_DIR) && git checkout $(PD_BRANCH)
 
 -include $(PD_DIR)/pd.mk
 

--- a/hw/floo_axi_router.sv
+++ b/hw/floo_axi_router.sv
@@ -49,7 +49,7 @@ module floo_axi_router #(
   input  id_t id_i,
   /// Routing table
   /// (only used for `RouteAlgo == IdTable`)
-  input  addr_rule_t [NumAddrRules-1:0] id_route_map_i,
+  input  addr_rule_t [floo_pkg::floo_iomsb(NumAddrRules):0] id_route_map_i,
   /// Input and output links
   input   floo_req_t [NumInputs-1:0] floo_req_i,
   input   floo_rsp_t [NumOutputs-1:0] floo_rsp_i,

--- a/hw/floo_nw_router.sv
+++ b/hw/floo_nw_router.sv
@@ -71,7 +71,7 @@ module floo_nw_router
   input  id_t id_i,
   /// Routing table
   /// (only used for `RouteAlgo == IdTable`)
-  input  addr_rule_t [NumAddrRules-1:0] id_route_map_i,
+  input  addr_rule_t [floo_iomsb(NumAddrRules):0] id_route_map_i,
   /// Input and output links
   input   floo_req_t [NumInputs-1:0]    floo_req_i,
   input   floo_rsp_t [NumOutputs-1:0]   floo_rsp_i,

--- a/hw/floo_route_select.sv
+++ b/hw/floo_route_select.sv
@@ -37,7 +37,7 @@ module floo_route_select
   input  logic                          test_enable_i,
 
   input  id_t                           xy_id_i,
-  input  addr_rule_t [NumAddrRules-1:0] id_route_map_i,
+  input  addr_rule_t [floo_iomsb(NumAddrRules):0] id_route_map_i,
 
   input  flit_t                         channel_i,
   input  logic                          valid_i,

--- a/hw/floo_router.sv
+++ b/hw/floo_router.sv
@@ -61,7 +61,7 @@ module floo_router
   /// Only used for `XYRouting`, tie to '0 otherwise
   input  id_t                                        xy_id_i,
   /// Only used for `IdTable` routing, tie to '0 otherwise
-  input  addr_rule_t [NumAddrRules-1:0]              id_route_map_i,
+  input  addr_rule_t [floo_iomsb(NumAddrRules):0]              id_route_map_i,
   /// Input channels
   input  logic  [NumInput-1:0][NumVirtChannels-1:0]  valid_i,
   output logic  [NumInput-1:0][NumVirtChannels-1:0]  ready_o,

--- a/hw/include/floo_noc/typedef.svh
+++ b/hw/include/floo_noc/typedef.svh
@@ -120,9 +120,9 @@
 // `FLOO_TYPEDEF_AXI_FROM_CFG(axi, AxiCfg)
 `define FLOO_TYPEDEF_AXI_FROM_CFG(name, cfg)                                                                                                                        \
   typedef logic [cfg.AddrWidth-1:0] ``name``_addr_t;                                                                                                                \
-  typedef logic [cfg.InIdWidth-1:0] ``name``_in_id_t;                                                                                                               \
-  typedef logic [cfg.OutIdWidth-1:0] ``name``_out_id_t;                                                                                                             \
-  typedef logic [cfg.UserWidth-1:0] ``name``_user_t;                                                                                                                \
+  typedef logic [floo_iomsb(cfg.InIdWidth):0] ``name``_in_id_t;                                                                                                               \
+  typedef logic [floo_iomsb(cfg.OutIdWidth):0] ``name``_out_id_t;                                                                                                             \
+  typedef logic [floo_iomsb(cfg.UserWidth):0] ``name``_user_t;                                                                                                                \
   typedef logic [cfg.DataWidth-1:0] ``name``_data_t;                                                                                                                \
   typedef logic [cfg.DataWidth/8-1:0] ``name``_strb_t;                                                                                                              \
   `AXI_TYPEDEF_ALL_CT(``name``_in, ``name``_in_req_t, ``name``_in_rsp_t, ``name``_addr_t, ``name``_in_id_t, ``name``_data_t, ``name``_strb_t, ``name``_user_t)      \

--- a/hw/include/floo_noc/typedef.svh
+++ b/hw/include/floo_noc/typedef.svh
@@ -120,9 +120,9 @@
 // `FLOO_TYPEDEF_AXI_FROM_CFG(axi, AxiCfg)
 `define FLOO_TYPEDEF_AXI_FROM_CFG(name, cfg)                                                                                                                        \
   typedef logic [cfg.AddrWidth-1:0] ``name``_addr_t;                                                                                                                \
-  typedef logic [floo_iomsb(cfg.InIdWidth):0] ``name``_in_id_t;                                                                                                               \
-  typedef logic [floo_iomsb(cfg.OutIdWidth):0] ``name``_out_id_t;                                                                                                             \
-  typedef logic [floo_iomsb(cfg.UserWidth):0] ``name``_user_t;                                                                                                                \
+  typedef logic [floo_pkg::floo_iomsb(cfg.InIdWidth):0] ``name``_in_id_t;                                                                                           \
+  typedef logic [floo_pkg::floo_iomsb(cfg.OutIdWidth):0] ``name``_out_id_t;                                                                                         \
+  typedef logic [floo_pkg::floo_iomsb(cfg.UserWidth):0] ``name``_user_t;                                                                                            \
   typedef logic [cfg.DataWidth-1:0] ``name``_data_t;                                                                                                                \
   typedef logic [cfg.DataWidth/8-1:0] ``name``_strb_t;                                                                                                              \
   `AXI_TYPEDEF_ALL_CT(``name``_in, ``name``_in_req_t, ``name``_in_rsp_t, ``name``_addr_t, ``name``_in_id_t, ``name``_data_t, ``name``_strb_t, ``name``_user_t)      \

--- a/hw/synth/floo_synth_params_pkg.sv
+++ b/hw/synth/floo_synth_params_pkg.sv
@@ -7,9 +7,8 @@
 `include "axi/typedef.svh"
 `include "floo_noc/typedef.svh"
 
-import floo_pkg::*;
-
 package floo_synth_params_pkg;
+  import floo_pkg::*;
 
   // Router parameters
   localparam int unsigned InFifoDepth = 2;

--- a/hw/synth/floo_synth_params_pkg.sv
+++ b/hw/synth/floo_synth_params_pkg.sv
@@ -7,8 +7,9 @@
 `include "axi/typedef.svh"
 `include "floo_noc/typedef.svh"
 
+import floo_pkg::*;
+
 package floo_synth_params_pkg;
-  import floo_pkg::*;
 
   // Router parameters
   localparam int unsigned InFifoDepth = 2;

--- a/hw/tb/tb_floo_axi_chimney.sv
+++ b/hw/tb/tb_floo_axi_chimney.sv
@@ -9,6 +9,7 @@
 `include "floo_noc/typedef.svh"
 
 module tb_floo_axi_chimney;
+  import floo_pkg::*;
 
   localparam time CyclTime = 10ns;
   localparam time ApplTime = 2ns;


### PR DESCRIPTION
This PR introduces some fixes to compile floonoc with VCS.

All the files reuse the `floo_iomsb` to make sure signals are defined with a positive index.