### PR TITLE
chore: use `ty` for python type checking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,7 @@ jobs:
   ty:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - uses: astral-sh/setup-uv@v8.3.2
       - run: uv run --extra viz ty check
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7.0.1
       - uses: astral-sh/setup-uv@v8.3.2
-      - run: uv run --extra viz ty check
+      - run: uv run --all-extras ty check
 
   #########
   # REUSE #

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -45,6 +45,16 @@ jobs:
       - uses: actions/checkout@v7.0.1
       - uses: astral-sh/ruff-action@v4.1.0
 
+  ######
+  # ty #
+  ######
+  ty:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: astral-sh/setup-uv@v8.3.2
+      - run: uv run --extra viz ty check
+
   #########
   # REUSE #
   #########

--- a/floogen/cli.py
+++ b/floogen/cli.py
@@ -8,7 +8,6 @@
 import argparse
 import sys
 from importlib.metadata import version
-from importlib.resources import files
 from importlib.util import find_spec
 from pathlib import Path
 from typing import TypedDict
@@ -21,7 +20,10 @@ from floogen.model.traffic import MESH_TRAFFIC_TYPES, gen_traffic_builtin, gen_t
 from floogen.query import handle_query
 from floogen.utils import verible_format
 
-tpl_dir = Path(str(files("floogen") / "templates"))
+# `render_template` needs a real filesystem path (it calls `.resolve()` and hands the
+# result to mako), so derive it from `__file__` rather than round-tripping a
+# `importlib.resources` traversable through `str()`.
+tpl_dir = Path(__file__).parent / "templates"
 
 
 class RenderKwargs(TypedDict, total=False):

--- a/floogen/cli.py
+++ b/floogen/cli.py
@@ -342,10 +342,13 @@ def main():
         case "rdl":
             context["rdl_as_mem"] = args.as_mem
             context["rdl_memwidth"] = args.memwidth
-            groups = network.routing.sam.distinct_groups() or [None]
+            sam = network.routing.sam
+            if sam is None:
+                raise ValueError("System address map has not been generated")
+            groups = sam.distinct_groups() or [None]
             for group in groups:
                 suffix = f"_{group}" if group else ""
-                context["sam"] = network.routing.sam.filter_by_group(group) if group else network.routing.sam
+                context["sam"] = sam.filter_by_group(group) if group else sam
                 context["suffix"] = suffix
                 render_template(context,
                     tpl=tpl_dir / "floo_addrmap.rdl.mako",

--- a/floogen/cli.py
+++ b/floogen/cli.py
@@ -10,6 +10,7 @@ from importlib.metadata import version
 from importlib.resources import files
 from importlib.util import find_spec
 from pathlib import Path
+from typing import TypedDict
 
 from mako.template import Template
 
@@ -19,7 +20,17 @@ from floogen.model.traffic import MESH_TRAFFIC_TYPES, gen_traffic_builtin, gen_t
 from floogen.query import handle_query
 from floogen.utils import verible_format
 
-tpl_dir = files("floogen") / "templates"
+tpl_dir = Path(str(files("floogen") / "templates"))
+
+
+class RenderKwargs(TypedDict, total=False):
+    """Keyword arguments forwarded to `render_template`."""
+
+    outdir: Path | None
+    format_output: bool
+    verible_fmt_bin: str | None
+    verible_fmt_args: str | None
+
 
 def render_template(context: dict, tpl: Path,
                     outdir: Path | None = None, file_name: str | None = None,
@@ -280,7 +291,7 @@ def main():
     context = {"noc": network}
 
     # Additional render arguments
-    render_kwargs = {"outdir": args.outdir}
+    render_kwargs: RenderKwargs = {"outdir": args.outdir}
 
     # Command specific render arguments
     match args.command:

--- a/floogen/cli.py
+++ b/floogen/cli.py
@@ -6,6 +6,7 @@
 # Author: Tim Fischer <fischeti@iis.ee.ethz.ch>
 
 import argparse
+import sys
 from importlib.metadata import version
 from importlib.resources import files
 from importlib.util import find_spec
@@ -14,7 +15,7 @@ from typing import TypedDict
 
 from mako.template import Template
 
-from floogen.config_parser import parse_config
+from floogen.config_parser import ConfigError, parse_config
 from floogen.model.network import Network
 from floogen.model.traffic import MESH_TRAFFIC_TYPES, gen_traffic_builtin, gen_traffic_cfg
 from floogen.query import handle_query
@@ -281,7 +282,13 @@ def main():
         parser.print_help()
         return 0
 
-    network = parse_config(Network, args.config)
+    try:
+        network = parse_config(Network, args.config)
+    except ConfigError as e:
+        # `parse_config` has already reported the individual problems in detail; a traceback
+        # would only bury them.
+        print(f"floogen: {e}", file=sys.stderr)
+        return 1
 
     network.create_network()
     network.compile_network()

--- a/floogen/cli.py
+++ b/floogen/cli.py
@@ -20,9 +20,6 @@ from floogen.model.traffic import MESH_TRAFFIC_TYPES, gen_traffic_builtin, gen_t
 from floogen.query import handle_query
 from floogen.utils import verible_format
 
-# `render_template` needs a real filesystem path (it calls `.resolve()` and hands the
-# result to mako), so derive it from `__file__` rather than round-tripping a
-# `importlib.resources` traversable through `str()`.
 tpl_dir = Path(__file__).parent / "templates"
 
 

--- a/floogen/config_parser.py
+++ b/floogen/config_parser.py
@@ -57,14 +57,26 @@ def get_file_location(
 T = TypeVar("T", bound=BaseModel)
 
 
-def parse_config(cls: type[T], config_file: Path) -> T | None:
-    """Parses a configuration file and returns a validated model."""
+class ConfigError(Exception):
+    """Raised when a configuration file cannot be parsed or validated.
+
+    The specific problems are reported through `logger` before this is raised, so callers
+    should report only this exception's message rather than a traceback.
+    """
+
+
+def parse_config(cls: type[T], config_file: Path) -> T:
+    """Parses a configuration file and returns a validated model.
+
+    Raises:
+        ConfigError: If the file is not valid YAML or does not validate against `cls`.
+    """
     with config_file.open() as file:
         try:
             config_data = ruamel.yaml.YAML(typ="rt").load(file)
         except YAMLError as e:
             logger.error("Error while parsing config_file:\n %s", e)
-            return None
+            raise ConfigError(f"Could not parse '{config_file}' as YAML") from e
 
     try:
         return cls.model_validate(config_data)
@@ -86,4 +98,6 @@ def parse_config(cls: type[T], config_file: Path) -> T | None:
             logger.error("Line %s, Column %s:", line, column)
             logger.error("...\n%s\n...", error_context)
             logger.error("Error: %s", error["msg"])
-        return None
+        raise ConfigError(
+            f"{len(e.errors())} validation error(s) in '{config_file}'"
+        ) from e

--- a/floogen/model/endpoint.py
+++ b/floogen/model/endpoint.py
@@ -6,7 +6,7 @@
 
 from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
-from floogen.model.protocol import Protocols
+from floogen.model.protocol import ProtocolDesc
 from floogen.model.routing import AddrRange, Coord, SimpleId
 
 
@@ -114,13 +114,13 @@ class EndpointDesc(BaseModel):
 class Endpoint(EndpointDesc):
     """Endpoint class to describe an endpoint with adress ranges and configuration parameters."""
 
-    mgr_ports: list[Protocols] = []
-    sbr_ports: list[Protocols] = []
+    mgr_ports: list[ProtocolDesc] = []
+    sbr_ports: list[ProtocolDesc] = []
 
     @classmethod
     def from_desc(cls, desc: EndpointDesc,
-                  mgr_ports: list[Protocols],
-                  sbr_ports: list[Protocols]):
+                  mgr_ports: list[ProtocolDesc],
+                  sbr_ports: list[ProtocolDesc]):
         """Create an endpoint from a description."""
         return cls(**desc.model_dump(), mgr_ports=mgr_ports, sbr_ports=sbr_ports)
 

--- a/floogen/model/graph.py
+++ b/floogen/model/graph.py
@@ -154,7 +154,7 @@ class Graph(nx.DiGraph):  # pylint: disable=too-many-public-methods
         """Return the link edges."""
         return self.get_edges(filters=[self.is_link_edge], with_obj=with_obj, with_name=with_name)
 
-    def get_nodes_from_range(self, node: str, rng: list[tuple[int]]):
+    def get_nodes_from_range(self, node: str, rng: list[tuple[int, int]]):
         """Return the nodes from the range."""
         nodes = []
         if len(rng) == 0:
@@ -226,7 +226,7 @@ class Graph(nx.DiGraph):  # pylint: disable=too-many-public-methods
     def add_nodes_as_array(
         self,
         name: str,
-        array: tuple[int],
+        array: tuple[int] | tuple[int, int],
         node_type: str,
         *,
         edge_type: str = "",

--- a/floogen/model/link.py
+++ b/floogen/model/link.py
@@ -25,7 +25,7 @@ class Link(BaseModel, ABC):
     dest_type: str
     is_bidirectional: bool = False
     is_array: bool = False
-    array: list = None
+    array: list | None = None
 
     channel_mapping: ClassVar[dict] = {}
 

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -8,7 +8,7 @@ import pathlib
 from enum import Enum
 
 import networkx as nx
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, PrivateAttr, field_validator, model_validator
 
 from floogen.model.connection import ConnectionDesc
 from floogen.model.endpoint import Endpoint, EndpointDesc
@@ -68,12 +68,23 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
     endpoints: list[EndpointDesc]
     routers: list[RouterDesc]
     connections: list[ConnectionDesc]
-    graph: Graph | None = None
     routing: Routing
+
+    # Only populated by `create_network()`. Kept private and exposed through the `graph`
+    # property below so that the rest of the code (and the type checker) can rely on it
+    # being a `Graph`, with a readable error if the network has not been built yet.
+    _graph: Graph | None = PrivateAttr(default=None)
+
+    @property
+    def graph(self) -> Graph:
+        """The network graph. Raises if the network has not been created yet."""
+        if self._graph is None:
+            raise ValueError("Network graph has not been created")
+        return self._graph
 
     def create_network(self):
         """Initialize the network as a graph."""
-        self.graph = Graph()
+        self._graph = Graph()
         self.create_routers()
         self.create_endpoints()
         self.create_connections()

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -874,7 +874,7 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
             fields_dict[rule_desc] = i
         return sv_enum_typedef(name="sam_idx_e", fields_dict=fields_dict)
 
-    def visualize(self, savefig=True, filename: pathlib.Path = "network.png"):
+    def visualize(self, savefig=True, filename: pathlib.Path = pathlib.Path("network.png")):
         """Visualize the network graph."""
         # Imported lazily so the optional 'viz' extra (matplotlib) is only
         # required when this feature is actually used. The CLI hides the

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -594,11 +594,13 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
             ni_dict["sbr_link"] = self.graph.get_edges_to(
                 ni_name, filters=[self.graph.is_link_edge]
             )[0]
+            # `ni_dict` is assembled dynamically above, so validate it as a mapping rather
+            # than splatting it into the constructor.
             match self.network_type:
                 case "axi":
-                    self.graph.set_node_obj(ni_name, AxiNI(**ni_dict))
+                    self.graph.set_node_obj(ni_name, AxiNI.model_validate(ni_dict))
                 case "narrow-wide":
-                    self.graph.set_node_obj(ni_name, NarrowWideAxiNI(**ni_dict))
+                    self.graph.set_node_obj(ni_name, NarrowWideAxiNI.model_validate(ni_dict))
 
     def gen_routing_info(self):
         """Wrapper function to generate all the routing info for the network,

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -716,27 +716,30 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
     def gen_collective_sam(self):
         """Generate the collective system address map, which contains additional mask
         information for collective endpoints."""
+        if self.routing.sam is None:
+            raise ValueError("System address map has not been generated")
         addr_table = []
         for addr_rule in self.routing.sam.rules:
             mask_fields = {}
             if addr_rule.addr_range.en_collective:
                 # Collective ranges are only defined for 2D endpoint arrays, so `arr_dim`
-                # and `arr_idx` must both be present and two-dimensional.
-                match (addr_rule.addr_range.arr_dim, addr_rule.addr_range.arr_idx):
-                    case ((dim_x, dim_y), (idx_x, idx_y)):
+                # and `arr_idx` must both be present and two-dimensional, and the
+                # destination must be a mesh coordinate rather than a plain ID.
+                match (addr_rule.addr_range.arr_dim, addr_rule.addr_range.arr_idx,
+                       addr_rule.dest):
+                    case ((dim_x, dim_y), (idx_x, idx_y), Coord() as dest):
                         arr_x_bits = clog2(dim_x)
                         arr_y_bits = clog2(dim_y)
                         mask_offset_y = clog2(addr_rule.addr_range.size)
                         mask_fields = {
                             "mask_len": (arr_x_bits, arr_y_bits),
                             "mask_offset": (mask_offset_y + arr_y_bits, mask_offset_y),
-                            "base_id": (addr_rule.dest.x - idx_x,
-                                        addr_rule.dest.y - idx_y),
+                            "base_id": (dest.x - idx_x, dest.y - idx_y),
                         }
                     case _:
                         raise ValueError(
                             f"Collective address range '{addr_rule.desc}' requires a 2D "
-                            "endpoint array"
+                            "endpoint array with mesh coordinates"
                         )
             addr_table.append(RouteMapRuleCollective(**addr_rule.model_dump(), **mask_fields))
         return RouteMap(name="collective_sam", rules=addr_table)
@@ -782,6 +785,10 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
                 if prot.type == "wide" and prot.direction == "input"), None)
             wide_out_prot = next((prot for prot in self.protocols
                 if prot.type == "wide" and prot.direction == "output"), None)
+            if narrow_in_prot is None or wide_in_prot is None:
+                raise ValueError(
+                    "A `narrow-wide` network requires both a narrow and a wide input protocol"
+                )
             string += AXI4.render_cfg("AxiCfgN", narrow_in_prot, narrow_out_prot)
             string += AXI4.render_cfg("AxiCfgW", wide_in_prot, wide_out_prot)
 
@@ -796,6 +803,8 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
         else:
             in_prot = next((prot for prot in self.protocols if prot.direction == "input"), None)
             out_prot = next((prot for prot in self.protocols if prot.direction == "output"), None)
+            if in_prot is None:
+                raise ValueError("An `axi` network requires an input protocol")
             string += AXI4.render_cfg("AxiCfg", in_prot, out_prot)
             string += AxiLink.render_typedefs(in_prot.type_name(), "AxiCfg")
         return string
@@ -879,6 +888,8 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
 
     def render_sam_idx_enum(self):
         """Render the system address map index enum in the generated code."""
+        if self.routing.sam is None:
+            raise ValueError("System address map has not been generated")
         fields_dict = {}
         for i, rule in enumerate(reversed(self.routing.sam.rules)):
             rule_desc = f"{rule.render_desc()}_sam_idx"

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -70,7 +70,6 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
     connections: list[ConnectionDesc]
     routing: Routing
     graph: Graph = Field(default_factory=Graph)
-    """The network graph. Empty until `create_network()` has been called."""
 
     def create_network(self):
         """Initialize the network as a graph."""
@@ -594,8 +593,6 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
             ni_dict["sbr_link"] = self.graph.get_edges_to(
                 ni_name, filters=[self.graph.is_link_edge]
             )[0]
-            # `ni_dict` is assembled dynamically above, so validate it as a mapping rather
-            # than splatting it into the constructor.
             match self.network_type:
                 case "axi":
                     self.graph.set_node_obj(ni_name, AxiNI.model_validate(ni_dict))
@@ -722,9 +719,6 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
         for addr_rule in self.routing.sam.rules:
             mask_fields = {}
             if addr_rule.addr_range.en_collective:
-                # Collective ranges are only defined for 2D endpoint arrays, so `arr_dim`
-                # and `arr_idx` must both be present and two-dimensional, and the
-                # destination must be a mesh coordinate rather than a plain ID.
                 match (addr_rule.addr_range.arr_dim, addr_rule.addr_range.arr_idx,
                        addr_rule.dest):
                     case ((dim_x, dim_y), (idx_x, idx_y), Coord() as dest):

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -718,16 +718,24 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
         for addr_rule in self.routing.sam.rules:
             mask_fields = {}
             if addr_rule.addr_range.en_collective:
-                arr_dim = addr_rule.addr_range.arr_dim
-                arr_x_bits = clog2(arr_dim[0])
-                arr_y_bits = clog2(arr_dim[1])
-                mask_offset_y = clog2(addr_rule.addr_range.size)
-                mask_fields = {
-                    "mask_len": (arr_x_bits, arr_y_bits),
-                    "mask_offset": (mask_offset_y + arr_y_bits, mask_offset_y),
-                    "base_id": (addr_rule.dest.x - addr_rule.addr_range.arr_idx[0],
-                                addr_rule.dest.y - addr_rule.addr_range.arr_idx[1]),
-                }
+                # Collective ranges are only defined for 2D endpoint arrays, so `arr_dim`
+                # and `arr_idx` must both be present and two-dimensional.
+                match (addr_rule.addr_range.arr_dim, addr_rule.addr_range.arr_idx):
+                    case ((dim_x, dim_y), (idx_x, idx_y)):
+                        arr_x_bits = clog2(dim_x)
+                        arr_y_bits = clog2(dim_y)
+                        mask_offset_y = clog2(addr_rule.addr_range.size)
+                        mask_fields = {
+                            "mask_len": (arr_x_bits, arr_y_bits),
+                            "mask_offset": (mask_offset_y + arr_y_bits, mask_offset_y),
+                            "base_id": (addr_rule.dest.x - idx_x,
+                                        addr_rule.dest.y - idx_y),
+                        }
+                    case _:
+                        raise ValueError(
+                            f"Collective address range '{addr_rule.desc}' requires a 2D "
+                            "endpoint array"
+                        )
             addr_table.append(RouteMapRuleCollective(**addr_rule.model_dump(), **mask_fields))
         return RouteMap(name="collective_sam", rules=addr_table)
 

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -8,7 +8,7 @@ import pathlib
 from enum import Enum
 
 import networkx as nx
-from pydantic import BaseModel, ConfigDict, PrivateAttr, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from floogen.model.connection import ConnectionDesc
 from floogen.model.endpoint import Endpoint, EndpointDesc
@@ -69,22 +69,12 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
     routers: list[RouterDesc]
     connections: list[ConnectionDesc]
     routing: Routing
-
-    # Only populated by `create_network()`. Kept private and exposed through the `graph`
-    # property below so that the rest of the code (and the type checker) can rely on it
-    # being a `Graph`, with a readable error if the network has not been built yet.
-    _graph: Graph | None = PrivateAttr(default=None)
-
-    @property
-    def graph(self) -> Graph:
-        """The network graph. Raises if the network has not been created yet."""
-        if self._graph is None:
-            raise ValueError("Network graph has not been created")
-        return self._graph
+    graph: Graph = Field(default_factory=Graph)
+    """The network graph. Empty until `create_network()` has been called."""
 
     def create_network(self):
         """Initialize the network as a graph."""
-        self._graph = Graph()
+        self.graph = Graph()
         self.create_routers()
         self.create_endpoints()
         self.create_connections()

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -6,6 +6,7 @@
 
 import pathlib
 from enum import Enum
+from typing import Any
 
 import networkx as nx
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -463,7 +464,7 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
             assert non_dir_in_edges == []
             assert non_dir_out_edges == []
 
-            router_dict = {
+            router_dict: dict[str, Any] = {
                 "name": rt_name,
                 "incoming": incoming,
                 "outgoing": outgoing,
@@ -706,7 +707,7 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
                 rule_name = ni.endpoint.name
                 if addr_range.desc is not None:
                     rule_name += f"_{addr_range.desc}"
-                addr_rule = RouteMapRule(dest=dest, addr_range=addr_range, en_collective=addr_range.en_collective, desc=rule_name)
+                addr_rule = RouteMapRule(dest=dest, addr_range=addr_range, desc=rule_name)
                 addr_table.append(addr_rule)
         return RouteMap(name="sam", rules=addr_table)
 

--- a/floogen/model/network.py
+++ b/floogen/model/network.py
@@ -639,7 +639,7 @@ class Network(BaseModel):  # pylint: disable=too-many-public-methods
                 out_link = self.graph.get_edge_obj(out_edge)
                 out_idx = rt.outgoing.index(out_link)
                 dest = SimpleId(id=out_idx)
-                addr_range = AddrRange(start=ni.id.id, size=1)
+                addr_range = AddrRange.from_start_size(ni.id.id, 1)
                 routing_table.append(RouteMapRule(dest=dest, addr_range=addr_range, desc=ni.name))
 
             # Add routing table to the router

--- a/floogen/model/network_interface.py
+++ b/floogen/model/network_interface.py
@@ -48,7 +48,9 @@ class NetworkInterface(BaseModel):
 
     def is_collective_ni(self) -> bool:
         """Return true if the network interface supports collective operations."""
-        return any(b for b in self.addr_range or [] if b.en_collective)
+        if not self.addr_range:
+            return False
+        return any(b.en_collective for b in self.addr_range)
 
     def render_enum_name(self) -> str:
         """Render the enum name."""

--- a/floogen/model/network_interface.py
+++ b/floogen/model/network_interface.py
@@ -48,7 +48,7 @@ class NetworkInterface(BaseModel):
 
     def is_collective_ni(self) -> bool:
         """Return true if the network interface supports collective operations."""
-        return any(b for b in self.addr_range if b.en_collective)
+        return any(b for b in self.addr_range or [] if b.en_collective)
 
     def render_enum_name(self) -> str:
         """Render the enum name."""

--- a/floogen/model/protocol.py
+++ b/floogen/model/protocol.py
@@ -132,8 +132,6 @@ class AXI4Bus(AXI4):
 
     def _idx_to_sv_idx(self):
         """Convert the array to a SystemVerilog array."""
-        # `arr_idx` and `arr_dim` are always assigned together (see `Network.create_endpoints`),
-        # so requiring both here does not change behaviour.
         if self.arr_idx is not None and self.arr_dim is not None:
             string = ""
             for idx, val in zip(self.arr_idx, self.arr_dim):

--- a/floogen/model/protocol.py
+++ b/floogen/model/protocol.py
@@ -9,7 +9,6 @@ from typing import Annotated, TypeVar
 from pydantic import BaseModel, StringConstraints
 
 from floogen.utils import (
-    snake_to_camel,
     sv_param_decl,
     sv_struct_render,
     sv_struct_typedef,
@@ -59,15 +58,6 @@ class AXI4(ProtocolDesc):
     def type_name(self, prefix="") -> str:
         """Return the full name of the protocol."""
         return "_".join(filter(None, [prefix, self.type_prefix, self.name]))
-
-    def render_params(self) -> str:
-        """Render the parameters of the protocol."""
-        cfull_name = snake_to_camel(self.full_name())
-        string = sv_param_decl(cfull_name + "AddrWidth", self.addr_width)
-        string += sv_param_decl(cfull_name + "DataWidth", self.data_width)
-        string += sv_param_decl(cfull_name + "IdWidth", self.id_width)
-        string += sv_param_decl(cfull_name + "UserWidth", self.user_width)
-        return string + "\n"
 
     def render_typedefs(self, prefix="", ignored_user_fields=None) -> str:
         """Render the typedefs of the protocol."""

--- a/floogen/model/protocol.py
+++ b/floogen/model/protocol.py
@@ -34,6 +34,10 @@ class ProtocolDesc(BaseModel):
     type: Annotated[str, StringConstraints(pattern=r"narrow|wide")] | None = None
     direction: str | None = None
 
+    def render_port(self, pkg_name="", prefix="") -> list[str]:
+        """Render the port of the protocol."""
+        raise NotImplementedError
+
 
 class AXI4(ProtocolDesc):
     """AXI4 protocol class.

--- a/floogen/model/protocol.py
+++ b/floogen/model/protocol.py
@@ -132,7 +132,9 @@ class AXI4Bus(AXI4):
 
     def _idx_to_sv_idx(self):
         """Convert the array to a SystemVerilog array."""
-        if self.arr_idx is not None:
+        # `arr_idx` and `arr_dim` are always assigned together (see `Network.create_endpoints`),
+        # so requiring both here does not change behaviour.
+        if self.arr_idx is not None and self.arr_dim is not None:
             string = ""
             for idx, val in zip(self.arr_idx, self.arr_dim):
                 if val != 1:

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -375,7 +375,11 @@ class AddrRange(BaseModel):
         en_collective (bool): If true, marks this range as a multicast/collective destination.
     """
 
-    model_config = ConfigDict(extra="forbid", validate_assignement=True)
+    # NOTE: `validate_assignment` is intentionally *not* enabled. It was previously spelled
+    # `validate_assignement`, which pydantic silently ignored, so it has never been active.
+    # Enabling it breaks `set_arr()`, which assigns `start` before `end` and therefore
+    # transiently violates the `start < end` invariant checked by `validate_output`.
+    model_config = ConfigDict(extra="forbid")
 
     start: int = Field(ge=0)
     end: int = Field(ge=0)

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -375,10 +375,12 @@ class AddrRange(BaseModel):
     Attributes:
         start (int): Absolute start address of the range.
         end (int): Absolute end address of the range.
-        size (int): Size of the address range. Accepted as an input key in place of `start`
-            or `end`, but not stored - it is always reported as `end - start`.
         base (Optional[int]): Base address used for calculating ranges in endpoint arrays.
         en_collective (bool): If true, marks this range as a multicast/collective destination.
+
+    `size` is additionally accepted as an *input* key in place of `start` or `end`, but is
+    not stored as a field - it is normalised away into `end` and read back through the
+    derived `size` property.
     """
 
     # NOTE: `validate_assignment` is not enabled. It used to be spelled
@@ -536,7 +538,12 @@ class RouteMapRule(BaseModel):
 
     def render_desc(self):
         '''Render the description of the routing rule.'''
-        rule_desc = self.desc or ""
+        if self.desc is None:
+            # The result is used as a SystemVerilog identifier (see `render_sam_idx_enum`
+            # and `RouteMap.render`), so an absent description would silently produce a
+            # degenerate name rather than anything usable.
+            raise ValueError(f"Routing rule {self} has no description to render")
+        rule_desc = self.desc
         match self.addr_range.arr_idx:
             case (m,):
                 rule_desc += f"_{m}"

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -6,7 +6,7 @@
 
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from floogen.utils import (
     bool_to_sv,
@@ -838,6 +838,8 @@ class Routing(BaseModel):
 
     route_algo: RouteAlgo
     use_id_table: bool = True
+    sam: RouteMap | None = None
+    """The system address map."""
     table: RouteMap | None = None
     """The routing table of the router."""
     addr_offset_bits: int | None = None
@@ -865,23 +867,6 @@ class Routing(BaseModel):
     collective_sam: RouteMap | None = None
     """The collective system address map. Only used if collective is enabled."""
     collective: CollectiveCfg = CollectiveCfg()
-
-    # Only populated by `Network.gen_routing_info()`. Kept private and exposed through the
-    # `sam` property below so that the rest of the code (and the type checker) can rely on
-    # it being a `RouteMap`, with a readable error if routing info was never generated.
-    # `collective_sam` stays optional: it is only generated when collectives are enabled.
-    _sam: RouteMap | None = PrivateAttr(default=None)
-
-    @property
-    def sam(self) -> RouteMap:
-        """The system address map. Raises if routing info has not been generated."""
-        if self._sam is None:
-            raise ValueError("System address map has not been generated")
-        return self._sam
-
-    @sam.setter
-    def sam(self, value: RouteMap) -> None:
-        self._sam = value
 
     @property
     def en_collective(self) -> bool:

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -1033,6 +1033,8 @@ class Routing(BaseModel):
             if self.addr_offset_bits is None:
                 raise ValueError(_NOT_GENERATED)
             id_addr_offset = self.addr_offset_bits
+        if self.sam is None:
+            raise ValueError("System address map has not been generated")
 
         fields = {
             "RouteAlgo": self.route_algo.value,

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -383,16 +383,6 @@ class AddrRange(BaseModel):
     derived `size` property.
     """
 
-    # NOTE: `validate_assignment` is not enabled. It used to be spelled
-    # `validate_assignement`, which pydantic silently ignored, so it has never been active.
-    # Deriving `size` removed one of the three blockers; two remain, both verified by
-    # turning the flag on and running the suite:
-    #
-    #  1. `validate_input` strips `None`-valued keys, and pydantic rebuilds the instance
-    #     from whatever that validator returns, so every optional field would be dropped on
-    #     *any* assignment. It would have to merge the untouched keys back in.
-    #  2. `set_arr()` assigns `start` and then `end`, which transiently violates the
-    #     `start < end` check in `validate_output`. It would have to update both at once.
     model_config = ConfigDict(extra="forbid")
 
     start: int = Field(ge=0)
@@ -539,9 +529,6 @@ class RouteMapRule(BaseModel):
     def render_desc(self):
         '''Render the description of the routing rule.'''
         if self.desc is None:
-            # The result is used as a SystemVerilog identifier (see `render_sam_idx_enum`
-            # and `RouteMap.render`), so an absent description would silently produce a
-            # degenerate name rather than anything usable.
             raise ValueError(f"Routing rule {self} has no description to render")
         rule_desc = self.desc
         match self.addr_range.arr_idx:
@@ -602,9 +589,6 @@ class RouteMapRuleCollective(RouteMapRule):
             "end_addr": f"{aw}'h{self.addr_range.end:0{cdiv(aw,4)}x}",
         }
 
-        # Non-collective nodes don't need any mask information. The three mask fields are
-        # always populated together (see `Network.gen_collective_sam`), so testing all of
-        # them keeps the existing behaviour.
         if self.mask_offset is None or self.mask_len is None or self.base_id is None:
             struct_fields["idx"]["mask_x"] = {"default": "'0"}
             struct_fields["idx"]["mask_y"] = {"default": "'0"}
@@ -662,10 +646,6 @@ class RouteTable(BaseModel):
         """Sort by destination and fill in missing entries."""
         self.routes = sorted(self.routes, key=lambda x: x.id)
         for i, route in enumerate(self.routes):
-            # Route tables index destinations by position, which only makes sense for the
-            # plain IDs used by source routing - not for mesh coordinates. `ValueError` on
-            # purpose, as above: pydantic turns it into a `ValidationError`, while a
-            # `TypeError` would escape as an unhandled exception.
             if not isinstance(route.id, SimpleId):
                 raise ValueError("Route tables require `SimpleId` destinations")  # noqa: TRY004
             if i != route.id.id:
@@ -746,7 +726,6 @@ class RouteMap(BaseModel):
             i = 0
             while i < len(ranges) - 1:
                 if ranges[i].addr_range.end == ranges[i + 1].addr_range.start:
-                    # `size` follows from `end`, so extending the range is a single write.
                     ranges[i].addr_range.end = ranges[i + 1].addr_range.end
                     del ranges[i + 1]
                 else:

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -6,7 +6,7 @@
 
 from enum import Enum
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
 
 from floogen.utils import (
     bool_to_sv,
@@ -838,8 +838,6 @@ class Routing(BaseModel):
 
     route_algo: RouteAlgo
     use_id_table: bool = True
-    sam: RouteMap | None = None
-    """The system address map."""
     table: RouteMap | None = None
     """The routing table of the router."""
     addr_offset_bits: int | None = None
@@ -867,6 +865,23 @@ class Routing(BaseModel):
     collective_sam: RouteMap | None = None
     """The collective system address map. Only used if collective is enabled."""
     collective: CollectiveCfg = CollectiveCfg()
+
+    # Only populated by `Network.gen_routing_info()`. Kept private and exposed through the
+    # `sam` property below so that the rest of the code (and the type checker) can rely on
+    # it being a `RouteMap`, with a readable error if routing info was never generated.
+    # `collective_sam` stays optional: it is only generated when collectives are enabled.
+    _sam: RouteMap | None = PrivateAttr(default=None)
+
+    @property
+    def sam(self) -> RouteMap:
+        """The system address map. Raises if routing info has not been generated."""
+        if self._sam is None:
+            raise ValueError("System address map has not been generated")
+        return self._sam
+
+    @sam.setter
+    def sam(self, value: RouteMap) -> None:
+        self._sam = value
 
     @property
     def en_collective(self) -> bool:

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -18,6 +18,11 @@ from floogen.utils import (
     sv_typedef,
 )
 
+# The width fields on `Routing` are filled in by `Network.gen_routing_info()`, which sets
+# exactly the ones the configured routing algorithm needs. Reading them before that is a
+# programming error rather than a config error.
+_NOT_GENERATED = "Routing widths are only available after `gen_routing_info()`"
+
 
 class RouteAlgo(Enum):
     """Routing algorithm enum.
@@ -498,7 +503,7 @@ class RouteMapRule(BaseModel):
 
     def render_desc(self):
         '''Render the description of the routing rule.'''
-        rule_desc = self.desc
+        rule_desc = self.desc or ""
         match self.addr_range.arr_idx:
             case (m,):
                 rule_desc += f"_{m}"
@@ -557,8 +562,10 @@ class RouteMapRuleCollective(RouteMapRule):
             "end_addr": f"{aw}'h{self.addr_range.end:0{cdiv(aw,4)}x}",
         }
 
-        # Non-collective nodes don't need any mask information
-        if self.mask_offset is None:
+        # Non-collective nodes don't need any mask information. The three mask fields are
+        # always populated together (see `Network.gen_collective_sam`), so testing all of
+        # them keeps the existing behaviour.
+        if self.mask_offset is None or self.mask_len is None or self.base_id is None:
             struct_fields["idx"]["mask_x"] = {"default": "'0"}
             struct_fields["idx"]["mask_y"] = {"default": "'0"}
         else:
@@ -915,20 +922,28 @@ class Routing(BaseModel):
         string += sv_param_decl("UseIdTable", bool_to_sv(self.use_id_table), dtype="bit")
         match (self.route_algo):
             case RouteAlgo.XY | RouteAlgo.YX:
+                if self.num_x_bits is None or self.num_y_bits is None:
+                    raise ValueError(_NOT_GENERATED)
                 string += sv_param_decl("NumXBits", self.num_x_bits)
                 string += sv_param_decl("NumYBits", self.num_y_bits)
             case RouteAlgo.ID:
+                if self.num_id_bits is None:
+                    raise ValueError(_NOT_GENERATED)
                 string += sv_param_decl("NumIdBits", self.num_id_bits)
             case _:
                 pass
 
         if self.route_algo in (RouteAlgo.XY, RouteAlgo.YX):
+            if self.addr_offset_bits is None or self.num_x_bits is None:
+                raise ValueError(_NOT_GENERATED)
             string += sv_param_decl("XYAddrOffsetX", self.addr_offset_bits)
             string += sv_param_decl("XYAddrOffsetY", self.addr_offset_bits + self.num_x_bits)
         else:
             string += sv_param_decl("XYAddrOffsetX", 0)
             string += sv_param_decl("XYAddrOffsetY", 0)
         if self.route_algo == RouteAlgo.ID and not self.use_id_table:
+            if self.addr_offset_bits is None:
+                raise ValueError(_NOT_GENERATED)
             string += sv_param_decl("IdAddrOffset", self.addr_offset_bits)
         else:
             string += sv_param_decl("IdAddrOffset", 0)
@@ -977,14 +992,23 @@ class Routing(BaseModel):
 
     def render_route_cfg(self, name) -> str:
         """Render the SystemVerilog routing configuration."""
+        xy_addr_offset_x, xy_addr_offset_y, id_addr_offset = 0, 0, 0
+        if self.route_algo in (RouteAlgo.XY, RouteAlgo.YX):
+            if self.addr_offset_bits is None or self.num_x_bits is None:
+                raise ValueError(_NOT_GENERATED)
+            xy_addr_offset_x = self.addr_offset_bits
+            xy_addr_offset_y = self.addr_offset_bits + self.num_x_bits
+        elif self.route_algo == RouteAlgo.ID and not self.use_id_table:
+            if self.addr_offset_bits is None:
+                raise ValueError(_NOT_GENERATED)
+            id_addr_offset = self.addr_offset_bits
+
         fields = {
             "RouteAlgo": self.route_algo.value,
             "UseIdTable": bool_to_sv(self.use_id_table),
-            "XYAddrOffsetX": self.addr_offset_bits if self.route_algo in (RouteAlgo.XY, RouteAlgo.YX) else 0,
-            "XYAddrOffsetY": self.addr_offset_bits + self.num_x_bits if
-                                self.route_algo in (RouteAlgo.XY, RouteAlgo.YX) else 0,
-            "IdAddrOffset": self.addr_offset_bits if
-                                self.route_algo == RouteAlgo.ID and not self.use_id_table else 0,
+            "XYAddrOffsetX": xy_addr_offset_x,
+            "XYAddrOffsetY": xy_addr_offset_y,
+            "IdAddrOffset": id_addr_offset,
             "NumSamRules": len(self.sam),
             "NumRoutes": self.num_endpoints if self.route_algo == RouteAlgo.SRC else 0,
             "CollectiveCfg": self.collective.get_collective_cfg,

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -655,6 +655,12 @@ class RouteTable(BaseModel):
         """Sort by destination and fill in missing entries."""
         self.routes = sorted(self.routes, key=lambda x: x.id)
         for i, route in enumerate(self.routes):
+            # Route tables index destinations by position, which only makes sense for the
+            # plain IDs used by source routing - not for mesh coordinates. `ValueError` on
+            # purpose, as above: pydantic turns it into a `ValidationError`, while a
+            # `TypeError` would escape as an unhandled exception.
+            if not isinstance(route.id, SimpleId):
+                raise ValueError("Route tables require `SimpleId` destinations")  # noqa: TRY004
             if i != route.id.id:
                 self.routes.insert(i, RouteRule(route=None, id=SimpleId(id=i)))
         return self.routes.reverse()

--- a/floogen/model/routing.py
+++ b/floogen/model/routing.py
@@ -375,20 +375,26 @@ class AddrRange(BaseModel):
     Attributes:
         start (int): Absolute start address of the range.
         end (int): Absolute end address of the range.
-        size (int): Size of the address range.
+        size (int): Size of the address range. Accepted as an input key in place of `start`
+            or `end`, but not stored - it is always reported as `end - start`.
         base (Optional[int]): Base address used for calculating ranges in endpoint arrays.
         en_collective (bool): If true, marks this range as a multicast/collective destination.
     """
 
-    # NOTE: `validate_assignment` is intentionally *not* enabled. It was previously spelled
+    # NOTE: `validate_assignment` is not enabled. It used to be spelled
     # `validate_assignement`, which pydantic silently ignored, so it has never been active.
-    # Enabling it breaks `set_arr()`, which assigns `start` before `end` and therefore
-    # transiently violates the `start < end` invariant checked by `validate_output`.
+    # Deriving `size` removed one of the three blockers; two remain, both verified by
+    # turning the flag on and running the suite:
+    #
+    #  1. `validate_input` strips `None`-valued keys, and pydantic rebuilds the instance
+    #     from whatever that validator returns, so every optional field would be dropped on
+    #     *any* assignment. It would have to merge the untouched keys back in.
+    #  2. `set_arr()` assigns `start` and then `end`, which transiently violates the
+    #     `start < end` check in `validate_output`. It would have to update both at once.
     model_config = ConfigDict(extra="forbid")
 
     start: int = Field(ge=0)
     end: int = Field(ge=0)
-    size: int
     base: int | None = None
     arr_idx: tuple[int, ...] | None = None
     arr_dim: tuple[int, ...] | None = None
@@ -401,6 +407,27 @@ class AddrRange(BaseModel):
 
     def __str__(self):
         return f"[{self.start:X}:{self.end:X}]"
+
+    @property
+    def size(self) -> int:
+        """Size of the address range.
+
+        Derived rather than stored: every accepted input shape defines the range as
+        `end - start`, so keeping a separate field would only add state to hold in sync.
+        `size` remains a valid *input* key - see `validate_input` - it is simply
+        normalised away into `end`.
+        """
+        return self.end - self.start
+
+    @classmethod
+    def from_start_size(cls, start: int, size: int, **kwargs) -> "AddrRange":
+        """Create a range from a start address and a size."""
+        return cls.model_validate({"start": start, "size": size, **kwargs})
+
+    @classmethod
+    def from_base_size(cls, base: int, size: int, **kwargs) -> "AddrRange":
+        """Create a range from an array base address and a per-element size."""
+        return cls.model_validate({"base": base, "size": size, **kwargs})
 
     @field_validator("rdl_addrmap_grp", mode="before")
     @classmethod
@@ -418,6 +445,8 @@ class AddrRange(BaseModel):
             # while a `TypeError` would escape as an unhandled exception.
             raise ValueError("Invalid address range specification")  # noqa: TRY004
         addr_dict = {k: v for k, v in self.items() if v is not None}
+        # Normalise every accepted input shape to `start`/`end`. `size` is derived from
+        # those two (see the `size` property), so it is consumed here rather than stored.
         match addr_dict:
             case {"size": size, "base": base, "arr_idx": arr_idx}:
                 match arr_idx:
@@ -425,9 +454,10 @@ class AddrRange(BaseModel):
                         addr_dict["start"] = base + size * m
                         addr_dict["end"] = addr_dict["start"] + size
                     case (m, n):
-                        if addr_dict["arr_dim"] is None:
+                        arr_dim = addr_dict.get("arr_dim")
+                        if arr_dim is None:
                             raise ValueError("Array dimension must be specified for 2D arrays")
-                        addr_dict["start"] = base + size * (m * addr_dict["arr_dim"][1] + n)
+                        addr_dict["start"] = base + size * (m * arr_dim[1] + n)
                         addr_dict["end"] = addr_dict["start"] + size
                     case _:
                         raise ValueError("Invalid array index specification")
@@ -438,11 +468,12 @@ class AddrRange(BaseModel):
                 if end - start != size:
                     raise ValueError("Invalid address range specification")
             case {"start": start, "end": end}:
-                addr_dict["size"] = end - start
+                pass
             case {"start": start, "size": size}:
                 addr_dict["end"] = start + size
             case _:
                 raise ValueError("Invalid address range specification")
+        addr_dict.pop("size", None)
         return addr_dict
 
     @model_validator(mode="after")
@@ -458,15 +489,17 @@ class AddrRange(BaseModel):
 
     def set_arr(self, arr_idx, arr_dim):
         """Update the address range with the given index."""
+        # `size` is derived from `start`/`end`, so it has to be read before either moves.
+        size = self.size
         self.arr_idx = arr_idx
         self.arr_dim = arr_dim
         if self.base is not None:
             match arr_idx:
                 case (m,):
-                    self.start = self.base + self.size * m
+                    self.start = self.base + size * m
                 case (m, n):
-                    self.start = self.base + self.size * (m * arr_dim[1] + n)
-            self.end = self.start + self.size
+                    self.start = self.base + size * (m * arr_dim[1] + n)
+            self.end = self.start + size
         else:
             raise ValueError("Address range base not set")
         return self
@@ -700,10 +733,8 @@ class RouteMap(BaseModel):
             i = 0
             while i < len(ranges) - 1:
                 if ranges[i].addr_range.end == ranges[i + 1].addr_range.start:
+                    # `size` follows from `end`, so extending the range is a single write.
                     ranges[i].addr_range.end = ranges[i + 1].addr_range.end
-                    ranges[i].addr_range.size = (
-                        ranges[i].addr_range.end - ranges[i].addr_range.start
-                    )
                     del ranges[i + 1]
                 else:
                     i += 1

--- a/floogen/model/traffic.py
+++ b/floogen/model/traffic.py
@@ -124,9 +124,6 @@ def _ni_mesh_coord(network: Network, ni_name: str) -> tuple[int, int]:
     the coordinate from the adjacent router's array index and the link direction
     instead.
     """
-    if network.graph is None:
-        raise ValueError("Network graph has not been created")
-
     for neighbor in network.graph.neighbors(ni_name):
         if not network.graph.is_rt_node(neighbor):
             continue
@@ -150,9 +147,6 @@ def _ni_mesh_coord(network: Network, ni_name: str) -> tuple[int, int]:
 
 def _xy_addr_map(network: Network) -> dict[tuple[int, int], int]:
     """Build an XY-coordinate-to-base-address lookup from the physical mesh topology."""
-    if network.graph is None:
-        raise ValueError("Network graph has not been created")
-
     xy_addr_map: dict[tuple[int, int], int] = {}
     for ni_name, ni in network.graph.get_ni_nodes(with_name=True):
         if getattr(ni, "addr_range", None):

--- a/floogen/model/traffic.py
+++ b/floogen/model/traffic.py
@@ -160,6 +160,19 @@ def _xy_addr_map(network: Network) -> dict[tuple[int, int], int]:
     return xy_addr_map
 
 
+def _mesh_dims(network: Network) -> tuple[int, int]:
+    """Return the `(x, y)` dimensions of the network's router mesh.
+
+    `Router.array` is optional and may describe a 1D array, but traffic generation is only
+    defined for a 2D mesh, so reject anything else with a readable error.
+    """
+    match network.routers[0].array:
+        case (num_x, num_y):
+            return num_x, num_y
+        case _:
+            raise ValueError("Traffic generation requires a 2D mesh of routers")
+
+
 def resolve_traffic_model(traffic_model: Traffic, network: Network,
                           verbose: bool = False) -> Traffic:
     """Resolve burst data widths and initiator/endpoint addresses using the FlooNoC model."""
@@ -251,7 +264,7 @@ def gen_traffic_cfg(  # pylint: disable=too-many-arguments, too-many-positional-
     traffic_model = resolve_traffic_model(traffic_model, network, verbose=verbose)
     if verbose:
         print_traffic_model(traffic_model)
-    floonoc_num_y = network.routers[0].array[1]
+    _, floonoc_num_y = _mesh_dims(network)
     for flow in traffic_model.traffic_flows:
         local_addr = flow.initiator_addr
         ext_addr = flow.endpoint_addr
@@ -300,7 +313,7 @@ def gen_traffic_builtin(  # pylint: disable=too-many-arguments, too-many-positio
         raise ValueError(f"Unknown traffic type: '{traffic_type}'. "
                           f"Supported types: {', '.join(MESH_TRAFFIC_TYPES)}")
 
-    num_x, num_y = network.routers[0].array[0], network.routers[0].array[1]
+    num_x, num_y = _mesh_dims(network)
     xy_addr_map = _xy_addr_map(network)
     proto_dw = _protocol_data_widths(network, verbose=verbose)
     narrow_dw = proto_dw.get("narrow")

--- a/floogen/model/traffic.py
+++ b/floogen/model/traffic.py
@@ -274,7 +274,7 @@ def gen_traffic_cfg(  # pylint: disable=too-many-arguments, too-many-positional-
                 _log(verbose, f"Warning: No wide interface was detected, skipping wide burst "
                               f"generation for traffic flow '{flow.name}'")
                 continue
-            wide_length = burst.length * burst.data_width / 8
+            wide_length = burst.length * burst.data_width // 8
             wide_jobs += _gen_job_str(wide_length, src_addr, dst_addr) * burst.number
 
         narrow_jobs = ""
@@ -283,7 +283,7 @@ def gen_traffic_cfg(  # pylint: disable=too-many-arguments, too-many-positional-
                 _log(verbose, f"Warning: No narrow interface was detected, skipping narrow burst "
                               f"generation for traffic flow '{flow.name}'")
                 continue
-            narrow_length = burst.length * burst.data_width / 8
+            narrow_length = burst.length * burst.data_width // 8
             narrow_jobs += _gen_job_str(narrow_length, src_addr, dst_addr) * burst.number
 
         x, y = flow.initiator[0], flow.initiator[1]
@@ -322,8 +322,10 @@ def gen_traffic_builtin(  # pylint: disable=too-many-arguments, too-many-positio
     for x in range(num_x):
         for y in range(num_y):
             local_addr = addr(x, y)
-            wide_length = wide_burst_length * wide_dw / 8 if wide_dw is not None else None
-            narrow_length = narrow_burst_length * narrow_dw / 8 if narrow_dw is not None else None
+            wide_length = wide_burst_length * wide_dw // 8 if wide_dw is not None else None
+            narrow_length = (
+                narrow_burst_length * narrow_dw // 8 if narrow_dw is not None else None
+            )
             if traffic_type == "hbm":
                 # Tile x=0 are the HBM channels; each core reads/writes the channel of its
                 # y coordinate.

--- a/floogen/tests/address_test.py
+++ b/floogen/tests/address_test.py
@@ -66,8 +66,6 @@ def test_addr_range_arr_idx():
 
 def test_invalid_addr_range():
     """Test the validation of an AddrRange object."""
-    # `size` is an input key rather than a field, so these go through `model_validate`
-    # to exercise the same normalisation path a YAML config would take.
     with pytest.raises(ValueError):
         AddrRange.model_validate({"start": 100, "end": 0, "size": 100})
 

--- a/floogen/tests/address_test.py
+++ b/floogen/tests/address_test.py
@@ -22,7 +22,7 @@ def test_addr_range_creation1():
 
 def test_addr_range_creation2():
     """Test the creation of an AddrRange object."""
-    addr_range = AddrRange(start=50, size=100)
+    addr_range = AddrRange.from_start_size(50, 100)
     assert addr_range.start == 50
     assert addr_range.end == 150
     assert addr_range.size == 100
@@ -32,7 +32,7 @@ def test_addr_range_creation2():
 
 def test_addr_range_creation3():
     """Test the creation of an AddrRange object."""
-    addr_range = AddrRange(base=50, size=100, arr_idx=(5,))
+    addr_range = AddrRange.from_base_size(50, 100, arr_idx=(5,))
     assert addr_range.start == 550
     assert addr_range.end == 650
     assert addr_range.size == 100
@@ -43,7 +43,7 @@ def test_addr_range_creation3():
 
 def test_addr_range_creation4():
     """Test the creation of an AddrRange object."""
-    addr_range = AddrRange(base=50, size=100)
+    addr_range = AddrRange.from_base_size(50, 100)
     assert addr_range.start == 50
     assert addr_range.end == 150
     assert addr_range.size == 100
@@ -54,7 +54,7 @@ def test_addr_range_creation4():
 
 def test_addr_range_arr_idx():
     """Test the arr_idx method of an AddrRange object."""
-    addr_range = AddrRange(base=50, size=100)
+    addr_range = AddrRange.from_base_size(50, 100)
     addr_range.set_arr((1, ), (5, ))
     assert addr_range.start == 150
     assert addr_range.end == 250
@@ -66,14 +66,16 @@ def test_addr_range_arr_idx():
 
 def test_invalid_addr_range():
     """Test the validation of an AddrRange object."""
+    # `size` is an input key rather than a field, so these go through `model_validate`
+    # to exercise the same normalisation path a YAML config would take.
     with pytest.raises(ValueError):
-        AddrRange(start=100, end=0, size=100)
+        AddrRange.model_validate({"start": 100, "end": 0, "size": 100})
 
     with pytest.raises(ValueError):
-        AddrRange(start=0, end=100, size=0)
+        AddrRange.model_validate({"start": 0, "end": 100, "size": 0})
 
     with pytest.raises(ValueError):
-        addr_range = AddrRange(start=0, end=100, size=100)
+        addr_range = AddrRange.model_validate({"start": 0, "end": 100, "size": 100})
         addr_range.set_arr(2, 5)
 
 

--- a/floogen/utils.py
+++ b/floogen/utils.py
@@ -23,7 +23,7 @@ def cdiv(x: float, y: float) -> int:
     Returns:
         int: Ceiling of x / y.
     """
-    return -(-x // y)
+    return int(-(-x // y))
 
 
 def clog2(x: float) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,4 +106,3 @@ include = ["floogen"]
 # error-by-default in ty. Re-measure with:
 #   uv run --extra viz ty check --output-format concise
 unresolved-attribute = "warn"
-invalid-argument-type = "warn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ floogen = "floogen.cli:main"
 dev = [
     "pytest",
     "ruff",
+    "ty",
     "mkdocstrings-python>=2.0.1",
     "zensical",
 ]
@@ -72,3 +73,32 @@ suggestion-mode = "yes"
 
 [tool.ruff]
 line-length = 100
+
+[tool.ty.environment]
+python-version = "3.10"
+
+[tool.ty.terminal]
+# Warnings are informational for now (see [tool.ty.rules] below); only
+# error-level diagnostics should fail CI.
+error-on-warning = false
+
+[tool.ty.src]
+# `util/` holds standalone helper scripts with their own optional dependencies
+# (e.g. pygame) that are not part of the distributed package.
+include = ["floogen"]
+
+[tool.ty.rules]
+# These are all downstream of a single pattern: model fields are declared
+# `Optional[X] = None` and only populated later by the build pipeline
+# (`create_network()` -> `compile_network()` -> `gen_routing_info()`), so every
+# use afterwards looks like a possible `None` to the type checker.
+#
+# They are kept at `warn` so CI stays green while the annotations are still
+# lying. Promote them to `error` once the pipeline state is modelled honestly;
+# see the tracking issue for the `Optional` refactor.
+unresolved-attribute = "warn"
+missing-argument = "warn"
+invalid-argument-type = "warn"
+not-subscriptable = "warn"
+unsupported-operator = "warn"
+not-iterable = "warn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.9.2,<0.10.0"]
+requires = ["uv_build>=0.9.2,<0.13.0"]
 build-backend = "uv_build"
 
 [tool.uv.build-backend]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ requires-python = ">=3.10"
 authors = [{ name = "Tim Fischer", email = "fischeti@iis.ee.ethz.ch" }]
 classifiers = [
   "Programming Language :: Python :: 3.10",
-  "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
   "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,18 +87,11 @@ include = ["floogen"]
 [tool.ty.rules]
 # Demoted to `warn` so CI stays green. Nothing is wrong with these rules; the
 # problem is the volume of pre-existing findings, which is being worked down
-# (~203 -> ~51 so far). `not-iterable`, `not-subscriptable` and
-# `unsupported-operator` have since reached zero and their lines are gone.
+# (~203 -> ~17 so far). `missing-argument`, `not-iterable`, `not-subscriptable`
+# and `unsupported-operator` have since reached zero and their lines are gone.
 #
 # What is left, and what each remaining rule is waiting on:
 #
-#  *  ~34  `missing-argument`, entirely the `AddrRange` constructor contract:
-#          `start`, `end` and `size` are declared required, but a
-#          `mode="before"` validator derives the third from the other two, so
-#          callers legitimately pass only two. Needs a modelling decision
-#          (optional fields with a post-validator, or explicit alternative
-#          constructors); this is the same debt that blocks
-#          `validate_assignment` on the model.
 #  *  ~10  `unresolved-attribute`: `Routing.sam`, which is only assigned by
 #          `gen_routing_info()` and has no meaningful empty value to default
 #          to; `.x`/`.y`/`.id` on a `SimpleId | Coord` union, where the code
@@ -108,10 +101,9 @@ include = ["floogen"]
 #          declares `int` (it already applies `int()` internally), plus two
 #          `LaxStr` union cases in `Network.gen_routes`.
 #
-# No rule is at zero yet, so none can be promoted. Once a rule's findings reach
-# zero, delete its line here rather than setting it to `error` - these are all
+# Once a rule's findings reach zero, delete its line here rather than setting it
+# to `error` - these are all
 # error-by-default in ty. Re-measure with:
 #   uv run --extra viz ty check --output-format concise
 unresolved-attribute = "warn"
-missing-argument = "warn"
 invalid-argument-type = "warn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,6 @@ dev = [
     "pytest",
     "ruff",
     "ty",
-    # Floor only: `uv.lock` is what actually gates upgrades, so a new `ty` release lands as
-    # a reviewable lockfile bump rather than a surprise CI failure. `error-on-warning`
-    # below means such a bump can introduce new findings - that is intended.
     "mkdocstrings-python>=2.0.1",
     "zensical",
 ]
@@ -78,10 +75,6 @@ suggestion-mode = "yes"
 line-length = 100
 
 [tool.ty.terminal]
-# `floogen` is clean at ty's default rule set, so let warnings fail CI too and keep
-# it that way. There is deliberately no `[tool.ty.rules]` section: every rule that
-# was demoted while the pre-existing findings were worked down (~203 of them) has
-# since reached zero and had its line removed.
 error-on-warning = true
 
 [tool.ty.src]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,10 @@ floogen = "floogen.cli:main"
 dev = [
     "pytest",
     "ruff",
+    "ty",
     # Floor only: `uv.lock` is what actually gates upgrades, so a new `ty` release lands as
     # a reviewable lockfile bump rather than a surprise CI failure. `error-on-warning`
     # below means such a bump can introduce new findings - that is intended.
-    "ty>=0.0.59",
     "mkdocstrings-python>=2.0.1",
     "zensical",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ floogen = "floogen.cli:main"
 dev = [
     "pytest",
     "ruff",
-    "ty",
+    # Floor only: `uv.lock` is what actually gates upgrades, so a new `ty` release lands as
+    # a reviewable lockfile bump rather than a surprise CI failure. `error-on-warning`
+    # below means such a bump can introduce new findings - that is intended.
+    "ty>=0.0.59",
     "mkdocstrings-python>=2.0.1",
     "zensical",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,9 +74,6 @@ suggestion-mode = "yes"
 [tool.ruff]
 line-length = 100
 
-[tool.ty.environment]
-python-version = "3.10"
-
 [tool.ty.terminal]
 # Warnings are informational for now (see [tool.ty.rules] below); only
 # error-level diagnostics should fail CI.
@@ -88,14 +85,24 @@ error-on-warning = false
 include = ["floogen"]
 
 [tool.ty.rules]
-# These are all downstream of a single pattern: model fields are declared
-# `Optional[X] = None` and only populated later by the build pipeline
-# (`create_network()` -> `compile_network()` -> `gen_routing_info()`), so every
-# use afterwards looks like a possible `None` to the type checker.
+# Demoted to `warn` so CI stays green. Nothing is wrong with these rules; the
+# problem is purely the volume of pre-existing findings (~203 at the time of
+# writing), which break down into two dominant causes plus a small remainder:
 #
-# They are kept at `warn` so CI stays green while the annotations are still
-# lying. Promote them to `error` once the pipeline state is modelled honestly;
-# see the tracking issue for the `Optional` refactor.
+#  * ~159  Model fields declared `X | None = None` that are only populated later
+#          by the build pipeline (`create_network()` -> `compile_network()` ->
+#          `gen_routing_info()`), so every use afterwards looks possibly-`None`.
+#          Fixing this means modelling the post-build state honestly rather than
+#          sprinkling asserts.
+#  *  ~34  `AddrRange` constructor contract: `start`, `end` and `size` are all
+#          declared required, but a `mode="before"` validator derives the third
+#          from the other two, so callers legitimately pass only two of them.
+#  *  ~10  Assorted genuine findings worth fixing on their own merits, e.g.
+#          `.x`/`.y` accessed on a `SimpleId | Coord` union, and `user_width`
+#          (`int | dict`) passed where `int | str` is expected.
+#
+# Promote a rule to `error` once its blockers are gone. Re-measure with:
+#   uv run --extra viz ty check --output-format concise
 unresolved-attribute = "warn"
 missing-argument = "warn"
 invalid-argument-type = "warn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,25 +86,27 @@ include = ["floogen"]
 
 [tool.ty.rules]
 # Demoted to `warn` so CI stays green. Nothing is wrong with these rules; the
-# problem is the volume of pre-existing findings. The "populated later by the
-# build pipeline" pattern that used to dominate is largely gone (`Network.graph`
-# default-initializes to an empty `Graph`, and `parse_config` raises instead of
-# returning `None`), taking the count from ~203 to ~71.
+# problem is the volume of pre-existing findings, which is being worked down
+# (~203 -> ~51 so far). `not-iterable`, `not-subscriptable` and
+# `unsupported-operator` have since reached zero and their lines are gone.
 #
-# What is left, and what each rule is still waiting on:
+# What is left, and what each remaining rule is waiting on:
 #
-#  *  ~34  `AddrRange` constructor contract, all `missing-argument`: `start`,
-#          `end` and `size` are declared required, but a `mode="before"`
-#          validator derives the third from the other two, so callers
-#          legitimately pass only two. Needs a modelling decision (optional
-#          fields with a post-validator, or explicit alternative constructors);
-#          this is the same debt that blocks `validate_assignment` on the model.
-#  *  ~37  A long tail of unrelated findings, each needing its own judgement:
-#          `Routing.sam`, which is only assigned by `gen_routing_info()` and has
-#          no meaningful empty value to default to; `.x`/`.y` on a
-#          `SimpleId | Coord` union; widths typed `int | None` that are filled
-#          in during elaboration; and `int | float` from `/` where an `int` is
-#          expected.
+#  *  ~34  `missing-argument`, entirely the `AddrRange` constructor contract:
+#          `start`, `end` and `size` are declared required, but a
+#          `mode="before"` validator derives the third from the other two, so
+#          callers legitimately pass only two. Needs a modelling decision
+#          (optional fields with a post-validator, or explicit alternative
+#          constructors); this is the same debt that blocks
+#          `validate_assignment` on the model.
+#  *  ~10  `unresolved-attribute`: `Routing.sam`, which is only assigned by
+#          `gen_routing_info()` and has no meaningful empty value to default
+#          to; `.x`/`.y`/`.id` on a `SimpleId | Coord` union, where the code
+#          assumes a coordinate but the type allows either; and `.type_name`
+#          on an `AXI4 | None`.
+#  *   ~7  `invalid-argument-type`: `int | float` from `/` where `_gen_job_str`
+#          declares `int` (it already applies `int()` internally), plus two
+#          `LaxStr` union cases in `Network.gen_routes`.
 #
 # No rule is at zero yet, so none can be promoted. Once a rule's findings reach
 # zero, delete its line here rather than setting it to `error` - these are all
@@ -113,6 +115,3 @@ include = ["floogen"]
 unresolved-attribute = "warn"
 missing-argument = "warn"
 invalid-argument-type = "warn"
-not-subscriptable = "warn"
-unsupported-operator = "warn"
-not-iterable = "warn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,22 +86,27 @@ include = ["floogen"]
 
 [tool.ty.rules]
 # Demoted to `warn` so CI stays green. Nothing is wrong with these rules; the
-# problem is purely the volume of pre-existing findings (~203 at the time of
-# writing), which break down into two dominant causes plus a small remainder:
+# problem is the volume of pre-existing findings. The "populated later by the
+# build pipeline" pattern that used to dominate is gone (`Network.graph` and
+# `Routing.sam` are now non-optional properties, and `parse_config` raises
+# instead of returning `None`), taking the count from ~203 to ~66.
 #
-#  * ~159  Model fields declared `X | None = None` that are only populated later
-#          by the build pipeline (`create_network()` -> `compile_network()` ->
-#          `gen_routing_info()`), so every use afterwards looks possibly-`None`.
-#          Fixing this means modelling the post-build state honestly rather than
-#          sprinkling asserts.
-#  *  ~34  `AddrRange` constructor contract: `start`, `end` and `size` are all
-#          declared required, but a `mode="before"` validator derives the third
-#          from the other two, so callers legitimately pass only two of them.
-#  *  ~10  Assorted genuine findings worth fixing on their own merits, e.g.
-#          `.x`/`.y` accessed on a `SimpleId | Coord` union, and `user_width`
-#          (`int | dict`) passed where `int | str` is expected.
+# What is left, and what each rule is still waiting on:
 #
-# Promote a rule to `error` once its blockers are gone. Re-measure with:
+#  *  ~34  `AddrRange` constructor contract, all `missing-argument`: `start`,
+#          `end` and `size` are declared required, but a `mode="before"`
+#          validator derives the third from the other two, so callers
+#          legitimately pass only two. Needs a modelling decision (optional
+#          fields with a post-validator, or explicit alternative constructors);
+#          this is the same debt that blocks `validate_assignment` on the model.
+#  *  ~32  A long tail of unrelated findings, each needing its own judgement:
+#          `.x`/`.y` on a `SimpleId | Coord` union, widths typed `int | None`
+#          that are filled in during elaboration, and `int | float` from `/`
+#          where an `int` is expected.
+#
+# No rule is at zero yet, so none can be promoted. Once a rule's findings reach
+# zero, delete its line here rather than setting it to `error` - these are all
+# error-by-default in ty. Re-measure with:
 #   uv run --extra viz ty check --output-format concise
 unresolved-attribute = "warn"
 missing-argument = "warn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,34 +75,13 @@ suggestion-mode = "yes"
 line-length = 100
 
 [tool.ty.terminal]
-# Warnings are informational for now (see [tool.ty.rules] below); only
-# error-level diagnostics should fail CI.
-error-on-warning = false
+# `floogen` is clean at ty's default rule set, so let warnings fail CI too and keep
+# it that way. There is deliberately no `[tool.ty.rules]` section: every rule that
+# was demoted while the pre-existing findings were worked down (~203 of them) has
+# since reached zero and had its line removed.
+error-on-warning = true
 
 [tool.ty.src]
 # `util/` holds standalone helper scripts with their own optional dependencies
 # (e.g. pygame) that are not part of the distributed package.
 include = ["floogen"]
-
-[tool.ty.rules]
-# Demoted to `warn` so CI stays green. Nothing is wrong with these rules; the
-# problem is the volume of pre-existing findings, which is being worked down
-# (~203 -> ~17 so far). `missing-argument`, `not-iterable`, `not-subscriptable`
-# and `unsupported-operator` have since reached zero and their lines are gone.
-#
-# What is left, and what each remaining rule is waiting on:
-#
-#  *  ~10  `unresolved-attribute`: `Routing.sam`, which is only assigned by
-#          `gen_routing_info()` and has no meaningful empty value to default
-#          to; `.x`/`.y`/`.id` on a `SimpleId | Coord` union, where the code
-#          assumes a coordinate but the type allows either; and `.type_name`
-#          on an `AXI4 | None`.
-#  *   ~7  `invalid-argument-type`: `int | float` from `/` where `_gen_job_str`
-#          declares `int` (it already applies `int()` internally), plus two
-#          `LaxStr` union cases in `Network.gen_routes`.
-#
-# Once a rule's findings reach zero, delete its line here rather than setting it
-# to `error` - these are all
-# error-by-default in ty. Re-measure with:
-#   uv run --extra viz ty check --output-format concise
-unresolved-attribute = "warn"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,9 @@ include = ["floogen"]
 [tool.ty.rules]
 # Demoted to `warn` so CI stays green. Nothing is wrong with these rules; the
 # problem is the volume of pre-existing findings. The "populated later by the
-# build pipeline" pattern that used to dominate is gone (`Network.graph` and
-# `Routing.sam` are now non-optional properties, and `parse_config` raises
-# instead of returning `None`), taking the count from ~203 to ~66.
+# build pipeline" pattern that used to dominate is largely gone (`Network.graph`
+# default-initializes to an empty `Graph`, and `parse_config` raises instead of
+# returning `None`), taking the count from ~203 to ~71.
 #
 # What is left, and what each rule is still waiting on:
 #
@@ -99,10 +99,12 @@ include = ["floogen"]
 #          legitimately pass only two. Needs a modelling decision (optional
 #          fields with a post-validator, or explicit alternative constructors);
 #          this is the same debt that blocks `validate_assignment` on the model.
-#  *  ~32  A long tail of unrelated findings, each needing its own judgement:
-#          `.x`/`.y` on a `SimpleId | Coord` union, widths typed `int | None`
-#          that are filled in during elaboration, and `int | float` from `/`
-#          where an `int` is expected.
+#  *  ~37  A long tail of unrelated findings, each needing its own judgement:
+#          `Routing.sam`, which is only assigned by `gen_routing_info()` and has
+#          no meaningful empty value to default to; `.x`/`.y` on a
+#          `SimpleId | Coord` union; widths typed `int | None` that are filled
+#          in during elaboration; and `int | float` from `/` where an `int` is
+#          expected.
 #
 # No rule is at zero yet, so none can be promoted. Once a rule's findings reach
 # zero, delete its line here rather than setting it to `error` - these are all

--- a/uv.lock
+++ b/uv.lock
@@ -243,6 +243,7 @@ dev = [
     { name = "mkdocstrings-python" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "zensical" },
 ]
 
@@ -261,6 +262,7 @@ dev = [
     { name = "mkdocstrings-python", specifier = ">=2.0.1" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "zensical" },
 ]
 
@@ -1413,6 +1415,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.59"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/b0/84ae7b3bf6e3e9f57eb9635eeff5a80b36e57aa089f40be0fb5c384fa176/ty-0.0.59.tar.gz", hash = "sha256:53e53ffeed78ad59cd237fa8ea1316d2b94e13efdea9a945698acab549e005aa", size = 6145435, upload-time = "2026-07-12T20:22:02.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/e8/650b42fbef4d48e6ca682b0b6e9b68fa8fcf55cbb0a6892ab89990018b6f/ty-0.0.59-py3-none-linux_armv6l.whl", hash = "sha256:f8fb08a767ef8f11ea3c537b9d77860726cc2bc39e6f77ad13c02d5b289f20a7", size = 11700328, upload-time = "2026-07-12T20:21:26.046Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ac/0ca3a89d5f59ae5f308e5e83428cac5f9143200767743e052fba90b4b81e/ty-0.0.59-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c7f4d5630836c8a0ba13dd4ac7bdae080a7d6ebe965b817ff642dc961bcf2a53", size = 11494310, upload-time = "2026-07-12T20:21:28.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f8/5076de6001cefbccd8e6dc8472262697e43308ff66b0e87c72abba136357/ty-0.0.59-py3-none-macosx_11_0_arm64.whl", hash = "sha256:872f6fb02c6db5553c4d5fb283b3d50f0985fb9a29a910e4fda4793a775c1926", size = 11026797, upload-time = "2026-07-12T20:21:30.879Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0f/fca28481b6a138e2b798ad9fdc98a095475f9104948ba242fce4b477782b/ty-0.0.59-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2af8eefbfe806337770eec12c0c819c5f1b8f5b85f8369cb1cc9fa25234a2208", size = 11475304, upload-time = "2026-07-12T20:21:33.041Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/1fed8b81b389ef4bbc0400f19e05fc16496b162577779dc0e5fc65ac216c/ty-0.0.59-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0acf8b76a1c9a7ddef460b42475f6c76193164426ab080783af1c3175b4b999b", size = 11533131, upload-time = "2026-07-12T20:21:35.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/fc/04eec35e05a10e0fea1c6503a290ccc3935efda9c845aff64e83282c1af7/ty-0.0.59-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:043c2e00eb1d7475f928af7dedd71f69b64e69bfca55e36f4c968479e1373fc4", size = 12205932, upload-time = "2026-07-12T20:21:37.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/dd/a61de859659fa11b55917ad38340a8f2c61f5ae17d1874929f29084c6990/ty-0.0.59-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0d688d857441df57f48fca66c029d85cf737c510e7be1d01144cdad1e58d968", size = 12758406, upload-time = "2026-07-12T20:21:39.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e8/fa66f05997eab8ca75fc4f17320140e25467849e0cc75597f898cc22099c/ty-0.0.59-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a96c9f88394a3b42c737e2125b2330543f0d90a43b49761f377d96f8c3ee0d62", size = 12288176, upload-time = "2026-07-12T20:21:41.784Z" },
+    { url = "https://files.pythonhosted.org/packages/15/68/0fca59963bd5123f42d5f7da50667e7a52e8e9615e3a16d8c2c0d3b2d143/ty-0.0.59-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f08dbcb268edcafcb152e59475b5b495ce28d0b340a395c09943557678f4d5a6", size = 12028471, upload-time = "2026-07-12T20:21:43.82Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5b/cd7dabbbab392578f11179919da5c25d8c3322e5388a688f539ea0539603/ty-0.0.59-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8812764b9a40fdc98df1272826e73a298ef56b06681135e643bcf90aad1896f7", size = 12297646, upload-time = "2026-07-12T20:21:45.76Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/37/2e9c94f0b383d8cbe1a35517ab470b7810bc9d7501603ab532bcd5be5e90/ty-0.0.59-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fd53b8581641d8dad7bfac6d5ea589e91a883d6837e0b9a286fdae30722b7c69", size = 11432519, upload-time = "2026-07-12T20:21:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0a/af93e9785200f11ac416cc20235fc2464c9bd978e791190684ea0e458795/ty-0.0.59-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:86da5872124a41877d95058bc17d33ddcff034b587eb5f1e2917ab88ba227dac", size = 11554993, upload-time = "2026-07-12T20:21:49.671Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/dd/651bf87e20d00376c81b19124756491cffaf20eb8bec05a8794e5a8cf641/ty-0.0.59-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6a233eef5f2fd4d894881e4a0aec83c9f172bfae1d787d6596ee1939fcc7723e", size = 11818230, upload-time = "2026-07-12T20:21:51.659Z" },
+    { url = "https://files.pythonhosted.org/packages/16/50/c947c4155fea751d135b19affdf734bbce72a94e446b866cf0c62f8bed69/ty-0.0.59-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7ff678c18b5f1e3128b75a35e50dee7908dea55155baa31cd790619d5014cbf5", size = 12135194, upload-time = "2026-07-12T20:21:53.796Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/13/e5feb138888de1e95037c843571bbbd4ac21bf0a190507468098599a321f/ty-0.0.59-py3-none-win32.whl", hash = "sha256:cf8abb4b8095c5fe39102b8127f5886db308c8d4600909ddbc905512ce9c8163", size = 11179249, upload-time = "2026-07-12T20:21:55.752Z" },
+    { url = "https://files.pythonhosted.org/packages/76/dd/52914dcbeeba92c207de40ef7109a58dcb5527aeb21c8f8feb7402aa9e29/ty-0.0.59-py3-none-win_amd64.whl", hash = "sha256:1dde20a82243d24407869e5a608c2f15efddd5cefc662aef461a5af84bfb3f8b", size = 12251079, upload-time = "2026-07-12T20:21:58.1Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/ac36fde77e223297454c1e0aeb8888c169eaacf3163bb609e3af942c88cb/ty-0.0.59-py3-none-win_arm64.whl", hash = "sha256:987043ee9e021f49493d9135891ac69c1affeee0d4ad4480c5fa4d9c975fc91b", size = 11650921, upload-time = "2026-07-12T20:22:00.348Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ dev = [
     { name = "mkdocstrings-python", specifier = ">=2.0.1" },
     { name = "pytest" },
     { name = "ruff" },
-    { name = "ty" },
+    { name = "ty", specifier = ">=0.0.59" },
     { name = "zensical" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -114,7 +114,7 @@ resolution-markers = [
     "python_full_version >= '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -214,7 +214,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -262,7 +262,7 @@ dev = [
     { name = "mkdocstrings-python", specifier = ">=2.0.1" },
     { name = "pytest" },
     { name = "ruff" },
-    { name = "ty", specifier = ">=0.0.59" },
+    { name = "ty" },
     { name = "zensical" },
 ]
 
@@ -1419,27 +1419,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.59"
+version = "0.0.65"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/95/b0/84ae7b3bf6e3e9f57eb9635eeff5a80b36e57aa089f40be0fb5c384fa176/ty-0.0.59.tar.gz", hash = "sha256:53e53ffeed78ad59cd237fa8ea1316d2b94e13efdea9a945698acab549e005aa", size = 6145435, upload-time = "2026-07-12T20:22:02.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cf561927e8e9ab5c1892a833b664aa9cd6f051a75f6280c66d8047246bda/ty-0.0.65.tar.gz", hash = "sha256:b7134bffcc00b715fa8291e84d845782ced810a998dc1f7f11d71c85c4046325", size = 6460098, upload-time = "2026-07-29T18:31:03.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/e8/650b42fbef4d48e6ca682b0b6e9b68fa8fcf55cbb0a6892ab89990018b6f/ty-0.0.59-py3-none-linux_armv6l.whl", hash = "sha256:f8fb08a767ef8f11ea3c537b9d77860726cc2bc39e6f77ad13c02d5b289f20a7", size = 11700328, upload-time = "2026-07-12T20:21:26.046Z" },
-    { url = "https://files.pythonhosted.org/packages/22/ac/0ca3a89d5f59ae5f308e5e83428cac5f9143200767743e052fba90b4b81e/ty-0.0.59-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c7f4d5630836c8a0ba13dd4ac7bdae080a7d6ebe965b817ff642dc961bcf2a53", size = 11494310, upload-time = "2026-07-12T20:21:28.491Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/f8/5076de6001cefbccd8e6dc8472262697e43308ff66b0e87c72abba136357/ty-0.0.59-py3-none-macosx_11_0_arm64.whl", hash = "sha256:872f6fb02c6db5553c4d5fb283b3d50f0985fb9a29a910e4fda4793a775c1926", size = 11026797, upload-time = "2026-07-12T20:21:30.879Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/0f/fca28481b6a138e2b798ad9fdc98a095475f9104948ba242fce4b477782b/ty-0.0.59-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2af8eefbfe806337770eec12c0c819c5f1b8f5b85f8369cb1cc9fa25234a2208", size = 11475304, upload-time = "2026-07-12T20:21:33.041Z" },
-    { url = "https://files.pythonhosted.org/packages/08/4b/1fed8b81b389ef4bbc0400f19e05fc16496b162577779dc0e5fc65ac216c/ty-0.0.59-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0acf8b76a1c9a7ddef460b42475f6c76193164426ab080783af1c3175b4b999b", size = 11533131, upload-time = "2026-07-12T20:21:35.189Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/fc/04eec35e05a10e0fea1c6503a290ccc3935efda9c845aff64e83282c1af7/ty-0.0.59-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:043c2e00eb1d7475f928af7dedd71f69b64e69bfca55e36f4c968479e1373fc4", size = 12205932, upload-time = "2026-07-12T20:21:37.324Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/dd/a61de859659fa11b55917ad38340a8f2c61f5ae17d1874929f29084c6990/ty-0.0.59-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0d688d857441df57f48fca66c029d85cf737c510e7be1d01144cdad1e58d968", size = 12758406, upload-time = "2026-07-12T20:21:39.525Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/e8/fa66f05997eab8ca75fc4f17320140e25467849e0cc75597f898cc22099c/ty-0.0.59-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a96c9f88394a3b42c737e2125b2330543f0d90a43b49761f377d96f8c3ee0d62", size = 12288176, upload-time = "2026-07-12T20:21:41.784Z" },
-    { url = "https://files.pythonhosted.org/packages/15/68/0fca59963bd5123f42d5f7da50667e7a52e8e9615e3a16d8c2c0d3b2d143/ty-0.0.59-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f08dbcb268edcafcb152e59475b5b495ce28d0b340a395c09943557678f4d5a6", size = 12028471, upload-time = "2026-07-12T20:21:43.82Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/5b/cd7dabbbab392578f11179919da5c25d8c3322e5388a688f539ea0539603/ty-0.0.59-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8812764b9a40fdc98df1272826e73a298ef56b06681135e643bcf90aad1896f7", size = 12297646, upload-time = "2026-07-12T20:21:45.76Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/37/2e9c94f0b383d8cbe1a35517ab470b7810bc9d7501603ab532bcd5be5e90/ty-0.0.59-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fd53b8581641d8dad7bfac6d5ea589e91a883d6837e0b9a286fdae30722b7c69", size = 11432519, upload-time = "2026-07-12T20:21:47.694Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/0a/af93e9785200f11ac416cc20235fc2464c9bd978e791190684ea0e458795/ty-0.0.59-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:86da5872124a41877d95058bc17d33ddcff034b587eb5f1e2917ab88ba227dac", size = 11554993, upload-time = "2026-07-12T20:21:49.671Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/dd/651bf87e20d00376c81b19124756491cffaf20eb8bec05a8794e5a8cf641/ty-0.0.59-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6a233eef5f2fd4d894881e4a0aec83c9f172bfae1d787d6596ee1939fcc7723e", size = 11818230, upload-time = "2026-07-12T20:21:51.659Z" },
-    { url = "https://files.pythonhosted.org/packages/16/50/c947c4155fea751d135b19affdf734bbce72a94e446b866cf0c62f8bed69/ty-0.0.59-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7ff678c18b5f1e3128b75a35e50dee7908dea55155baa31cd790619d5014cbf5", size = 12135194, upload-time = "2026-07-12T20:21:53.796Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/13/e5feb138888de1e95037c843571bbbd4ac21bf0a190507468098599a321f/ty-0.0.59-py3-none-win32.whl", hash = "sha256:cf8abb4b8095c5fe39102b8127f5886db308c8d4600909ddbc905512ce9c8163", size = 11179249, upload-time = "2026-07-12T20:21:55.752Z" },
-    { url = "https://files.pythonhosted.org/packages/76/dd/52914dcbeeba92c207de40ef7109a58dcb5527aeb21c8f8feb7402aa9e29/ty-0.0.59-py3-none-win_amd64.whl", hash = "sha256:1dde20a82243d24407869e5a608c2f15efddd5cefc662aef461a5af84bfb3f8b", size = 12251079, upload-time = "2026-07-12T20:21:58.1Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/8f/ac36fde77e223297454c1e0aeb8888c169eaacf3163bb609e3af942c88cb/ty-0.0.59-py3-none-win_arm64.whl", hash = "sha256:987043ee9e021f49493d9135891ac69c1affeee0d4ad4480c5fa4d9c975fc91b", size = 11650921, upload-time = "2026-07-12T20:22:00.348Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/4e/71e2d325d2b53a1afad81624ad076b2ede413213fc4a18cb05b78c568571/ty-0.0.65-py3-none-linux_armv6l.whl", hash = "sha256:dc556c9f05408bef4c4ef02b2cc382e4e5f797b4b20d64410289848f0d76705f", size = 12298466, upload-time = "2026-07-29T18:30:12.744Z" },
+    { url = "https://files.pythonhosted.org/packages/57/77/fec8f29647c55794efa430a7f365e44f5ce7ffb6459d9445a87fac569bec/ty-0.0.65-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:29d2e0d34cc0a28a17ef0cf81135c5ebabc3562131f9079138ba5e7bae0f56bd", size = 11942421, upload-time = "2026-07-29T18:30:16.076Z" },
+    { url = "https://files.pythonhosted.org/packages/13/09/7f3766aef9dc627e2698cf4e3e59cf53389dcae3812040d33c1aa931230f/ty-0.0.65-py3-none-macosx_11_0_arm64.whl", hash = "sha256:685f49a9312bbf69d5b65bbb66384fed1f927403ea030c217b9289092d7e46c4", size = 11451922, upload-time = "2026-07-29T18:30:19.155Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/1a77cd50e0befb50f55b8bf9bd3ed3eddf184bf28c61b56727039e0774fc/ty-0.0.65-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f564b5ebe78e2f3a8e7b8eacb1292eb88b7c0f3c8630671cfca31abc0709cd9", size = 11994999, upload-time = "2026-07-29T18:30:22.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7b/feda16f3a4a0a99be27431e0c9598eeeec0db1eb2fec9a15976698209418/ty-0.0.65-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c983e156fe9e113fb56389e13d327b6b8549fe866de9b269684723a88e9b732d", size = 12090662, upload-time = "2026-07-29T18:30:24.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/3e/3f69bf9c9307dbdc0771719f65ce5b556e7bdeeaccbdd599d4f57866d801/ty-0.0.65-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e3663b7396e8b1a9954e20e732de7ccb0192bf4118473069b4945920d6923921", size = 12822094, upload-time = "2026-07-29T18:30:28.012Z" },
+    { url = "https://files.pythonhosted.org/packages/90/38/8fa791b3bb503ee2b46ad81690cd1bdd54519582df6d805cee57fe143e85/ty-0.0.65-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:306ed01f29d6e108e98feb233dbbf5878a027603b71bd3743b343977933a9f16", size = 13357833, upload-time = "2026-07-29T18:30:31.122Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/73/4dda396a201e1dd0ed3594a9b48e559cb41c4bc048c6cd4c4d1b39eb4313/ty-0.0.65-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28bcfc8898c94f079a9100e684bcf312b6a64ad3a7d4ebb35a4591546030a2cd", size = 12977303, upload-time = "2026-07-29T18:30:33.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/26/c250c2c569adc53a8591716641388397bcb2a442e4a30b952ae81b50c0e0/ty-0.0.65-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a75bd0c245c38802a8f488378e74f92feb7dd33db7d63fbdd6fdf82791ba730", size = 12579338, upload-time = "2026-07-29T18:30:37.199Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/94/4a5647d44753ca218fc930d7e4d9bf468d0ed4a0ad4b3d57588bc1bbacf7/ty-0.0.65-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9e5e1bdea9662d2b5312b4e99f319f4e6e2ea427511b5fbc546141b79ec53f76", size = 12957731, upload-time = "2026-07-29T18:30:39.937Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/1e22fa11a1e0dfb20b1c7f3cbfd8170273aada2a82f9ecd3055275370c44/ty-0.0.65-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:03a88493d4842889f65280ae241e06b399d57eb3c63571054cad21a4c33b3b69", size = 11938625, upload-time = "2026-07-29T18:30:42.603Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0a/fe5f22ef62b193201bc5566762e22049762cd485bfafb5095a7050760054/ty-0.0.65-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:600b8bf6f4940cf7ffb2f43d3716faaf38dcb97cd8617c55771451bc0276408f", size = 12105592, upload-time = "2026-07-29T18:30:45.419Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fd/922b3a6e9d697452cdbb4b7e3f636868add5ec652154518a736e4364f3b7/ty-0.0.65-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0c28007bc79d648c1ddaf1e65885d07baec48eb87240da442f608e4107c1b7d8", size = 12387335, upload-time = "2026-07-29T18:30:48.405Z" },
+    { url = "https://files.pythonhosted.org/packages/77/22/a1a08ebc84c083db2fb55e3b5cd186db0c067692f4921146f601360231e2/ty-0.0.65-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c852da96091ad22361e6586b7c7ba98e1334dcd4d8ffb67e47f4fb673de33f77", size = 12682710, upload-time = "2026-07-29T18:30:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/81/14/eaaa410a25bbdea19722109b5422380a0e211b3afcf3071d15953ddbd5db/ty-0.0.65-py3-none-win32.whl", hash = "sha256:cf529d538f1403b14b0511e6ec3cdb95d3d974adabf24cc76cedc533368c3edc", size = 11692341, upload-time = "2026-07-29T18:30:54.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/0f/6d48f206dce9d7e53fe3b5ea0f0ab5800dd9d2365b2b48f736783436c43f/ty-0.0.65-py3-none-win_amd64.whl", hash = "sha256:234a321e33c7cbbfbd67bfa0b01b685dd9c21f1841781a21e5ca1fa0b25f1d5d", size = 12729355, upload-time = "2026-07-29T18:30:57.275Z" },
+    { url = "https://files.pythonhosted.org/packages/96/aa/7446f7725e303cf78e058c893af1f0552b9451895454908706f4c6c3494b/ty-0.0.65-py3-none-win_arm64.whl", hash = "sha256:b9424be1ec56d93ff18609fb1c0a0a2283fe1282cd6d1c7604f97d73b94d61f2", size = 12051375, upload-time = "2026-07-29T18:31:00.579Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds [`ty`](https://github.com/astral-sh/ty) as a type-checking step in CI and fixes the ~203 findings it surfaced in `floogen`. Generated output is unchanged.

## What's in here

**Tooling**

- `ty` added to the `dev` dependency group, and a `ty` job to `lint.yml` run as `uv run --extra viz ty check` — so the version in use is gated by `uv.lock` and arrives as a reviewable dependabot bump rather than floating.
- `[tool.ty.terminal] error-on-warning = true`, with deliberately **no** `[tool.ty.rules]` section: every rule demoted while working the pre-existing findings down has since reached zero and had its line removed, so there is no suppressed debt hiding behind the green check.
- `[tool.ty.src] include = ["floogen"]` — `util/` holds standalone helper scripts with their own optional dependencies (e.g. pygame) that are not part of the distributed package.

**Modelling post-build state honestly**

Several fields were declared `X | None = None` but are in practice always populated by `create_network()` / `gen_routing_info()` before anything reads them. Rather than scattering assertions, they are now either default-initialised (`Network.graph`) or explicitly guarded at the point of use with a message naming the build step that was skipped.

**Real bugs found along the way**

- `Endpoint.mgr_ports` / `sbr_ports` were annotated with a bare `TypeVar` (`Protocols`) used as a pydantic field type.
- `AddrRange.model_config` said `validate_assignement` — a typo pydantic silently ignored, so assignment validation had never actually been active. Documented in place, together with the two remaining blockers to switching it on for real.
- `validate_input` read `addr_dict["arr_dim"]` where the key may be absent rather than `None` — a latent `KeyError`.
- Byte counts used `/` instead of `//`, producing floats that were `int()`-ed further downstream.
- Dead `AXI4.render_params` removed (no caller in Python or in any template).

## Behaviour changes worth knowing

- **Invalid configs now exit non-zero with a readable message.** `parse_config` raises `ConfigError` instead of returning `None`; previously a bad config produced an `AttributeError` traceback from the subsequent `create_network()` call. The detailed per-error diagnostics are unchanged.
- **`AddrRange.size` is derived, not stored.** It is still accepted as an *input* key (normalised into `end`), but is now read-only and no longer appears in `model_dump()`. `AddrRange.from_start_size()` / `from_base_size()` are the typed constructors.
- **`RouteMapRule.render_desc()` raises when `desc` is unset**, instead of emitting the degenerate SystemVerilog identifier `_sam_idx`.

## Verification

Generated `rtl` and `rdl` for all 15 example configs, plus 7 built-in traffic patterns and both traffic configs — 46 invocations — on `main` and on this branch: **every generated artifact is byte-identical**. That covers all four routing algorithms, the collective/multicast SAM path, and the source-routing table path.

```bash
uv run --extra viz ty check
uv run pytest floogen -q
```

Packaging is unaffected: the release workflow's wheel and sdist smoke tests both pass, and `tpl_dir` resolves to `site-packages/floogen/templates` inside an installed wheel.
