### PR TITLE
ci: add Dependabot for uv and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+# Copyright 2024 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+version: 2
+updates:
+  # Python dependencies managed by uv (pyproject.toml + uv.lock)
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Only update to versions that have been published for at least 7 days,
+    # to avoid pulling in compromised releases that get yanked quickly.
+    cooldown:
+      default-days: 7
+    groups:
+      python-deps:
+        patterns: ["*"]
+
+  # GitHub Actions used in .github/workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
## What

Adds a `.github/dependabot.yml` enabling automated dependency updates for:

- **`uv`** — Python dependencies in `pyproject.toml` + `uv.lock` (weekly)
- **`github-actions`** — actions pinned in `.github/workflows` (weekly)

## Why

We want Python dependencies (and CI actions) kept current automatically. Dependabot is native to GitHub, needs no app install, and its PRs are already tested by the existing `floogen` workflow (`uv sync --locked` + pytest).

## Notes for reviewers

- Updates are **grouped** into a single PR per ecosystem (`groups: patterns: ["*"]`) to keep noise down.
- A **7-day `cooldown`** (`default-days: 7`) means Dependabot only proposes versions that have been published for at least a week — a guard against pulling in compromised releases that get yanked quickly. (Note: this does not delay Dependabot *security* updates driven by advisories.)
- Most runtime deps are unpinned ranges, so Dependabot mainly refreshes `uv.lock`; pinned constraints like `click` and `uv_build` may also see `pyproject.toml` bumps.
- Activates once merged to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)