### PR TITLE
chore: python deps clean up

### DIFF
--- a/docs/floogen/cli.md
+++ b/docs/floogen/cli.md
@@ -62,6 +62,30 @@ floogen top -c <config_file> -o <output_dir>
 
 Generates a graphical representation of the network topology. This is critical for verifying that your complex graph connections match your mental model.
 
+!!! note "Requires the optional `viz` extra"
+
+    This command depends on `matplotlib`, which is **not** installed by default. The
+    `visualize` command is only available once the optional `viz` extra is installed.
+    Without it, `visualize` is hidden from the CLI and will not appear in `floogen --help`.
+
+    === "uv"
+
+        **As a global tool:**
+        ```bash
+        uv tool install 'floogen[viz]'
+        ```
+
+        **Inside the repository** (one-off, for the `visualize` command):
+        ```bash
+        uv run --extra viz floogen visualize -c <config_file>
+        ```
+
+    === "pip"
+
+        ```bash
+        pip install 'floogen[viz]'
+        ```
+
 **Usage:**
 
 ```bash

--- a/floogen/cli.py
+++ b/floogen/cli.py
@@ -9,6 +9,7 @@ import argparse
 from pathlib import Path
 from importlib.resources import files
 from importlib.metadata import version
+from importlib.util import find_spec
 
 from mako.template import Template
 
@@ -162,13 +163,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Path to external template to render. Multiple templates can be specified.",
     )
 
-    # floogen visualize
-    subparsers.add_parser(
-        "visualize",
-        parents=[common],
-        add_help=True,
-        help="Visualize the network graph.",
-    )
+    # floogen visualize (only available if the optional 'viz' extra is installed)
+    if find_spec("matplotlib") is not None:
+        subparsers.add_parser(
+            "visualize",
+            parents=[common],
+            add_help=True,
+            help="Visualize the network graph.",
+        )
 
     # floogen query <key>
     p_query = subparsers.add_parser(

--- a/floogen/config_parser.py
+++ b/floogen/config_parser.py
@@ -5,9 +5,10 @@
 #
 # Author: Tim Fischer <fischeti@iis.ee.ethz.ch>
 
+from collections.abc import Mapping
 from pathlib import Path
 import logging
-from typing import List, Union, Tuple, Mapping, TypeVar
+from typing import TypeVar
 
 from pydantic import ValidationError, BaseModel
 
@@ -15,44 +16,31 @@ from ruamel.yaml.comments import CommentedMap
 from ruamel.yaml import YAMLError
 import ruamel.yaml
 
-import click
+logger = logging.getLogger(__name__)
 
-logger = logging.getLogger("padrick.ConfigParser")
-
-
-def get_error_context(config_file: Path, line, column, context_before=4, context_after=4):
-    """Retrieves the context surrounding an error in a configuration file."""
-    lines_to_return = []
-    with config_file.open() as file:
-        for line_idx, line in enumerate(file.readlines()):
-            if line_idx + 1 == line:
-                lines_to_return.append(line)
-                lines_to_return.append(click.style(column * " " + "^\n", blink=True, fg="yellow"))
-            elif line_idx + 1 >= line - context_before and line_idx + 1 <= line + context_after:
-                lines_to_return.append(line)
-    return "".join(lines_to_return)
+# ANSI escapes to highlight the error column with a yellow caret.
+_YELLOW = "\033[33m"
+_RESET = "\033[0m"
 
 
-def get_human_readable_error_path(config_data: dict, error_location: List[Union[str, int]]):
-    """Transforms a list of path segments into a human readable string."""
-    transformed_path_segments = []
-    node = config_data
-    for path_segment in error_location:
-        try:
-            node = node[path_segment]
-        except KeyError:
-            transformed_path_segments.append(path_segment)
-            break
-        if isinstance(path_segment, int):
-            transformed_path_segments.append(node.get("name", path_segment))
-        else:
-            transformed_path_segments.append(path_segment)
-    return "->".join(transformed_path_segments)
+def get_error_context(
+    config_file: Path, line: int, column: int, context_before: int = 4, context_after: int = 4
+) -> str:
+    """Return the lines surrounding `line`, with a caret marking `column`."""
+    lines = config_file.read_text().splitlines()
+    start = max(line - context_before, 1)
+    end = min(line + context_after, len(lines))
+    context = []
+    for lineno in range(start, end + 1):
+        context.append(lines[lineno - 1])
+        if lineno == line:
+            context.append(f"{_YELLOW}{column * ' '}^{_RESET}")
+    return "\n".join(context)
 
 
 def get_file_location(
-    config_data: CommentedMap, error_location: List[Union[str, int]]
-) -> Tuple[Tuple[int, int], Mapping]:
+    config_data: CommentedMap, error_location: tuple[str | int, ...]
+) -> tuple[tuple[int, int], Mapping]:
     """Retrieves the location of an error in a configuration file."""
     node = config_data
     location = (node.lc.line + 1, node.lc.col)
@@ -71,46 +59,33 @@ def get_file_location(
 T = TypeVar("T", bound=BaseModel)
 
 
-def parse_config(cls: T, config_file: Path) -> Union[T, None]:
+def parse_config(cls: type[T], config_file: Path) -> T | None:
     """Parses a configuration file and returns a validated model."""
     with config_file.open() as file:
         try:
-            yaml = ruamel.yaml.YAML(typ="rt")
-            # enable support for !include directives (see pyyaml-include package)
-            # if not include_base_dir:
-            #     include_base_dir = config_file.parent
-            # if not ignore_includes:
-            #     include_constructor = YamlIncludeConstructor(base_dir=str(include_base_dir))
-            # else:
-            #     include_constructor = IgnoreIncludeConstructor
-            # yaml.register_class(include_constructor)
-            config_data = yaml.load(file)
-            # config_data = ruamel.yaml.load(file, Loader=ruamel.yaml.RoundTripLoader)
+            config_data = ruamel.yaml.YAML(typ="rt").load(file)
         except YAMLError as e:
             logger.error("Error while parsing config_file:\n %s", e)
             return None
-        try:
-            model = cls.model_validate(config_data)
-            return model
-        except ValidationError as e:
-            logger.error(
-                "Encountered %s validation errors while parsing the configuration file:",
-                len(e.errors()),
-            )
-            for error in e.errors():
-                if error["type"] == "extra":
-                    error[
-                        "msg"
-                    ] = f'Unknown field {error["loc"][-1]}. \
-                        Did you mispell the field name?'
-                if error["type"] == "missing":
-                    error["msg"] = f'Missing field \'{error["loc"][-1]}\''
-                else:
-                    error["msg"] = f'{error["msg"]} (field \'{error["loc"][-1]}\')'
-                # error_path = get_human_readable_error_path(config_data, error["loc"])
-                (line, column), _ = get_file_location(config_data, error["loc"])
-                error_context = get_error_context(config_file, line, column, context_after=10)
-                logger.error("Line %s, Column %s:", line, column)
-                logger.error("...\n%s\n...", error_context)
-                logger.error("Error: %s", error["msg"])
-            return None
+
+    try:
+        return cls.model_validate(config_data)
+    except ValidationError as e:
+        logger.error(
+            "Encountered %s validation errors while parsing the configuration file:",
+            len(e.errors()),
+        )
+        for error in e.errors():
+            field = error["loc"][-1]
+            if error["type"] == "extra_forbidden":
+                error["msg"] = f"Unknown field '{field}'. Did you misspell the field name?"
+            elif error["type"] == "missing":
+                error["msg"] = f"Missing field '{field}'"
+            else:
+                error["msg"] = f"{error['msg']} (field '{field}')"
+            (line, column), _ = get_file_location(config_data, error["loc"])
+            error_context = get_error_context(config_file, line, column, context_after=10)
+            logger.error("Line %s, Column %s:", line, column)
+            logger.error("...\n%s\n...", error_context)
+            logger.error("Error: %s", error["msg"])
+        return None

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -10,7 +10,6 @@ from typing import Optional, List
 from enum import Enum
 
 import networkx as nx
-import matplotlib.pyplot as plt
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 from floogen.model.routing import Routing, RouteAlgo, RouteMapRule, RouteRule, RouteMap, RouteTable, RouteMapRuleCollective, WideRwDecouple
@@ -849,6 +848,11 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
 
     def visualize(self, savefig=True, filename: pathlib.Path = "network.png"):
         """Visualize the network graph."""
+        # Imported lazily so the optional 'viz' extra (matplotlib) is only
+        # required when this feature is actually used. The CLI hides the
+        # `visualize` command when matplotlib is unavailable.
+        import matplotlib.pyplot as plt  # pylint: disable=import-outside-toplevel
+
         ni_nodes = self.graph.get_ni_nodes(with_obj=False, with_name=True)
         router_nodes = self.graph.get_rt_nodes(with_obj=False, with_name=True)
         filtered_graph = self.graph.subgraph(ni_nodes + router_nodes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
   "networkx",
   "mako",
   "ruamel.yaml",
-  "click>=8.3.1",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,13 @@ keywords = ["noc", "network-on-chip", "generator", "systemverilog", "eda", "pulp
 dependencies = [
   "pydantic",
   "networkx",
-  "matplotlib",
   "mako",
   "ruamel.yaml",
   "click>=8.3.1",
 ]
+
+[project.optional-dependencies]
+viz = ["matplotlib"]
 
 [project.urls]
 Homepage = "https://github.com/pulp-platform/FlooNoC"
@@ -45,7 +47,6 @@ dev = [
     "mkdocstrings-python>=2.0.1",
     "zensical",
 ]
-viz = ["pygame"]
 
 [build-system]
 requires = ["uv_build>=0.9.2,<0.10.0"]

--- a/uv.lock
+++ b/uv.lock
@@ -226,7 +226,6 @@ name = "floogen"
 version = "0.8.3"
 source = { editable = "." }
 dependencies = [
-    { name = "click" },
     { name = "mako" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -249,7 +248,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click", specifier = ">=8.3.1" },
     { name = "mako" },
     { name = "matplotlib", marker = "extra == 'viz'" },
     { name = "networkx" },

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -114,7 +114,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -214,7 +214,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -228,11 +228,15 @@ source = { editable = "." }
 dependencies = [
     { name = "click" },
     { name = "mako" },
-    { name = "matplotlib" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pydantic" },
     { name = "ruamel-yaml" },
+]
+
+[package.optional-dependencies]
+viz = [
+    { name = "matplotlib" },
 ]
 
 [package.dev-dependencies]
@@ -242,19 +246,17 @@ dev = [
     { name = "ruff" },
     { name = "zensical" },
 ]
-viz = [
-    { name = "pygame" },
-]
 
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "mako" },
-    { name = "matplotlib" },
+    { name = "matplotlib", marker = "extra == 'viz'" },
     { name = "networkx" },
     { name = "pydantic" },
     { name = "ruamel-yaml" },
 ]
+provides-extras = ["viz"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -263,7 +265,6 @@ dev = [
     { name = "ruff" },
     { name = "zensical" },
 ]
-viz = [{ name = "pygame" }]
 
 [[package]]
 name = "fonttools"
@@ -1180,42 +1181,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
     { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
     { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
-]
-
-[[package]]
-name = "pygame"
-version = "2.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/49/cc/08bba60f00541f62aaa252ce0cfbd60aebd04616c0b9574f755b583e45ae/pygame-2.6.1.tar.gz", hash = "sha256:56fb02ead529cee00d415c3e007f75e0780c655909aaa8e8bf616ee09c9feb1f", size = 14808125, upload-time = "2024-09-29T13:41:34.698Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/0b/334c7c50a2979e15f2a027a41d1ca78ee730d5b1c7f7f4b26d7cb899839d/pygame-2.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9beeb647e555afb5657111fa83acb74b99ad88761108eaea66472e8b8547b55b", size = 13109297, upload-time = "2024-09-29T14:25:34.709Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/48/f8b1069788d1bd42e63a960d74d3355242480b750173a42b2749687578ca/pygame-2.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:10e3d2a55f001f6c0a6eb44aa79ea7607091c9352b946692acedb2ac1482f1c9", size = 12375837, upload-time = "2024-09-29T14:25:50.538Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/33/a1310386b8913ce1bdb90c33fa536970e299ad57eb35785f1d71ea1e2ad3/pygame-2.6.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:816e85000c5d8b02a42b9834f761a5925ef3377d2924e3a7c4c143d2990ce5b8", size = 13607860, upload-time = "2024-09-29T11:10:44.173Z" },
-    { url = "https://files.pythonhosted.org/packages/88/0f/4e37b115056e43714e7550054dd3cd7f4d552da54d7fc58a2fb1407acda5/pygame-2.6.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a78fd030d98faab4a8e27878536fdff7518d3e062a72761c552f624ebba5a5f", size = 14304696, upload-time = "2024-09-29T11:39:46.724Z" },
-    { url = "https://files.pythonhosted.org/packages/11/b3/de6ed93ae483cf3bac8f950a955e83f7ffe59651fd804d100fff65d66d6c/pygame-2.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:da3ad64d685f84a34ebe5daacb39fff14f1251acb34c098d760d63fee768f50c", size = 13977684, upload-time = "2024-09-29T11:39:49.921Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/05/d86440aa879708c41844bafc6b3eb42c6d8cf54082482499b53139133e2a/pygame-2.6.1-cp310-cp310-win32.whl", hash = "sha256:9dd5c054d4bd875a8caf978b82672f02bec332f52a833a76899220c460bb4b58", size = 10251775, upload-time = "2024-09-29T11:40:34.952Z" },
-    { url = "https://files.pythonhosted.org/packages/38/88/8de61324775cf2c844a51d8db14a8a6d2a9092312f27678f6eaa3a460376/pygame-2.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:00827aba089355925902d533f9c41e79a799641f03746c50a374dc5c3362e43d", size = 10618801, upload-time = "2024-09-29T12:13:25.284Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/ca/8f367cb9fe734c4f6f6400e045593beea2635cd736158f9fabf58ee14e3c/pygame-2.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:20349195326a5e82a16e351ed93465a7845a7e2a9af55b7bc1b2110ea3e344e1", size = 13113753, upload-time = "2024-09-29T14:26:13.751Z" },
-    { url = "https://files.pythonhosted.org/packages/83/47/6edf2f890139616b3219be9cfcc8f0cb8f42eb15efd59597927e390538cb/pygame-2.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f3935459109da4bb0b3901da9904f0a3e52028a3332a355d298b1673a334cf21", size = 12378146, upload-time = "2024-09-29T14:26:22.456Z" },
-    { url = "https://files.pythonhosted.org/packages/00/9e/0d8aa8cf93db2d2ee38ebaf1c7b61d0df36ded27eb726221719c150c673d/pygame-2.6.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c31dbdb5d0217f32764797d21c2752e258e5fb7e895326538d82b5f75a0cd856", size = 13611760, upload-time = "2024-09-29T11:10:47.317Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/9e/d06adaa5cc65876bcd7a24f59f67e07f7e4194e6298130024ed3fb22c456/pygame-2.6.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:173badf82fa198e6888017bea40f511cb28e69ecdd5a72b214e81e4dcd66c3b1", size = 14298054, upload-time = "2024-09-29T11:39:53.891Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/a1/9ae2852ebd3a7cc7d9ae7ff7919ab983e4a5c1b7a14e840732f23b2b48f6/pygame-2.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce8cc108b92de9b149b344ad2e25eedbe773af0dc41dfb24d1f07f679b558c60", size = 13977107, upload-time = "2024-09-29T11:39:56.831Z" },
-    { url = "https://files.pythonhosted.org/packages/31/df/6788fd2e9a864d0496a77670e44a7c012184b7a5382866ab0e60c55c0f28/pygame-2.6.1-cp311-cp311-win32.whl", hash = "sha256:811e7b925146d8149d79193652cbb83e0eca0aae66476b1cb310f0f4226b8b5c", size = 10250863, upload-time = "2024-09-29T11:44:48.199Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/55/ca3eb851aeef4f6f2e98a360c201f0d00bd1ba2eb98e2c7850d80aabc526/pygame-2.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:91476902426facd4bb0dad4dc3b2573bc82c95c71b135e0daaea072ed528d299", size = 10622016, upload-time = "2024-09-29T12:17:01.545Z" },
-    { url = "https://files.pythonhosted.org/packages/92/16/2c602c332f45ff9526d61f6bd764db5096ff9035433e2172e2d2cadae8db/pygame-2.6.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:4ee7f2771f588c966fa2fa8b829be26698c9b4836f82ede5e4edc1a68594942e", size = 13118279, upload-time = "2024-09-29T14:26:30.427Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/53/77ccbc384b251c6e34bfd2e734c638233922449a7844e3c7a11ef91cee39/pygame-2.6.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c8040ea2ab18c6b255af706ec01355c8a6b08dc48d77fd4ee783f8fc46a843bf", size = 12384524, upload-time = "2024-09-29T14:26:49.996Z" },
-    { url = "https://files.pythonhosted.org/packages/06/be/3ed337583f010696c3b3435e89a74fb29d0c74d0931e8f33c0a4246307a9/pygame-2.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47a6938de93fa610accd4969e638c2aebcb29b2fca518a84c3a39d91ab47116", size = 13587123, upload-time = "2024-09-29T11:10:50.072Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/ca/b015586a450db59313535662991b34d24c1f0c0dc149cc5f496573900f4e/pygame-2.6.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:33006f784e1c7d7e466fcb61d5489da59cc5f7eb098712f792a225df1d4e229d", size = 14275532, upload-time = "2024-09-29T11:39:59.356Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/f2/d31e6ad42d657af07be2ffd779190353f759a07b51232b9e1d724f2cda46/pygame-2.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1206125f14cae22c44565c9d333607f1d9f59487b1f1432945dfc809aeaa3e88", size = 13952653, upload-time = "2024-09-29T11:40:01.781Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/42/8ea2a6979e6fa971702fece1747e862e2256d4a8558fe0da6364dd946c53/pygame-2.6.1-cp312-cp312-win32.whl", hash = "sha256:84fc4054e25262140d09d39e094f6880d730199710829902f0d8ceae0213379e", size = 10252421, upload-time = "2024-09-29T11:14:26.877Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/90/7d766d54bb95939725e9a9361f9c06b0cfbe3fe100aa35400f0a461a278a/pygame-2.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:3a9e7396be0d9633831c3f8d5d82dd63ba373ad65599628294b7a4f8a5a01a65", size = 10624591, upload-time = "2024-09-29T11:52:54.489Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/91/718acf3e2a9d08a6ddcc96bd02a6f63c99ee7ba14afeaff2a51c987df0b9/pygame-2.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ae6039f3a55d800db80e8010f387557b528d34d534435e0871326804df2a62f2", size = 13090765, upload-time = "2024-09-29T14:27:02.377Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/c6/9cb315de851a7682d9c7568a41ea042ee98d668cb8deadc1dafcab6116f0/pygame-2.6.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2a3a1288e2e9b1e5834e425bedd5ba01a3cd4902b5c2bff8ed4a740ccfe98171", size = 12381704, upload-time = "2024-09-29T14:27:10.228Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/8f/617a1196e31ae3b46be6949fbaa95b8c93ce15e0544266198c2266cc1b4d/pygame-2.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:27eb17e3dc9640e4b4683074f1890e2e879827447770470c2aba9f125f74510b", size = 13581091, upload-time = "2024-09-29T11:30:27.653Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/87/2851a564e40a2dad353f1c6e143465d445dab18a95281f9ea458b94f3608/pygame-2.6.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c1623180e70a03c4a734deb9bac50fc9c82942ae84a3a220779062128e75f3b", size = 14273844, upload-time = "2024-09-29T11:40:04.138Z" },
-    { url = "https://files.pythonhosted.org/packages/85/b5/aa23aa2e70bcba42c989c02e7228273c30f3b44b9b264abb93eaeff43ad7/pygame-2.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef07c0103d79492c21fced9ad68c11c32efa6801ca1920ebfd0f15fb46c78b1c", size = 13951197, upload-time = "2024-09-29T11:40:06.785Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/06/29e939b34d3f1354738c7d201c51c250ad7abefefaf6f8332d962ff67c4b/pygame-2.6.1-cp313-cp313-win32.whl", hash = "sha256:3acd8c009317190c2bfd81db681ecef47d5eb108c2151d09596d9c7ea9df5c0e", size = 10249309, upload-time = "2024-09-29T11:10:23.329Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/11/17f7f319ca91824b86557e9303e3b7a71991ef17fd45286bf47d7f0a38e6/pygame-2.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:813af4fba5d0b2cb8e58f5d95f7910295c34067dcc290d34f1be59c48bd1ea6a", size = 10620084, upload-time = "2024-09-29T11:48:51.587Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Moves `matplotlib` dependency to the `viz` extra, since it is rarely used and not super useful to get rid of some dependencies.

Refactors and fixes `config_parser`, which also got rid of the `click` dependency.