### PR TITLE
hw: use per-channel valid for dec_error assertion in id_translation

### DIFF
--- a/hw/floo_axi_chimney.sv
+++ b/hw/floo_axi_chimney.sv
@@ -481,7 +481,13 @@ module floo_axi_chimney
 
   for (genvar ch = 0; ch < NumAxiChannels; ch++) begin : gen_route
     localparam axi_ch_e Ch = axi_ch_e'(ch);
+
     if (Ch == AxiAw || Ch == AxiAr) begin : gen_req_route
+
+      logic axi_req_valid;
+      assign axi_req_valid = (Ch == AxiAw)? axi_aw_queue_valid_out :
+                              (Ch == AxiAr)? axi_ar_queue_valid_out : 1'b0;
+
       // Translate the address from AXI requests to a destination ID
       floo_id_translation #(
         .RouteCfg   (RouteCfg),
@@ -494,7 +500,7 @@ module floo_axi_chimney
       ) i_floo_id_translation (
         .clk_i,
         .rst_ni,
-        .valid_i       (axi_aw_queue_valid_out),
+        .valid_i       (axi_req_valid),
         .addr_i        (axi_req_addr[ch]),
         .id_o          (id_out[ch]),
         .mask_addr_x_o (x_mask_sel[ch]),

--- a/hw/floo_nw_chimney.sv
+++ b/hw/floo_nw_chimney.sv
@@ -977,6 +977,12 @@ module floo_nw_chimney
     if (Ch == NarrowAw || Ch == NarrowAr ||
         Ch == WideAw || Ch == WideAr) begin : gen_req_route
 
+      logic axi_req_valid;
+      assign axi_req_valid = (Ch == NarrowAw)? axi_narrow_aw_queue_valid_out :
+                             (Ch == NarrowAr)? axi_narrow_ar_queue_valid_out :
+                             (Ch == WideAw)?   axi_wide_aw_queue_valid_out :
+                             (Ch == WideAr)?   axi_wide_ar_queue_valid_out : 1'b0;
+
       // Translate the address from AXI requests to a destination ID
       floo_id_translation #(
         .RouteCfg   (RouteCfg),
@@ -989,7 +995,7 @@ module floo_nw_chimney
       ) i_floo_id_translation (
         .clk_i,
         .rst_ni,
-        .valid_i       (axi_narrow_aw_queue_valid_out),
+        .valid_i       (axi_req_valid),
         .addr_i        (axi_req_addr[ch]),
         .id_o          (id_out[ch]),
         .mask_addr_x_o (x_mask_sel[ch]),


### PR DESCRIPTION
The shared `valid_i` gating is latent rather than harmless: all four request-channel `floo_id_translation` instances gate their `DecodeError` assertion with the _NarrowAw_ valid. This goes unnoticed as long as the chimney's AXI slave port is driven by a regular AXI manager, whose idle Ax payloads hold either the reset value or the last issued (i.e. decodable) address. 

The assertion misfires once a chimney's input is driven back-to-back by another chimney's master port (e.g. a chip-to-chip loopback): the idle AR payload is then the union-reinterpretation of whatever flit was last unpacked (`floo_req_in.narrow_ar.payload`), typically far outside the SAM, so dec_error is high while the (wrongly shared) NarrowAw valid is asserted.