### PR TITLE
feat: add support for YX routing algorithm

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ compile-meshes:
   parallel:
     matrix:
       - DUT: [axi_mesh, nw_mesh]
-        ROUTE_ALGO: [xy, src, id]
+        ROUTE_ALGO: [xy, yx, src, id]
   script:
     - $UV run --cache-dir $CI_BUILDS_DIR/../cache/uv floogen rtl -c floogen/examples/${DUT}_${ROUTE_ALGO}.yml -o generated --no-format
     # Compile the network
@@ -109,7 +109,7 @@ run-traffic:
   parallel:
     matrix:
       - DUT: [axi_mesh, nw_mesh]
-        ROUTE_ALGO: [xy, src, id]
+        ROUTE_ALGO: [xy, yx, src, id]
         TRAFFIC_TYPE: [uniform, hbm, shuffle, hotspot]
         TRAFFIC_RW: [read, write]
   script:

--- a/floogen/examples/axi_mesh_yx.yml
+++ b/floogen/examples/axi_mesh_yx.yml
@@ -1,0 +1,69 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: axi_mesh
+description: "AXI mesh configuration with YX routing for FlooGen"
+network_type: "axi"
+
+routing:
+  route_algo: "YX"
+  use_id_table: true
+
+protocols:
+  - name: "axi_in"
+    protocol: "AXI4"
+    data_width: 64
+    addr_width: 48
+    id_width: 4
+    user_width: 1
+    type_prefix: # prevents `axi_axi` prefix
+  - name: "axi_out"
+    protocol: "AXI4"
+    data_width: 64
+    addr_width: 48
+    id_width: 2
+    user_width: 1
+    type_prefix: # prevents `axi_axi` prefix
+
+endpoints:
+  - name: "cluster"
+    array: [4, 4]
+    addr_range:
+      base: 0x0000_0000_0000
+      size: 0x0000_0001_0000
+    mgr_port_protocol:
+      - "axi_in"
+    sbr_port_protocol:
+      - "axi_out"
+  - name: "hbm"
+    array: [4]
+    addr_range:
+      base: 0x0000_8000_0000
+      size: 0x0000_0001_0000
+    sbr_port_protocol:
+      - "axi_out"
+
+routers:
+  - name: "router"
+    array: [4, 4]
+    degree: 5
+
+connections:
+  - src: "cluster"
+    dst: "router"
+    src_range:
+    - [0, 3]
+    - [0, 3]
+    dst_range:
+    - [0, 3]
+    - [0, 3]
+    dst_dir: "Eject"
+  - src: "hbm"
+    dst: "router"
+    src_range:
+    - [0, 3]
+    dst_range:
+    - [0, 0]
+    - [0, 3]
+    dst_dir: "West"

--- a/floogen/examples/axi_mesh_yx.yml
+++ b/floogen/examples/axi_mesh_yx.yml
@@ -64,6 +64,6 @@ connections:
     src_range:
     - [0, 3]
     dst_range:
-    - [0, 0]
     - [0, 3]
-    dst_dir: "West"
+    - [0, 0]
+    dst_dir: "South"

--- a/floogen/examples/nw_mesh_yx.yml
+++ b/floogen/examples/nw_mesh_yx.yml
@@ -1,0 +1,86 @@
+# Copyright 2023 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: nw_mesh
+description: "NW mesh configuration with YX routing for FlooGen"
+network_type: "narrow-wide"
+
+routing:
+  route_algo: "YX"
+  use_id_table: true
+
+protocols:
+  - name: "narrow_in"
+    type: "narrow"
+    protocol: "AXI4"
+    data_width: 64
+    addr_width: 48
+    id_width: 4
+    user_width: 1
+  - name: "narrow_out"
+    type: "narrow"
+    protocol: "AXI4"
+    data_width: 64
+    addr_width: 48
+    id_width: 2
+    user_width: 1
+  - name: "wide_in"
+    type: "wide"
+    protocol: "AXI4"
+    data_width: 512
+    addr_width: 48
+    id_width: 3
+    user_width: 1
+  - name: "wide_out"
+    type: "wide"
+    protocol: "AXI4"
+    data_width: 512
+    addr_width: 48
+    id_width: 1
+    user_width: 1
+
+endpoints:
+  - name: "cluster"
+    array: [4, 4]
+    addr_range:
+      base: 0x0000_0000_0000
+      size: 0x0000_0001_0000
+    mgr_port_protocol:
+      - "narrow_in"
+      - "wide_in"
+    sbr_port_protocol:
+      - "narrow_out"
+      - "wide_out"
+  - name: "hbm"
+    array: [4]
+    addr_range:
+      base: 0x0000_8000_0000
+      size: 0x0000_0001_0000
+    sbr_port_protocol:
+      - "narrow_out"
+      - "wide_out"
+
+routers:
+  - name: "router"
+    array: [4, 4]
+    degree: 5
+
+connections:
+  - src: "cluster"
+    dst: "router"
+    src_range:
+    - [0, 3]
+    - [0, 3]
+    dst_range:
+    - [0, 3]
+    - [0, 3]
+    dst_dir: "Eject"
+  - src: "hbm"
+    dst: "router"
+    src_range:
+    - [0, 3]
+    dst_range:
+    - [0, 0]
+    - [0, 3]
+    dst_dir: "West"

--- a/floogen/examples/nw_mesh_yx.yml
+++ b/floogen/examples/nw_mesh_yx.yml
@@ -81,6 +81,6 @@ connections:
     src_range:
     - [0, 3]
     dst_range:
-    - [0, 0]
     - [0, 3]
-    dst_dir: "West"
+    - [0, 0]
+    dst_dir: "South"

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -338,7 +338,7 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
         """Infer the id type from the network."""
         # Add XY coordinates to the nodes
         match self.routing.route_algo:
-            case RouteAlgo.XY:
+            case RouteAlgo.XY | RouteAlgo.YX:
                 # 1st stage: Get all router nodes
                 for node_name, node in self.graph.get_rt_nodes(with_name=True):
                     x, y = self.graph.get_node_arr_idx(node_name)
@@ -461,7 +461,7 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
                 "degree": num_edges,
                 "route_algo": self.routing.route_algo,
             }
-            if self.routing.route_algo == RouteAlgo.XY:
+            if self.routing.route_algo in (RouteAlgo.XY, RouteAlgo.YX):
                 router_dict["id"] = self.graph.get_node_id(rt_name)
             match self.network_type:
                 case "axi":
@@ -600,7 +600,7 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
             )
         self.routing.num_id_bits = clog2(len(self.graph.get_ni_nodes()))
         match self.routing.route_algo:
-            case RouteAlgo.XY:
+            case RouteAlgo.XY | RouteAlgo.YX:
                 for info, value in self.gen_xy_routing_info().items():
                     setattr(self.routing, info, value)
             case RouteAlgo.ID:

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -874,7 +874,7 @@ class Routing(BaseModel):
     @model_validator(mode="after")
     def validate_collective_route_algo(self):
         """Collective operations are supported with XY routing only."""
-        if self.en_collective and self.route_algo != RouteAlgo.XY:
+        if self.en_collective and self.route_algo != RouteAlgo.XY and self.route_algo != RouteAlgo.YX:
             raise ValueError(
                 "Collective operations are only supported with XY routing algorithm, "
                 f"but got {self.route_algo}"
@@ -886,7 +886,7 @@ class Routing(BaseModel):
         string += sv_param_decl("RouteAlgo", self.route_algo.value, dtype="route_algo_e")
         string += sv_param_decl("UseIdTable", bool_to_sv(self.use_id_table), dtype="bit")
         match (self.route_algo):
-            case RouteAlgo.XY:
+            case RouteAlgo.XY | RouteAlgo.YX:
                 string += sv_param_decl("NumXBits", self.num_x_bits)
                 string += sv_param_decl("NumYBits", self.num_y_bits)
             case RouteAlgo.ID:
@@ -894,7 +894,7 @@ class Routing(BaseModel):
             case _:
                 pass
 
-        if self.route_algo == RouteAlgo.XY:
+        if self.route_algo in (RouteAlgo.XY, RouteAlgo.YX):
             string += sv_param_decl("XYAddrOffsetX", self.addr_offset_bits)
             string += sv_param_decl("XYAddrOffsetY", self.addr_offset_bits + self.num_x_bits)
         else:
@@ -913,7 +913,7 @@ class Routing(BaseModel):
         if self.port_id_bits > 0:
             string += sv_typedef("port_id_t", array_size=self.port_id_bits)
         match self.route_algo:
-            case RouteAlgo.XY:
+            case RouteAlgo.XY | RouteAlgo.YX:
                 string += sv_typedef("x_bits_t", array_size=self.num_x_bits)
                 string += sv_typedef("y_bits_t", array_size=self.num_y_bits)
                 id_fields = {"x": "x_bits_t", "y": "y_bits_t"}
@@ -952,9 +952,9 @@ class Routing(BaseModel):
         fields = {
             "RouteAlgo": self.route_algo.value,
             "UseIdTable": bool_to_sv(self.use_id_table),
-            "XYAddrOffsetX": self.addr_offset_bits if self.route_algo == RouteAlgo.XY else 0,
+            "XYAddrOffsetX": self.addr_offset_bits if self.route_algo in (RouteAlgo.XY, RouteAlgo.YX) else 0,
             "XYAddrOffsetY": self.addr_offset_bits + self.num_x_bits if
-                                self.route_algo == RouteAlgo.XY else 0,
+                                self.route_algo in (RouteAlgo.XY, RouteAlgo.YX) else 0,
             "IdAddrOffset": self.addr_offset_bits if
                                 self.route_algo == RouteAlgo.ID and not self.use_id_table else 0,
             "NumSamRules": len(self.sam),

--- a/floogen/templates/floo_axi_chimney.sv.mako
+++ b/floogen/templates/floo_axi_chimney.sv.mako
@@ -6,7 +6,7 @@
 <% in_prot = next((prot for prot in noc.protocols if prot.direction == "input"), None) %>\
 <% out_prot = next((prot for prot in noc.protocols if prot.direction == "output"), None) %>\
 
-% if ni.routing.route_algo.value == 'XYRouting':
+% if ni.routing.route_algo.value == 'XYRouting' or ni.routing.route_algo.value == 'YXRouting':
   localparam id_t ${ni.name.upper()}_ID = ${actual_xy_id.render()};
 % else:
   localparam id_t ${ni.name.upper()}_ID = id_t'(${ni.id.render()});

--- a/floogen/templates/floo_axi_router.sv.mako
+++ b/floogen/templates/floo_axi_router.sv.mako
@@ -47,7 +47,7 @@ ${rsp_type} [${len(router.outgoing)-1}:0] ${router.name}_rsp_in;
   % endif
 % endfor
 
-% if router.route_algo == RouteAlgo.XY:
+% if router.route_algo == RouteAlgo.XY or router.route_algo == RouteAlgo.YX:
   localparam id_t ${router.name.upper()}_ID = ${offset_xy_id.render()};
 % endif
 
@@ -71,7 +71,7 @@ floo_axi_router #(
   .clk_i,
   .rst_ni,
   .test_enable_i,
-% if router.route_algo == RouteAlgo.XY:
+% if router.route_algo == RouteAlgo.XY or router.route_algo == RouteAlgo.YX:
   .id_i (${router.name.upper()}_ID),
 % else:
   .id_i ('0),

--- a/floogen/templates/floo_nw_chimney.sv.mako
+++ b/floogen/templates/floo_nw_chimney.sv.mako
@@ -8,7 +8,7 @@
 <% wide_in_prot = next((prot for prot in noc.protocols if prot.type == "wide" and prot.direction == "input"), None) %>\
 <% wide_out_prot = next((prot for prot in noc.protocols if prot.type == "wide" and prot.direction == "output"), None) %>\
 
-% if ni.routing.route_algo.value == 'XYRouting':
+% if ni.routing.route_algo.value == 'XYRouting' or ni.routing.route_algo.value == 'YXRouting':
   localparam id_t ${ni.name.upper()}_ID = ${actual_xy_id.render()};
 % else:
   localparam id_t ${ni.name.upper()}_ID = id_t'(${ni.id.render()});

--- a/floogen/templates/floo_nw_router.sv.mako
+++ b/floogen/templates/floo_nw_router.sv.mako
@@ -64,7 +64,7 @@ ${wide_type} [${len(router.outgoing)-1}:0] ${router.name}_wide_out;
   % endif
 % endfor
 
-% if router.route_algo == RouteAlgo.XY:
+% if router.route_algo == RouteAlgo.XY or router.route_algo == RouteAlgo.YX:
   localparam id_t ${router.name.upper()}_ID = ${offset_xy_id.render()};
 % endif
 
@@ -105,7 +105,7 @@ floo_nw_router #(
   .clk_i,
   .rst_ni,
   .test_enable_i,
-% if router.route_algo == RouteAlgo.XY:
+% if router.route_algo == RouteAlgo.XY or router.route_algo == RouteAlgo.YX:
   .id_i (${router.name.upper()}_ID),
 % else:
   .id_i ('0),

--- a/hw/floo_meta_buffer.sv
+++ b/hw/floo_meta_buffer.sv
@@ -219,7 +219,8 @@ module floo_meta_buffer #(
   // NoC addr/mask to AXI addr/mask conversion
   localparam int unsigned AddrWidth = $bits(addr_t);
   if (EnCollective && RouteCfg.UseIdTable &&
-     (RouteCfg.RouteAlgo == floo_pkg::XYRouting))
+     (RouteCfg.RouteAlgo == floo_pkg::XYRouting ||
+      RouteCfg.RouteAlgo == floo_pkg::YXRouting))
   begin : gen_mcast_table_conversion
     id_t out, in_mask, in_id;
     mask_sel_t x_mask_sel, y_mask_sel;

--- a/hw/floo_nw_chimney.sv
+++ b/hw/floo_nw_chimney.sv
@@ -62,7 +62,7 @@ module floo_nw_chimney
   /// SAM Index type to support multicast info
   parameter type sam_idx_t                              = id_t,
   /// Struct consisting of offset and len to speficy the position of the mask bits
-  /// (only used if `EnMultiCast && RouteCfg.UseIdTable == 1'b1 && RouteCfg.RouteAlgo == XYRouting`)
+  /// (only used if `EnMultiCast && RouteCfg.UseIdTable == 1'b1 && RouteAlgo is XY or YX`)
   parameter type mask_sel_t                             = logic,
   /// Narrow AXI manager request channel type
   parameter type axi_narrow_in_req_t                    = logic,
@@ -1034,7 +1034,8 @@ module floo_nw_chimney
           (en_wide_collective(CollectOpCfg) && Ch == WideAw)) begin : gen_req_id_mask
         // Evaluate the ID Mask according to the info read from the SAM through the flooo_id_translation module
         if (RouteCfg.UseIdTable &&
-            RouteCfg.RouteAlgo == floo_pkg::XYRouting) begin: gen_collecttive_idtable
+            (RouteCfg.RouteAlgo == floo_pkg::XYRouting ||
+             RouteCfg.RouteAlgo == floo_pkg::YXRouting)) begin: gen_collecttive_idtable
           assign x_addr_mask[ch] = (({AddrWidth{1'b1}} >> (AddrWidth - x_mask_sel[ch].len))
                                     << x_mask_sel[ch].offset);
           assign y_addr_mask[ch] = (({AddrWidth{1'b1}} >> (AddrWidth - y_mask_sel[ch].len))
@@ -1042,7 +1043,8 @@ module floo_nw_chimney
           assign mask_id[ch].x = (axi_req_user[ch] & x_addr_mask[ch]) >> x_mask_sel[ch].offset;
           assign mask_id[ch].y = (axi_req_user[ch] & y_addr_mask[ch]) >> y_mask_sel[ch].offset;
           assign mask_id[ch].port_id = '0;
-        end else if (RouteCfg.RouteAlgo == floo_pkg::XYRouting) begin: gen_collective_noidtable
+        end else if (RouteCfg.RouteAlgo == floo_pkg::XYRouting ||
+                     RouteCfg.RouteAlgo == floo_pkg::YXRouting) begin: gen_collective_noidtable
           assign mask_id[ch].x = axi_req_user[ch][RouteCfg.XYAddrOffsetX +: $bits(id_out[ch].x)];
           assign mask_id[ch].y = axi_req_user[ch][RouteCfg.XYAddrOffsetY +: $bits(id_out[ch].y)];
           assign mask_id[ch].port_id = '0;

--- a/hw/floo_output_arbiter.sv
+++ b/hw/floo_output_arbiter.sv
@@ -20,6 +20,8 @@ module floo_output_arbiter import floo_pkg::*;
   parameter int unsigned NumParallelRedRoutes = 0,
   /// Collective ops configuration
   parameter collect_op_be_cfg_t  CollectOpCfg    = CollectiveSupportDefaultCfg,
+  /// Routing algorithm
+  parameter route_algo_e    RouteAlgo   = XYRouting,
   /// Type definitions
   parameter type         flit_t               = logic,
   parameter type         hdr_t                = logic,
@@ -107,6 +109,7 @@ module floo_output_arbiter import floo_pkg::*;
       .flit_t               ( flit_t               ),
       .hdr_t                ( hdr_t                ),
       .id_t                 ( id_t                 ),
+      .RouteAlgo            ( RouteAlgo            ),
       .AxiCfg               ( AxiCfg               )
     ) i_reduction_arbiter (
       .xy_id_i,

--- a/hw/floo_pkg.sv
+++ b/hw/floo_pkg.sv
@@ -35,7 +35,10 @@ package floo_pkg;
     ///  XY coordinates, which can be done with addressoffsets `XYAddrOffsetX`
     /// and `XYAddrOffsetY`, or by indexing the system address map `Sam`. This
     /// is controlled with the `UseIdTable` parameter.
-    XYRouting
+    XYRouting,
+    /// `YXRouting` is identical to `XYRouting` but resolves the Y dimension first,
+    /// then the X dimension. Useful when the Y dimension is the critical path.
+    YXRouting
   } route_algo_e;
 
   /// The directions in a 2D mesh network, mainly useful for indexing

--- a/hw/floo_pkg.sv
+++ b/hw/floo_pkg.sv
@@ -37,7 +37,7 @@ package floo_pkg;
     /// is controlled with the `UseIdTable` parameter.
     XYRouting,
     /// `YXRouting` is identical to `XYRouting` but resolves the Y dimension first,
-    /// then the X dimension. Useful when the Y dimension is the critical path.
+    /// then the X dimension.
     YXRouting
   } route_algo_e;
 

--- a/hw/floo_reduction_arbiter.sv
+++ b/hw/floo_reduction_arbiter.sv
@@ -23,6 +23,8 @@ module floo_reduction_arbiter import floo_pkg::*;
   parameter int unsigned NumRoutes            = 1,
   /// Collective ops configuration
   parameter collect_op_be_cfg_t  CollectOpCfg    = CollectiveSupportDefaultCfg,
+  /// Routing algorithm
+  parameter route_algo_e    RouteAlgo   = XYRouting,
   /// Type definitions
   parameter type         flit_t               = logic,
   parameter type         hdr_t                = logic,
@@ -71,7 +73,8 @@ module floo_reduction_arbiter import floo_pkg::*;
       .NumRoutes ( NumRoutes ),
       .flit_t    ( flit_t    ),
       .id_t      ( id_t      ),
-      .FwdMode   ( 0         ) // We enable the backward mode for reduction
+      .FwdMode   ( 0         ), // We enable the backward mode for reduction
+      .RouteAlgo ( RouteAlgo  )
     ) i_route_xymask (
       .channel_i    ( data_i[i]   ),
       .xy_id_i      ( xy_id_i         ),

--- a/hw/floo_reduction_unit.sv
+++ b/hw/floo_reduction_unit.sv
@@ -273,7 +273,6 @@ module floo_reduction_unit
         .ready_i  (result_ready_out)
   );
 
-  // TODO(lleone): Make sure this logic is actually optimized away in PnR
   // Apply the result from the offload unit to the stored flit
   always_comb begin: gen_result_flit
     w_flit_result = floo_axi_w_flit_t'(metadata_flit_out);

--- a/hw/floo_route_select.sv
+++ b/hw/floo_route_select.sv
@@ -96,7 +96,7 @@ module floo_route_select
       channel_o.hdr.dst_id = channel_i.hdr.dst_id >> RouteSelWidth;
     end
 
-  end else if (RouteAlgo == XYRouting) begin : gen_xy_routing
+  end else if (RouteAlgo == XYRouting || RouteAlgo == YXRouting) begin : gen_xy_yx_routing
     // Routing based on simple XY routing
     // Assumes an even-bit ID field in the flit_t used for xy
     // assert ((IdWidth/2)*2 == IdWidth);
@@ -118,7 +118,7 @@ module floo_route_select
         .flit_t        ( flit_t           ),
         .id_t          ( id_t             ),
         .FwdMode       ( 1'b1             ),
-        .RouteAlgo     ( XYRouting  )
+        .RouteAlgo     ( RouteAlgo        )
       ) i_route_xymask (
         .channel_i   ( channel_i ),
         .xy_id_i     ( xy_id_i   ),
@@ -128,30 +128,58 @@ module floo_route_select
       assign route_sel_multicast = '0;  // No MCast supported
     end
 
-    // Calculate here the unicast output mask
-    id_t id_in;
-    assign id_in = id_t'(channel_i.hdr.dst_id);
-    always_comb begin
-      route_sel_id = East;
-      if (id_in.x == xy_id_i.x && id_in.y == xy_id_i.y) begin
-        route_sel_id = Eject + channel_i.hdr.dst_id.port_id;
-      end else if (id_in.x == xy_id_i.x) begin
-        if (id_in.y < xy_id_i.y) begin
-          route_sel_id = South;
+    if (RouteAlgo == XYRouting) begin : gen_xy_routing
+      // Routing based on simple XY routing (X dimension resolved first, then Y)
+      // Calculate here the unicast output mask
+      id_t id_in;
+      assign id_in = id_t'(channel_i.hdr.dst_id);
+      always_comb begin
+        route_sel_id = East;
+        if (id_in.x == xy_id_i.x && id_in.y == xy_id_i.y) begin
+          route_sel_id = Eject + channel_i.hdr.dst_id.port_id;
+        end else if (id_in.x == xy_id_i.x) begin
+          if (id_in.y < xy_id_i.y) begin
+            route_sel_id = South;
+          end else begin
+            route_sel_id = North;
+          end
         end else begin
-          route_sel_id = North;
+          if (id_in.x < xy_id_i.x) begin
+            route_sel_id = West;
+          end else begin
+            route_sel_id = East;
+          end
         end
-      end else begin
-        if (id_in.x < xy_id_i.x) begin
-          route_sel_id = West;
-        end else begin
-          route_sel_id = East;
-        end
+        route_sel_unicast = '0;
+        route_sel_unicast[route_sel_id] = 1'b1;
       end
-      route_sel_unicast = '0;
-      route_sel_unicast[route_sel_id] = 1'b1;
+    end else begin : gen_yx_routing
+      // Routing based on simple YX routing (Y dimension resolved first, then X)
+      id_t id_in;
+      assign id_in = id_t'(channel_i.hdr.dst_id);
+      always_comb begin
+        route_sel_id = North;
+        if (id_in.x == xy_id_i.x && id_in.y == xy_id_i.y) begin
+          route_sel_id = Eject + channel_i.hdr.dst_id.port_id;
+        end else if (id_in.y == xy_id_i.y) begin
+          // Y matches — now route along X
+          if (id_in.x < xy_id_i.x) begin
+            route_sel_id = West;
+          end else begin
+            route_sel_id = East;
+          end
+        end else begin
+          // Route along Y first
+          if (id_in.y < xy_id_i.y) begin
+            route_sel_id = South;
+          end else begin
+            route_sel_id = North;
+          end
+        end
+        route_sel_unicast = '0;
+        route_sel_unicast[route_sel_id] = 1'b1;
+      end
     end
-
     // Depending on the flit header choose the correct route
     if(EnMultiCast) begin: gen_mcast_out_sel
       assign route_sel = (channel_i.hdr.collective_op == Multicast) ?
@@ -159,68 +187,7 @@ module floo_route_select
     end else begin: gen_unicast_route_sel
       assign route_sel = route_sel_unicast;
     end
-
     // Assign the data directly to the output
-    assign channel_o = channel_i;
-
-  end else if (RouteAlgo == YXRouting) begin : gen_yx_routing
-    // Routing based on simple YX routing (Y dimension resolved first, then X)
-
-    // Port map same as XYRouting:
-    //   - 0: target/destination (Eject)
-    //   - 1: upper bits decreasing (South)
-    //   - 2: lower bits decreasing (West)
-    //   - 3: upper bits increasing (North)
-    //   - 4: lower bits increasing (East)
-
-    if (EnMultiCast) begin : gen_mcast_route_sel
-      floo_route_xymask #(
-        .NumRoutes  ( NumRoutes  ),
-        .flit_t     ( flit_t     ),
-        .id_t       ( id_t       ),
-        .FwdMode    ( 1'b1       ),
-        .RouteAlgo  ( YXRouting  )
-      ) i_route_xymask (
-        .channel_i   ( channel_i         ),
-        .xy_id_i     ( xy_id_i           ),
-        .route_sel_o ( route_sel_multicast )
-      );
-    end else begin : gen_no_mcast
-      assign route_sel_multicast = '0;
-    end
-
-    id_t id_in;
-    assign id_in = id_t'(channel_i.hdr.dst_id);
-    always_comb begin
-      route_sel_id = North;
-      if (id_in.x == xy_id_i.x && id_in.y == xy_id_i.y) begin
-        route_sel_id = Eject + channel_i.hdr.dst_id.port_id;
-      end else if (id_in.y == xy_id_i.y) begin
-        // Y matches — now route along X
-        if (id_in.x < xy_id_i.x) begin
-          route_sel_id = West;
-        end else begin
-          route_sel_id = East;
-        end
-      end else begin
-        // Route along Y first
-        if (id_in.y < xy_id_i.y) begin
-          route_sel_id = South;
-        end else begin
-          route_sel_id = North;
-        end
-      end
-      route_sel_unicast = '0;
-      route_sel_unicast[route_sel_id] = 1'b1;
-    end
-
-    if (EnMultiCast) begin : gen_mcast_out_sel
-      assign route_sel = (channel_i.hdr.collective_op == Multicast) ?
-                        route_sel_multicast : route_sel_unicast;
-    end else begin : gen_unicast_route_sel
-      assign route_sel = route_sel_unicast;
-    end
-
     assign channel_o = channel_i;
 
   end else begin : gen_err

--- a/hw/floo_route_select.sv
+++ b/hw/floo_route_select.sv
@@ -117,7 +117,8 @@ module floo_route_select
         .NumRoutes     ( NumRoutes        ),
         .flit_t        ( flit_t           ),
         .id_t          ( id_t             ),
-        .FwdMode       ( 1'b1             )
+        .FwdMode       ( 1'b1             ),
+        .RouteAlgo     ( XYRouting  )
       ) i_route_xymask (
         .channel_i   ( channel_i ),
         .xy_id_i     ( xy_id_i   ),
@@ -160,6 +161,66 @@ module floo_route_select
     end
 
     // Assign the data directly to the output
+    assign channel_o = channel_i;
+
+  end else if (RouteAlgo == YXRouting) begin : gen_yx_routing
+    // Routing based on simple YX routing (Y dimension resolved first, then X)
+
+    // Port map same as XYRouting:
+    //   - 0: target/destination (Eject)
+    //   - 1: upper bits decreasing (South)
+    //   - 2: lower bits decreasing (West)
+    //   - 3: upper bits increasing (North)
+    //   - 4: lower bits increasing (East)
+
+    if (EnMultiCast) begin : gen_mcast_route_sel
+      floo_route_xymask #(
+        .NumRoutes  ( NumRoutes  ),
+        .flit_t     ( flit_t     ),
+        .id_t       ( id_t       ),
+        .FwdMode    ( 1'b1       ),
+        .RouteAlgo  ( YXRouting  )
+      ) i_route_xymask (
+        .channel_i   ( channel_i         ),
+        .xy_id_i     ( xy_id_i           ),
+        .route_sel_o ( route_sel_multicast )
+      );
+    end else begin : gen_no_mcast
+      assign route_sel_multicast = '0;
+    end
+
+    id_t id_in;
+    assign id_in = id_t'(channel_i.hdr.dst_id);
+    always_comb begin
+      route_sel_id = North;
+      if (id_in.x == xy_id_i.x && id_in.y == xy_id_i.y) begin
+        route_sel_id = Eject + channel_i.hdr.dst_id.port_id;
+      end else if (id_in.y == xy_id_i.y) begin
+        // Y matches — now route along X
+        if (id_in.x < xy_id_i.x) begin
+          route_sel_id = West;
+        end else begin
+          route_sel_id = East;
+        end
+      end else begin
+        // Route along Y first
+        if (id_in.y < xy_id_i.y) begin
+          route_sel_id = South;
+        end else begin
+          route_sel_id = North;
+        end
+      end
+      route_sel_unicast = '0;
+      route_sel_unicast[route_sel_id] = 1'b1;
+    end
+
+    if (EnMultiCast) begin : gen_mcast_out_sel
+      assign route_sel = (channel_i.hdr.collective_op == Multicast) ?
+                        route_sel_multicast : route_sel_unicast;
+    end else begin : gen_unicast_route_sel
+      assign route_sel = route_sel_unicast;
+    end
+
     assign channel_o = channel_i;
 
   end else begin : gen_err

--- a/hw/floo_route_select.sv
+++ b/hw/floo_route_select.sv
@@ -96,7 +96,7 @@ module floo_route_select
       channel_o.hdr.dst_id = channel_i.hdr.dst_id >> RouteSelWidth;
     end
 
-  end else if (RouteAlgo == XYRouting || RouteAlgo == YXRouting) begin : gen_xy_yx_routing
+  end else if (RouteAlgo == XYRouting || RouteAlgo == YXRouting) begin : gen_dor_routing
     // Routing based on simple XY routing
     // Assumes an even-bit ID field in the flit_t used for xy
     // assert ((IdWidth/2)*2 == IdWidth);

--- a/hw/floo_route_xymask.sv
+++ b/hw/floo_route_xymask.sv
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: SHL-0.51
 //
 // Author:
+// - Lorenzo Leone <lleone@iis.ee.ethz.ch>
 // - Chen Wu <chenwu@student.ethz.ch>
 // - Raphael Roth <raroth@student.ethz.ch>
 
@@ -12,7 +13,7 @@
 // input direction (e.g. which input provides a flit).
 
 // Limitations:
-// - It only supports xy routing
+// - It only supports xy and yx routing
 // - It only supports 5 in/out routes
 
 `include "common_cells/assertions.svh"
@@ -24,6 +25,8 @@ module floo_route_xymask import floo_pkg::*; #(
   /// 1: Determine output directions of the forward path in Multicast
   /// 0: Determine input directions of the backward path in Multicast i.e the reduction
   parameter bit             FwdMode     = 1'b1,
+  /// Routing algorithm: XYRouting resolves X first, YXRouting resolves Y first
+  parameter route_algo_e    RouteAlgo   = XYRouting,
   /// type for data flit
   parameter type            flit_t      = logic,
   /// type for local id (router id)
@@ -129,31 +132,65 @@ module floo_route_xymask import floo_pkg::*; #(
         route_output[Eject] = 1'b1;
       end
 
-      // If the multicast was issued from an endpoint in the same row
-      // i.e. the same Y-coordinate, we forward it to `East` if:
-      // 1. The request is incoming from `West` or `Eject` and
-      // 2. There are more multicast destinations in the `East` direction
-      // The same applies to the `West` direction.
-      if (xy_id_i.y == src_id.y) begin
-        if (xy_id_i.x >= src_id.x && xy_id_i.x < dst_id_max.x) begin
-          route_output[East] = 1;
-        end
-        if (xy_id_i.x <= src_id.x && xy_id_i.x > dst_id_min.x) begin
-          route_output[West] = 1;
-        end
-      end
+      if (RouteAlgo == XYRouting) begin
+        // XY: spread along X first (same row as source), then along Y
 
-      // If there are multicast destinations in the current column,
-      // We inject it to `North` if:
-      // 1. The request is incoming from `South` or `Eject` and
-      // 2. There are more multicast destinations in the `North` direction
-      // The same applies to the `South` direction.
-      if (x_matched_output) begin
-        if (xy_id_i.y >= src_id.y && xy_id_i.y < dst_id_max.y) begin
-          route_output[North] = 1;
+        // If the multicast was issued from an endpoint in the same row
+        // i.e. the same Y-coordinate, we forward it to `East` if:
+        // 1. The request is incoming from `West` or `Eject` and
+        // 2. There are more multicast destinations in the `East` direction
+        // The same applies to the `West` direction.
+        if (xy_id_i.y == src_id.y) begin
+          if (xy_id_i.x >= src_id.x && xy_id_i.x < dst_id_max.x) begin
+            route_output[East] = 1;
+          end
+          if (xy_id_i.x <= src_id.x && xy_id_i.x > dst_id_min.x) begin
+            route_output[West] = 1;
+          end
         end
-        if (xy_id_i.y <= src_id.y && xy_id_i.y > dst_id_min.y) begin
-          route_output[South] = 1;
+
+        // If there are multicast destinations in the current column,
+        // We inject it to `North` if:
+        // 1. The request is incoming from `South` or `Eject` and
+        // 2. There are more multicast destinations in the `North` direction
+        // The same applies to the `South` direction.
+        if (x_matched_output) begin
+          if (xy_id_i.y >= src_id.y && xy_id_i.y < dst_id_max.y) begin
+            route_output[North] = 1;
+          end
+          if (xy_id_i.y <= src_id.y && xy_id_i.y > dst_id_min.y) begin
+            route_output[South] = 1;
+          end
+        end
+      end else begin
+        // YX: spread along Y first (same column as source), then along X
+
+        // If the multicast was issued from an endpoint in the same column
+        // i.e. the same X-coordinate, we forward it to `North` if:
+        // 1. The request is incoming from `South` or `Eject` and
+        // 2. There are more multicast destinations in the `North` direction
+        // The same applies to the `South` direction.
+        if (xy_id_i.x == src_id.x) begin
+          if (xy_id_i.y >= src_id.y && xy_id_i.y < dst_id_max.y) begin
+            route_output[North] = 1;
+          end
+          if (xy_id_i.y <= src_id.y && xy_id_i.y > dst_id_min.y) begin
+            route_output[South] = 1;
+          end
+        end
+
+        // If there are multicast destinations in the current row,
+        // We inject it to `East` if:
+        // 1. The request is incoming from `West` or `Eject` and
+        // 2. There are more multicast destinations in the `East` direction
+        // The same applies to the `West` direction.
+        if (y_matched_output) begin
+          if (xy_id_i.x >= src_id.x && xy_id_i.x < dst_id_max.x) begin
+            route_output[East] = 1;
+          end
+          if (xy_id_i.x <= src_id.x && xy_id_i.x > dst_id_min.x) begin
+            route_output[West] = 1;
+          end
         end
       end
     end
@@ -169,30 +206,63 @@ module floo_route_xymask import floo_pkg::*; #(
         route_expected_input[Eject] = 1'b1;
       end
 
-      // In the case of an reduction we want to collect the source responses first in the x direction.
-      // e.g. the North / South can only be selected if we are in the correct dst columne.
-      // We expect a packet from the north if the current y id is higher/equal as the destination but still
-      // inside the expected maximum range of the source reduction. Same for the South!
-      if(xy_id_i.x == dst_id.x) begin
-        if((xy_id_i.y >= dst_id.y) && (xy_id_i.y < src_id_max.y)) begin
-          route_expected_input[North] = 1'b1;
-        end
-        if((xy_id_i.y <= dst_id.y) && (xy_id_i.y > src_id_min.y)) begin
-          route_expected_input[South] = 1'b1;
-        end
-      end
+      if (RouteAlgo == XYRouting) begin
+        // XY: collect along X first, then along Y
 
-      // If we have multiple sources in the same row we first have to collect them in x direction
-      // therefor expecting inputs from either the east or west direction.
-      // For all members of a rows involved in the reduction the flag y_matched_expected_input is set!
-      // We expect a packet from the east if the current x id is higher/equal as the destination but still
-      // inside the expected maximum range of the source reduction. Same for the West!
-      if(y_matched_expected_input) begin
-        if((xy_id_i.x >= dst_id.x) && (xy_id_i.x < src_id_max.x)) begin
-          route_expected_input[East] = 1'b1;
+        // In the case of an reduction we want to collect the source responses first in the x direction.
+        // e.g. the North / South can only be selected if we are in the correct dst columne.
+        // We expect a packet from the north if the current y id is higher/equal as the destination but still
+        // inside the expected maximum range of the source reduction. Same for the South!
+        if(xy_id_i.x == dst_id.x) begin
+          if((xy_id_i.y >= dst_id.y) && (xy_id_i.y < src_id_max.y)) begin
+            route_expected_input[North] = 1'b1;
+          end
+          if((xy_id_i.y <= dst_id.y) && (xy_id_i.y > src_id_min.y)) begin
+            route_expected_input[South] = 1'b1;
+          end
         end
-        if((xy_id_i.x <= dst_id.x) && (xy_id_i.x > src_id_min.x)) begin
-          route_expected_input[West] = 1'b1;
+
+        // If we have multiple sources in the same row we first have to collect them in x direction
+        // therefor expecting inputs from either the east or west direction.
+        // For all members of a rows involved in the reduction the flag y_matched_expected_input is set!
+        // We expect a packet from the east if the current x id is higher/equal as the destination but still
+        // inside the expected maximum range of the source reduction. Same for the West!
+        if(y_matched_expected_input) begin
+          if((xy_id_i.x >= dst_id.x) && (xy_id_i.x < src_id_max.x)) begin
+            route_expected_input[East] = 1'b1;
+          end
+          if((xy_id_i.x <= dst_id.x) && (xy_id_i.x > src_id_min.x)) begin
+            route_expected_input[West] = 1'b1;
+          end
+        end
+      end else begin
+        // YX: collect along Y first, then along X
+
+        // In the case of a reduction we want to collect the source responses first in the y direction.
+        // e.g. the East / West can only be selected if we are in the correct dst row.
+        // We expect a packet from the east if the current x id is higher/equal as the destination but still
+        // inside the expected maximum range of the source reduction. Same for the West!
+        if(xy_id_i.y == dst_id.y) begin
+          if((xy_id_i.x >= dst_id.x) && (xy_id_i.x < src_id_max.x)) begin
+            route_expected_input[East] = 1'b1;
+          end
+          if((xy_id_i.x <= dst_id.x) && (xy_id_i.x > src_id_min.x)) begin
+            route_expected_input[West] = 1'b1;
+          end
+        end
+
+        // If we have multiple sources in the same column we first have to collect them in y direction
+        // therefor expecting inputs from either the north or south direction.
+        // For all members of a column involved in the reduction the flag x_matched_expected_input is set!
+        // We expect a packet from the north if the current y id is higher/equal as the destination but still
+        // inside the expected maximum range of the source reduction. Same for the South!
+        if(x_matched_expected_input) begin
+          if((xy_id_i.y >= dst_id.y) && (xy_id_i.y < src_id_max.y)) begin
+            route_expected_input[North] = 1'b1;
+          end
+          if((xy_id_i.y <= dst_id.y) && (xy_id_i.y > src_id_min.y)) begin
+            route_expected_input[South] = 1'b1;
+          end
         end
       end
     end
@@ -203,6 +273,8 @@ module floo_route_xymask import floo_pkg::*; #(
 
   // We only support five input/output routes
   `ASSERT_INIT(NoMultiCastSupport, NumRoutes == 5)
+  `ASSERT_INIT(CollectRouteAlg, RouteAlgo == XYRouting ||
+                                RouteAlgo == YXRouting)
 
   // TODO(colluca): fix code and uncomment
   // always_comb begin

--- a/hw/floo_router.sv
+++ b/hw/floo_router.sv
@@ -205,7 +205,8 @@ module floo_router
           .NumRoutes    (NumInput),
           .flit_t       (flit_t),
           .id_t         (id_t),
-          .FwdMode      (0)
+          .FwdMode      (0),
+          .RouteAlgo    (RouteAlgo)
         ) i_gen_route_xymask (
           .channel_i    (in_routed_data[in][v]),
           .xy_id_i      (xy_id_i),
@@ -347,7 +348,9 @@ module floo_router
         // we tie the handshake & data signals to 0, to optimize them away during synthesis
         if((NoLoopback && (in == out)) ||
            ((RouteAlgo == XYRouting) && XYRouteOpt &&
-            (in == South || in == North) && (out == East || out == West)))
+            (in == South || in == North) && (out == East || out == West)) ||
+           ((RouteAlgo == YXRouting) && XYRouteOpt &&
+            (in == East || in == West)  && (out == North || out == South)))
         begin : gen_no_conn
           assign masked_ready_transposed[in][v][out] = '0;
           assign masked_valid[out][v][in]     = '0;
@@ -423,6 +426,7 @@ module floo_router
         .NumRoutes            ( LocalNumInputs            ),
         .NumParallelRedRoutes ( NumParallelRedRoutes      ),
         .CollectOpCfg         ( CollectiveCfg             ),
+        .RouteAlgo            ( RouteAlgo                  ),
         .flit_t               ( flit_t                    ),
         .hdr_t                ( hdr_t                     ),
         .id_t                 ( id_t                      ),
@@ -518,6 +522,17 @@ module floo_router
     end
   end
 
+  // If YXRouting optimization is enabled, assert that not X->Y routing occurs
+  if ((RouteAlgo == YXRouting) && XYRouteOpt) begin : gen_yx_opt_assert
+    for (genvar v = 0; v < NumVirtChannels; v++) begin : gen_virt
+      `ASSERT(YXDirectionNotAllowed,
+          !(in_valid[East][v] && route_mask[East][v][North]) &&
+          !(in_valid[East][v] && route_mask[East][v][South]) &&
+          !(in_valid[West][v] && route_mask[West][v][North]) &&
+          !(in_valid[West][v] && route_mask[West][v][South]))
+    end
+  end
+
   // If `NoLoopback` is enabled, assert that no loopback occurs
   if (NoLoopback) begin: gen_no_loopback_assert
     for (genvar in = 0; in < NumInput; in++) begin : gen_input
@@ -537,7 +552,7 @@ module floo_router
   end
 
   // Multicast is currently only supported for `XYRouting`
-  `ASSERT_INIT(NoMultiCastSupport, !(EnMultiCast && RouteAlgo != XYRouting))
+  `ASSERT_INIT(NoMultiCastSupport, !(EnMultiCast && (RouteAlgo != XYRouting && RouteAlgo != YXRouting)))
   // We only support symmetrical configuration for the FP reduction
   `ASSERT_INIT(NoSymConfig, !(EnSequentialReduction && (NumInput != NumOutput)))
   // We can not support collective without loopback active

--- a/hw/floo_router.sv
+++ b/hw/floo_router.sv
@@ -552,7 +552,8 @@ module floo_router
   end
 
   // Multicast is currently only supported for `XYRouting`
-  `ASSERT_INIT(NoMultiCastSupport, !(EnMultiCast && (RouteAlgo != XYRouting && RouteAlgo != YXRouting)))
+  `ASSERT_INIT(NoMultiCastSupport, !(EnMultiCast &&
+              (RouteAlgo != XYRouting && RouteAlgo != YXRouting)))
   // We only support symmetrical configuration for the FP reduction
   `ASSERT_INIT(NoSymConfig, !(EnSequentialReduction && (NumInput != NumOutput)))
   // We can not support collective without loopback active


### PR DESCRIPTION
# YX Routing Algorithm 
Add YX routing algorithm support to FlooNoC. YX routing resolves the Y dimension first, then X—the inverse of XY routing. Both algorithms now support unicast, multicast, and reduction operations.

- **RTL**
  - `hw/floo_pkg.sv`: Added `YXRouting` to enum
  - `hw/floo_route_select.sv`: Unified XY/YX routing with separate unicast blocks; shared multicast instantiation
  - `hw/floo_route_xymask.sv`: Added `RouteAlgo` parameter; swapped dimension order for YX in masks

- **Floogen**:
  - `floogen/model/network.py`: Extended routing algorithm matching to accept YX; removed XY-only restriction for collective operations
  
 - **CI**:
   - `.gitlab-ci.yml`: Added `yx` to `compile-meshes` and `run-traffic` matrix
   - Added `floogen/examples/axi_mesh_yx.yml` and `nw_mesh_yx.yml` configs  