### PR TITLE
floogen: Add possibility of generating multiple RDL address maps.

### DIFF
--- a/docs/floogen/cli.md
+++ b/docs/floogen/cli.md
@@ -107,6 +107,12 @@ Generates the **SystemRDL** description for the endpoint address regions. This i
 floogen rdl -c <config_file> -o <output_dir>
 ```
 
+By default, this produces a single `<name>_addrmap.rdl` file containing all endpoints.
+If any endpoint declares [`rdl_addrmap_grp`](endpoints.md#systemrdl-addrmap-groups), one
+`<name>_addrmap_<group>.rdl` file is generated per distinct group instead, each
+containing only the endpoints tagged with that group (endpoints without
+`rdl_addrmap_grp` are included in every group).
+
 -----
 
 ### `query`

--- a/docs/floogen/endpoints.md
+++ b/docs/floogen/endpoints.md
@@ -113,6 +113,37 @@ endpoints:
       - "axi_out"
 ```
 
+### SystemRDL Generation
+
+The [`rdl` CLI command](cli.md#rdl) generates a SystemRDL description of the network's
+address map, with one addrmap entry per subordinate address range. By default, an
+address range without further annotation is either skipped or rendered as an anonymous
+`external mem` block (if `--as-mem` is passed on the command line). Two `addr_range`
+fields give finer control over how each range is rendered:
+
+- `rdl_name`: instantiates an externally-defined SystemRDL component (e.g. a register
+  file described in its own `.rdl` file) at this address range. FlooGen emits an
+  `` `include `` for it in the generated file.
+- `rdl_as_mem`: renders this specific range as an anonymous `external mem` block,
+  overriding the global `--as-mem` flag for this range only (`true` forces it on,
+  `false` forces it off, regardless of the CLI flag).
+
+`rdl_name` and `rdl_as_mem` are mutually exclusive on the same address range.
+
+```yaml
+endpoints:
+  - name: "cluster"
+    addr_range:
+      - base: 0x1000_0000
+        size: 0x0004_0000
+        rdl_name: "cluster_regs" # instantiate an externally-defined `cluster_regs.rdl`
+      - base: 0x1000_4000
+        size: 0x0000_1000
+        rdl_as_mem: true # always render as `external mem`, regardless of --as-mem
+    sbr_port_protocol:
+      - "axi_out"
+```
+
 ### SystemRDL Addrmap Groups
 
 Each address range can be tagged with one or more `rdl_addrmap_grp` values to control

--- a/docs/floogen/endpoints.md
+++ b/docs/floogen/endpoints.md
@@ -112,3 +112,37 @@ endpoints:
     sbr_port_protocol:
       - "axi_out"
 ```
+
+### SystemRDL Addrmap Groups
+
+Each address range can be tagged with one or more `rdl_addrmap_grp` values to control
+which generated SystemRDL addrmap(s) it appears in (see the [`rdl` CLI
+command](cli.md#rdl)). This is a per-`addr_range` field, not a per-endpoint one, since
+different address ranges of the *same* endpoint (e.g. its main registers vs. a
+debug-only region) may need to be reachable from different views. A single group can
+be given as a plain string, or multiple groups as a list. Address ranges without
+`rdl_addrmap_grp` are considered common and are included in every group's file.
+
+```yaml
+endpoints:
+  - name: "cluster"
+    addr_range:
+      - base: 0x1000_0000
+        size: 0x0004_0000
+        rdl_name: "cluster_regs"
+        rdl_addrmap_grp: ["32b", "64b"] # visible in both the 32b and 64b addrmaps
+      - base: 0x1000_4000
+        size: 0x0000_1000
+        rdl_name: "cluster_debug_regs"
+        rdl_addrmap_grp: "64b" # only visible in the 64b addrmap
+    sbr_port_protocol:
+      - "axi_out"
+  - name: "hbm"
+    addr_range:
+      base: 0x8000_0000
+      size: 0x1000_0000
+      rdl_name: "hbm_regs"
+      rdl_addrmap_grp: "64b" # only visible in the 64b addrmap
+    sbr_port_protocol:
+      - "axi_out"
+```

--- a/floogen/cli.py
+++ b/floogen/cli.py
@@ -252,7 +252,7 @@ def main():
             for group in groups:
                 suffix = f"_{group}" if group else ""
                 context["sam"] = network.routing.sam.filter_by_group(group) if group else network.routing.sam
-                context["addrmap_name"] = f"{network.name}_addrmap{suffix}"
+                context["suffix"] = suffix
                 render_template(context,
                     tpl=tpl_dir / "floo_addrmap.rdl.mako",
                     file_name=f"{network.name}_addrmap{suffix}.rdl",

--- a/floogen/cli.py
+++ b/floogen/cli.py
@@ -219,8 +219,6 @@ def main():
             context["name"] = args.name or network.name
             pkg_file_name = f"floo_{args.name or network.name}_noc_pkg.sv"
             top_file_name = f"floo_{args.name or network.name}_noc.sv"
-        case "rdl":
-            rdl_file_name = f"{network.name}_addrmap.rdl"
 
 
     match args.command:
@@ -250,11 +248,16 @@ def main():
         case "rdl":
             context["rdl_as_mem"] = args.as_mem
             context["rdl_memwidth"] = args.memwidth
-            render_template(context,
-                tpl=tpl_dir / "floo_addrmap.rdl.mako",
-                file_name=rdl_file_name,
-                **render_kwargs,
-            )
+            groups = network.routing.sam.distinct_groups() or [None]
+            for group in groups:
+                suffix = f"_{group}" if group else ""
+                context["sam"] = network.routing.sam.filter_by_group(group) if group else network.routing.sam
+                context["addrmap_name"] = f"{network.name}_addrmap{suffix}"
+                render_template(context,
+                    tpl=tpl_dir / "floo_addrmap.rdl.mako",
+                    file_name=f"{network.name}_addrmap{suffix}.rdl",
+                    **render_kwargs,
+                )
         case "template":
             for tpl in args.template:
                 render_template(context,

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -389,9 +389,19 @@ class AddrRange(BaseModel):
     rdl_as_mem: Optional[bool] = None
     en_collective: bool = False
     desc: Optional[str] = None
+    rdl_addrmap_grp: Optional[List[str]] = None
+    """One or more SystemRDL addrmap group tags this address range belongs to."""
 
     def __str__(self):
         return f"[{self.start:X}:{self.end:X}]"
+
+    @field_validator("rdl_addrmap_grp", mode="before")
+    @classmethod
+    def rdl_addrmap_grp_to_list(cls, v):
+        """Convert a single group name to a list."""
+        if isinstance(v, str):
+            return [v]
+        return v
 
     @model_validator(mode="before")
     def validate_input(self):
@@ -788,6 +798,20 @@ class RouteMap(BaseModel):
         for rule in rdl_names:
             string += f"`include \"{rule}.rdl\"\n"
         return string
+
+    def distinct_groups(self) -> List[str]:
+        """Return the sorted list of distinct RDL addrmap groups used by any rule."""
+        groups = set()
+        for rule in self.rules:
+            if rule.addr_range.rdl_addrmap_grp:
+                groups.update(rule.addr_range.rdl_addrmap_grp)
+        return sorted(groups)
+
+    def filter_by_group(self, group: str) -> "RouteMap":
+        """Return a new RouteMap with only rules in `group` (untagged rules included)."""
+        rules = [r for r in self.rules
+                 if not r.addr_range.rdl_addrmap_grp or group in r.addr_range.rdl_addrmap_grp]
+        return RouteMap(name=self.name, rules=rules)
 
     def pprint(self):
         """Pretty print the routing table."""

--- a/floogen/templates/floo_addrmap.rdl.mako
+++ b/floogen/templates/floo_addrmap.rdl.mako
@@ -12,7 +12,7 @@
 
 ${sam.render_rdl_inc()}
 
-addrmap ${addrmap_name} {
+addrmap ${noc.name}_addrmap${suffix} {
 
 ${sam.render_rdl(rdl_as_mem, rdl_memwidth)}
 

--- a/floogen/templates/floo_addrmap.rdl.mako
+++ b/floogen/templates/floo_addrmap.rdl.mako
@@ -10,10 +10,10 @@
 
 // AUTOMATICALLY GENERATED! DO NOT EDIT!
 
-${noc.routing.sam.render_rdl_inc()}
+${sam.render_rdl_inc()}
 
-addrmap ${noc.name}_addrmap {
+addrmap ${addrmap_name} {
 
-${noc.routing.sam.render_rdl(rdl_as_mem, rdl_memwidth)}
+${sam.render_rdl(rdl_as_mem, rdl_memwidth)}
 
 };

--- a/floogen/tests/address_test.py
+++ b/floogen/tests/address_test.py
@@ -154,3 +154,69 @@ def test_trim():
         RouteMapRule(addr_range=AddrRange(start=31, end=40), dest=SimpleId(id=2)),
     ]
     assert routing_table.rules == expected_rules
+
+
+def test_rdl_addrmap_grp_addr_range_scalar_and_list():
+    """Test that a scalar or list rdl_addrmap_grp both normalize to a List[str]."""
+    ar_scalar = AddrRange(start=0, end=0x1000, rdl_addrmap_grp="32b")
+    ar_list = AddrRange(start=0, end=0x1000, rdl_addrmap_grp=["32b", "64b"])
+    assert ar_scalar.rdl_addrmap_grp == ["32b"]
+    assert ar_list.rdl_addrmap_grp == ["32b", "64b"]
+
+
+def test_route_map_distinct_groups():
+    """Test that distinct_groups() collects the sorted set of groups across all rules."""
+    rule1 = RouteMapRule(addr_range=AddrRange(start=0, end=10, rdl_addrmap_grp=["32b", "64b"]),
+                          dest=SimpleId(id=1))
+    rule2 = RouteMapRule(addr_range=AddrRange(start=10, end=20, rdl_addrmap_grp=["32b"]),
+                          dest=SimpleId(id=2))
+    rule3 = RouteMapRule(addr_range=AddrRange(start=20, end=30), dest=SimpleId(id=3))
+    route_map = RouteMap(name="sam", rules=[rule1, rule2, rule3])
+    assert route_map.distinct_groups() == ["32b", "64b"]
+
+
+def test_route_map_filter_by_group():
+    """Test filtering a RouteMap by group, keeping untagged rules in every group."""
+    rule1 = RouteMapRule(addr_range=AddrRange(start=0, end=10, rdl_addrmap_grp=["32b", "64b"]),
+                          dest=SimpleId(id=1), desc="endpoint1")
+    rule2 = RouteMapRule(addr_range=AddrRange(start=10, end=20, rdl_addrmap_grp=["32b"]),
+                          dest=SimpleId(id=2), desc="endpoint2")
+    rule3 = RouteMapRule(addr_range=AddrRange(start=20, end=30, rdl_addrmap_grp=["64b"]),
+                          dest=SimpleId(id=3), desc="endpoint3")
+    route_map = RouteMap(name="sam", rules=[rule1, rule2, rule3])
+
+    grp_32b = route_map.filter_by_group("32b")
+    assert {r.desc for r in grp_32b.rules} == {"endpoint1", "endpoint2"}
+
+    grp_64b = route_map.filter_by_group("64b")
+    assert {r.desc for r in grp_64b.rules} == {"endpoint1", "endpoint3"}
+
+
+def test_route_map_filter_by_group_includes_untagged():
+    """Test that untagged rules are included in every group's filtered RouteMap."""
+    tagged = RouteMapRule(addr_range=AddrRange(start=0, end=10, rdl_addrmap_grp=["32b"]),
+                          dest=SimpleId(id=1), desc="tagged")
+    untagged = RouteMapRule(addr_range=AddrRange(start=10, end=20), dest=SimpleId(id=2),
+                             desc="untagged")
+    route_map = RouteMap(name="sam", rules=[tagged, untagged])
+
+    grp_32b = route_map.filter_by_group("32b")
+    assert {r.desc for r in grp_32b.rules} == {"tagged", "untagged"}
+
+    grp_64b = route_map.filter_by_group("64b")
+    assert {r.desc for r in grp_64b.rules} == {"untagged"}
+
+
+def test_rdl_addrmap_grp_differs_per_addr_range_of_same_endpoint():
+    """Test that two addr_ranges of the same endpoint can belong to different groups."""
+    narrow_range = RouteMapRule(addr_range=AddrRange(start=0, end=10, rdl_addrmap_grp="32b"),
+                                 dest=SimpleId(id=1), desc="ep_narrow")
+    wide_range = RouteMapRule(addr_range=AddrRange(start=10, end=20, rdl_addrmap_grp="64b"),
+                               dest=SimpleId(id=1), desc="ep_wide")
+    route_map = RouteMap(name="sam", rules=[narrow_range, wide_range])
+
+    grp_32b = route_map.filter_by_group("32b")
+    assert {r.desc for r in grp_32b.rules} == {"ep_narrow"}
+
+    grp_64b = route_map.filter_by_group("64b")
+    assert {r.desc for r in grp_64b.rules} == {"ep_wide"}


### PR DESCRIPTION
# Generation of Separate RDL Address Maps

This PR introduces the concept of **address map groups**.
In large systems, different endpoints may have different views of the system address space. For example, some managers, such as Snitch cores, may access a `32-bit` address space, while others, such as Cheshire, may use a `64-bit` address space.
Until now, *floogen* could generate only a single monolithic RDL file covering the entire address map.

With this PR, each RDL endpoint can be assigned to an address map group. FlooGen then generates a dedicated address map for each group, containing only the endpoints associated with that group.

## Summary:
- Floogen: 
  - Multiple RDL address group generation
  - RDL generation doc 